### PR TITLE
✨ feat: streamline Dockerfile by copying all necessary files in a single command

### DIFF
--- a/research-indicators/Dockerfile
+++ b/research-indicators/Dockerfile
@@ -11,15 +11,7 @@ COPY package*.json ./
 RUN npm ci
 
 # Copy only the necessary application files
-COPY src ./src
-COPY public ./public
-COPY angular.json ./
-COPY tsconfig*.json ./
-COPY eslint.config.js ./
-COPY .stylelintrc.json ./
-COPY ngsw-config.json ./
-COPY jest.config.ts ./
-COPY jest.setup.ts ./
+COPY . .
 
 # Build Angular application in production mode
 RUN npm run build --prod


### PR DESCRIPTION
This pull request simplifies the Dockerfile by consolidating multiple `COPY` commands into a single command to copy the entire project directory. This change reduces redundancy and makes the Dockerfile more concise.

* [`research-indicators/Dockerfile`](diffhunk://#diff-18fb2f74bbfeb61951e13d694fb3070c4670c785bd8dedfa77b9972329e83245L14-R14): Replaced individual `COPY` commands for specific files and directories (e.g., `src`, `public`, `angular.json`, etc.) with a single `COPY . .` command to copy the entire project directory.