### PR TITLE
♻️ refactor(ngsw-config): add index.html to the prefetch resource files

### DIFF
--- a/research-indicators/ngsw-config.json
+++ b/research-indicators/ngsw-config.json
@@ -8,6 +8,7 @@
       "resources": {
         "files": [
           "/favicon.ico",
+          "/index.html",
           "/manifest.webmanifest",
           "/*.css",
           "/*.js"


### PR DESCRIPTION
This pull request includes a minor update to the `ngsw-config.json` file to enhance caching behavior for the Angular Service Worker.

* [`research-indicators/ngsw-config.json`](diffhunk://#diff-637adce880a2c140f208cd9ef495e5f510af6ae8b1e9542e8c12e2b78e4abaf5R11): Added `/index.html` to the list of files under the `resources` section to ensure it is cached by the Service Worker.