### PR TITLE
✨ feat: refine Dockerfile by removing unnecessary Angular directory copy

### DIFF
--- a/research-indicators/Dockerfile
+++ b/research-indicators/Dockerfile
@@ -13,7 +13,6 @@ RUN npm ci --ignore-scripts
 # Copy only the necessary application files
 COPY src ./src
 COPY public ./public
-COPY .angular ./.angular
 COPY angular.json ./
 COPY tsconfig*.json ./
 COPY eslint.config.js ./


### PR DESCRIPTION
This pull request makes a small change to the `research-indicators/Dockerfile` by removing the unnecessary copying of the `.angular` directory during the Docker image build process.