### PR TITLE
✨ feat: simplify Dockerfile by removing unnecessary comment and adjusting npm install command

### DIFF
--- a/research-indicators/Dockerfile
+++ b/research-indicators/Dockerfile
@@ -7,8 +7,8 @@ WORKDIR /usr/src/app
 # Copy dependency files
 COPY package*.json ./
 
-# Install dependencies
-RUN npm ci --ignore-scripts
+# Install dependencies.
+RUN npm ci
 
 # Copy only the necessary application files
 COPY src ./src


### PR DESCRIPTION
This pull request makes a minor adjustment to the `Dockerfile` in the `research-indicators` directory. The change removes the `--ignore-scripts` flag from the `npm ci` command, allowing npm lifecycle scripts to run during dependency installation.

* [`research-indicators/Dockerfile`](diffhunk://#diff-18fb2f74bbfeb61951e13d694fb3070c4670c785bd8dedfa77b9972329e83245L10-R11): Updated the `RUN npm ci` command to remove the `--ignore-scripts` flag, enabling npm lifecycle scripts to execute during dependency installation.