### PR TITLE
🐛 fix(workflows): add coverage exclusions to SonarCloud analysis

### DIFF
--- a/.github/workflows/sonarcloud-analysis.yml
+++ b/.github/workflows/sonarcloud-analysis.yml
@@ -72,7 +72,8 @@ jobs:
             -Dsonar.organization=alliancebioversityciat \
             -Dsonar.host.url=https://sonarcloud.io \
             -Dsonar.login=${{ secrets.SONAR_TOKEN }} \
-            -Dsonar.exclusions=**/environments/**,**/*.spec.ts
+            -Dsonar.exclusions=**/environments/**,**/*.spec.ts \
+            -Dsonar.coverage.exclusions=**
         working-directory: ./research-indicators
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
This pull request updates the SonarCloud analysis workflow configuration to refine the handling of code coverage exclusions.

### Updates to SonarCloud configuration:

* [`.github/workflows/sonarcloud-analysis.yml`](diffhunk://#diff-7069e33747a5e54d51fd9be63ad0df207cd4380c0e0f84e07c59371fd178e5ecL75-R76): Added `-Dsonar.coverage.exclusions=**` to explicitly exclude all files from code coverage analysis during the SonarCloud scan.