### PR TITLE
🔧 chore(geographic-scope): remove redundant assignment of isFirstSelect

### DIFF
--- a/research-indicators/src/app/pages/platform/pages/result/pages/geographic-scope/geographic-scope.component.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/geographic-scope/geographic-scope.component.ts
@@ -64,9 +64,8 @@ export default class GeographicScopeComponent {
         ...value,
         countries: []
       }));
+      this.isFirstSelect = false;
     }
-
-    this.isFirstSelect = false;
   };
 
   canRemove = (): boolean => {


### PR DESCRIPTION
This pull request makes a minor adjustment to the `GeographicScopeComponent` class. The change fixes the code formatting by moving the `this.isFirstSelect = false;` line inside the correct block, ensuring that the flag is set only after the selection logic executes.