### PR TITLE
:page_facing_up: docs(license): add copyright and redistribution conditions

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,15 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright© 2025 Centro Internacional de Agricultura Tropical – CIAT and Bioversity International.
+
+      Redistribution and use in source and binary forms, with or without
+      modification, are permitted provided that the following conditions
+      are met:
+      
+      Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived from
+      this software without specific prior written permission.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Added copyright © 2025 Centro Internacional de Agricultura Tropical – CIAT and Bioversity International to the project license. Included conditions for redistribution and use, specifying that names of copyright holders or contributors may not be used for endorsement without prior written permission.