### PR TITLE
Ac 1170 us10 redirect after preliminary oicr submission and adjust oicr detail view

### DIFF
--- a/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.html
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.html
@@ -19,7 +19,7 @@
 
 <ng-template #createButton>
   @let disableCreateButton =
-    loading || isDisabled || !canEditOicr || (this.createResultManagementService.editingOicr() ? false : activeIndex() !== 3);
+    loading || isDisabled || !canEditOicr || (this.createResultManagementService.editingOicr() ? false : !this.step4opened());
   <button
     class="font-medium cursor-pointer text-[15px] disabled:cursor-default disabled:bg-[#E8EBED] disabled:text-[#A2A9AF] text-[12px] bg-[#035BA9] text-white px-8 py-2.5 rounded-xl flex items-center gap-2"
     (click)="createResult()"

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.html
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.html
@@ -18,10 +18,16 @@
 </ng-template>
 
 <ng-template #createButton>
+  @let disableCreateButton =
+    loading || isDisabled || !canEditOicr || (this.createResultManagementService.editingOicr() ? false : activeIndex() !== 3);
   <button
     class="font-medium cursor-pointer text-[15px] disabled:cursor-default disabled:bg-[#E8EBED] disabled:text-[#A2A9AF] text-[12px] bg-[#035BA9] text-white px-8 py-2.5 rounded-xl flex items-center gap-2"
     (click)="createResult()"
-    [disabled]="loading || isDisabled || !canEditOicr">
+    [pTooltip]="
+      !disableCreateButton ? '' : 'This button will be enabled once all steps are completed. Please make sure to review and fill out each section.'
+    "
+    tooltipPosition="top"
+    [disabled]="disableCreateButton">
     @if (loading) {
       <div class="min-w-[191px]">
         <i class="pi pi-spinner pi-spin text-white text-xs"></i>
@@ -108,13 +114,13 @@
     <p-steps
       [model]="createResultManagementService.stepItems()"
       [readonly]="false"
-      [activeIndex]="activeIndex"
+      [activeIndex]="activeIndex()"
       (activeIndexChange)="onActiveIndexChange($event)"
       [styleClass]="'completed-' + activeIndex"
       class="my-8">
     </p-steps>
 
-    @if (activeIndex === 0) {
+    @if (activeIndex() === 0) {
       <div id="general-information" class="flex-col flex gap-[20px] bg-white border-[#E8EBED] border-1 rounded-[15px] p-6">
         <p class="text-[15px] font-[800] text-[#173F6F]">GENERAL INFORMATION</p>
 
@@ -142,7 +148,7 @@
       </div>
     }
 
-    @if (activeIndex === 1) {
+    @if (activeIndex() === 1) {
       <div id="contributors" class="flex-col flex gap-[20px] bg-white border-[#E8EBED] border-1 rounded-[15px] p-6">
         <p class="text-[15px] font-[800] text-[#173F6F]">CONTRIBUTORS</p>
 
@@ -237,7 +243,7 @@
       </div>
     }
 
-    @if (activeIndex === 2) {
+    @if (activeIndex() === 2) {
       <div id="geographic-scope" class="flex-col flex gap-[20px] bg-white border-[#E8EBED] border-1 rounded-[15px] p-6">
         <p class="text-[15px] font-[800] text-[#173F6F]">GEOGRAPHIC SCOPE</p>
 
@@ -387,7 +393,7 @@
       </div>
     }
 
-    @if (activeIndex === 3) {
+    @if (activeIndex() === 3) {
       <div id="general-comments" class="flex-col flex gap-[20px] bg-white border-[#E8EBED] border-1 rounded-[15px] p-6">
         <p class="text-[15px] font-[800] text-[#173F6F]">GENERAL COMMENTS</p>
 

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.ts
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.ts
@@ -90,7 +90,7 @@ export class CreateOicrFormComponent {
   router = inject(Router);
   rolesService = inject(RolesService);
   projectResultsTableService = inject(ProjectResultsTableService);
-
+  step4opened = signal(false);
   filteredPrimaryContracts = signal<GetContracts[]>([]);
   contracts = signal<GetContractsExtended[]>([]);
   contractId: number | null = null;
@@ -182,7 +182,7 @@ export class CreateOicrFormComponent {
 
   stepFourCompletionEffect = effect(
     () => {
-      const completed = this.isCompleteStepOne && this.isCompleteStepTwo && this.isCompleteStepThree && this.activeIndex() === 3;
+      const completed = this.isCompleteStepOne && this.isCompleteStepTwo && this.isCompleteStepThree && this.step4opened();
       this.createResultManagementService.stepItems.update(items =>
         items.map((item, idx) => (idx === 3 ? { ...item, styleClass: completed ? 'oicr-step4-complete' : '' } : item))
       );
@@ -238,6 +238,7 @@ export class CreateOicrFormComponent {
 
   onActiveIndexChange(event: number) {
     this.activeIndex.set(event);
+    if (event === 3) this.step4opened.set(true);
   }
   removeSubnationalRegion(country: Country, region: Region) {
     this.createResultManagementService.createOicrBody.update(current => {

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.ts
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.ts
@@ -430,8 +430,8 @@ export class CreateOicrFormComponent {
       const next = current + 1;
       const sectionId = this.stepSectionIds[next] ?? this.stepSectionIds[0];
       this.onStepClick(next, sectionId);
+      if (next === 3) this.step4opened.set(true);
     }
-    if (current === 3) this.step4opened.set(true);
   }
 
   goBack() {

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.ts
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.ts
@@ -399,7 +399,6 @@ export class CreateOicrFormComponent {
               this.allModalsService.closeModal('createResult');
               this.getResultsService.updateList();
               this.createResultManagementService.currentRequestedResultCode.set(null);
-              this.projectResultsTableService.getData();
               this.cache.projectResultsSearchValue.set(this.createResultManagementService.createOicrBody().base_information.title);
               this.createResultManagementService.clearOicrBody();
             };

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.ts
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.ts
@@ -186,7 +186,7 @@ export class CreateOicrFormComponent {
         this.isCompleteStepOne &&
         this.isCompleteStepTwo &&
         this.isCompleteStepThree &&
-        (this.createResultManagementService.editingOicr() ? true : !this.step4opened());
+        (this.createResultManagementService.editingOicr() ? true : this.step4opened());
       this.createResultManagementService.stepItems.update(items =>
         items.map((item, idx) => (idx === 3 ? { ...item, styleClass: completed ? 'oicr-step4-complete' : '' } : item))
       );
@@ -278,10 +278,10 @@ export class CreateOicrFormComponent {
     const userIdValid = String(b.step_one.main_contact_person.user_id).trim().length > 0;
     const tagIdValid = b.step_one.tagging.tag_id > 0;
     const outcomeLen = (b.step_one.outcome_impact_statement ?? '').length;
-    
+
     const showOicrSelection = b.step_one.tagging.tag_id === 2 || b.step_one.tagging.tag_id === 3;
-    const oicrSelectionValid = !showOicrSelection || (b.step_one.link_result.external_oicr_id > 0);
-    
+    const oicrSelectionValid = !showOicrSelection || b.step_one.link_result.external_oicr_id > 0;
+
     return userIdValid && tagIdValid && outcomeLen > 0 && oicrSelectionValid;
   }
 

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.ts
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.ts
@@ -274,7 +274,11 @@ export class CreateOicrFormComponent {
     const userIdValid = String(b.step_one.main_contact_person.user_id).trim().length > 0;
     const tagIdValid = b.step_one.tagging.tag_id > 0;
     const outcomeLen = (b.step_one.outcome_impact_statement ?? '').length;
-    return userIdValid && tagIdValid && outcomeLen > 0;
+    
+    const showOicrSelection = b.step_one.tagging.tag_id === 2 || b.step_one.tagging.tag_id === 3;
+    const oicrSelectionValid = !showOicrSelection || (b.step_one.link_result.external_oicr_id > 0);
+    
+    return userIdValid && tagIdValid && outcomeLen > 0 && oicrSelectionValid;
   }
 
   get isCompleteStepTwo(): boolean {

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.ts
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.ts
@@ -97,7 +97,7 @@ export class CreateOicrFormComponent {
   private isFirstSelect = true;
   environment = environment;
   loading = false;
-  activeIndex = 0;
+  activeIndex = signal(0);
 
   optionsDisabled: WritableSignal<Lever[]> = signal([]);
   primaryOptionsDisabled: WritableSignal<Lever[]> = signal([]);
@@ -182,7 +182,7 @@ export class CreateOicrFormComponent {
 
   stepFourCompletionEffect = effect(
     () => {
-      const completed = this.isCompleteStepOne && this.isCompleteStepTwo && this.isCompleteStepThree;
+      const completed = this.isCompleteStepOne && this.isCompleteStepTwo && this.isCompleteStepThree && this.activeIndex() === 3;
       this.createResultManagementService.stepItems.update(items =>
         items.map((item, idx) => (idx === 3 ? { ...item, styleClass: completed ? 'oicr-step4-complete' : '' } : item))
       );
@@ -237,7 +237,7 @@ export class CreateOicrFormComponent {
   }
 
   onActiveIndexChange(event: number) {
-    this.activeIndex = event;
+    this.activeIndex.set(event);
   }
   removeSubnationalRegion(country: Country, region: Region) {
     this.createResultManagementService.createOicrBody.update(current => {
@@ -308,7 +308,7 @@ export class CreateOicrFormComponent {
   }
 
   onStepClick(stepIndex: number, sectionId: string) {
-    this.activeIndex = stepIndex;
+    this.activeIndex.set(stepIndex);
     this.scrollTo(sectionId);
   }
 
@@ -415,7 +415,7 @@ export class CreateOicrFormComponent {
   }
 
   goNext() {
-    const current = this.activeIndex;
+    const current = this.activeIndex();
     const lastIndex = this.createResultManagementService.stepItems().length - 1;
     if (current < lastIndex) {
       const next = current + 1;
@@ -425,7 +425,7 @@ export class CreateOicrFormComponent {
   }
 
   goBack() {
-    const current = this.activeIndex;
+    const current = this.activeIndex();
     if (current > 0) {
       const prev = current - 1;
       const sectionId = this.stepSectionIds[prev] ?? this.stepSectionIds[0];

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.ts
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.ts
@@ -182,7 +182,7 @@ export class CreateOicrFormComponent {
 
   stepFourCompletionEffect = effect(
     () => {
-      const completed = this.createResultManagementService.createOicrBody().step_four.general_comment.length > 0;
+      const completed = this.isCompleteStepOne && this.isCompleteStepTwo && this.isCompleteStepThree;
       this.createResultManagementService.stepItems.update(items =>
         items.map((item, idx) => (idx === 3 ? { ...item, styleClass: completed ? 'oicr-step4-complete' : '' } : item))
       );

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/services/create-result-management.service.ts
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/services/create-result-management.service.ts
@@ -21,7 +21,6 @@ export class CreateResultManagementService {
   oicrPrimaryOptionsDisabled: WritableSignal<Lever[]> = signal([]);
   stepItems = signal<MenuItem[]>([]);
   createOicrBody: WritableSignal<OicrCreation> = signal(this.getDefaultOicrBody());
-
   private getDefaultOicrBody(): OicrCreation {
     return {
       step_one: {

--- a/research-indicators/src/app/shared/components/custom-fields/oicr-form-fields/oicr-form-fields.component.ts
+++ b/research-indicators/src/app/shared/components/custom-fields/oicr-form-fields/oicr-form-fields.component.ts
@@ -93,6 +93,7 @@ export class OicrFormFieldsComponent {
     const response = await this.api.GET_OICRMetadata(externalOicrId);
     if (!response.successfulRequest) return;
     // Pre-fill OICR form fields with metadata
+    response.data.step_three.comment_geo_scope = response.data.step_three.comment_geo_scope || '';
     this.createResultManagementService.createOicrBody.update(b => {
       const primaryLeverIds = b.step_two.primary_lever.map(pl => Number(pl.lever_id));
       return {

--- a/research-indicators/src/app/shared/services/cache/current-result.service.ts
+++ b/research-indicators/src/app/shared/services/cache/current-result.service.ts
@@ -18,6 +18,7 @@ export class CurrentResultService {
     this.createResultManagementService.currentRequestedResultCode.set(resultCode);
     this.createResultManagementService.editingOicr.set(true);
     await this.api.GET_OICRModal(resultCode).then(response => {
+      response.data.step_three.comment_geo_scope = response.data.step_three.comment_geo_scope || '';
       this.createResultManagementService.createOicrBody.set(response.data);
       this.allModalsService.openModal('createResult');
       this.createResultManagementService.resultPageStep.set(2);

--- a/research-indicators/src/app/shared/services/cache/current-result.service.ts
+++ b/research-indicators/src/app/shared/services/cache/current-result.service.ts
@@ -23,6 +23,7 @@ export class CurrentResultService {
       this.createResultManagementService.resultPageStep.set(2);
       this.createResultManagementService.modalTitle.set('Edit OICR');
       this.createResultManagementService.contractId.set(response.data.base_information.contract_id);
+      this.createResultManagementService.resultTitle.set(response.data.base_information.title);
       this.cache.currentResultId.set(resultCode);
     });
     return true;


### PR DESCRIPTION
This pull request refactors the step navigation and validation logic in the `CreateOicrFormComponent` to use Angular signals, improves step completion checks, and enhances user experience by providing better feedback on form completion. It also fixes some pre-fill issues when editing or importing OICR data.

Key changes include:

**Step navigation and state management improvements:**

* Refactored `activeIndex` and `step4opened` to use Angular signals instead of primitive values, updating all references in both the TypeScript and HTML files to use the new signal-based approach. This ensures more reactive UI updates and consistent state management. [[1]](diffhunk://#diff-2f0e45d996b587a9514fa1d27bb92ece53dd0f57b184bcdfa7fc1986b08f6a62L93-R100) [[2]](diffhunk://#diff-024b8f5f52e4fe0f126f02eb26dd0c5df962f215b2c510164ab7d0570c7b834fL111-R123) [[3]](diffhunk://#diff-024b8f5f52e4fe0f126f02eb26dd0c5df962f215b2c510164ab7d0570c7b834fL145-R151) [[4]](diffhunk://#diff-024b8f5f52e4fe0f126f02eb26dd0c5df962f215b2c510164ab7d0570c7b834fL240-R246) [[5]](diffhunk://#diff-024b8f5f52e4fe0f126f02eb26dd0c5df962f215b2c510164ab7d0570c7b834fL390-R396) [[6]](diffhunk://#diff-2f0e45d996b587a9514fa1d27bb92ece53dd0f57b184bcdfa7fc1986b08f6a62L240-R245) [[7]](diffhunk://#diff-2f0e45d996b587a9514fa1d27bb92ece53dd0f57b184bcdfa7fc1986b08f6a62L311-R320) [[8]](diffhunk://#diff-2f0e45d996b587a9514fa1d27bb92ece53dd0f57b184bcdfa7fc1986b08f6a62L418-R437)

* Updated step navigation logic so that when the user navigates to step 4 (general comments), `step4opened` is set to true, allowing for more accurate tracking of user progress through the form. [[1]](diffhunk://#diff-2f0e45d996b587a9514fa1d27bb92ece53dd0f57b184bcdfa7fc1986b08f6a62L240-R245) [[2]](diffhunk://#diff-2f0e45d996b587a9514fa1d27bb92ece53dd0f57b184bcdfa7fc1986b08f6a62L418-R437)

**Form validation and user feedback:**

* Enhanced the validation for step one to require OICR selection when certain tag IDs are chosen, preventing users from proceeding without fulfilling all necessary requirements.

* Improved the logic for enabling/disabling the "Create" button: now, the button is only enabled when all steps are complete, and a tooltip provides guidance when it is disabled.

* Updated the step four completion effect to require all previous steps to be complete before marking step four as complete, except when editing an OICR, in which case step four is always considered open.

**Data pre-fill and consistency fixes:**

* Ensured that `comment_geo_scope` is always initialized to an empty string if missing when importing OICR metadata or editing an existing OICR, preventing potential issues with undefined values. [[1]](diffhunk://#diff-557bbe0e1541664a4a1110021e665c90e098c886fbc8bc197da9dc9460b7ce6aR96) [[2]](diffhunk://#diff-5bd8519f203d2bd87e56dfe9ef272d0b2a1c258f166a62f4cceda5e2a6bea000R21-R27)

**Minor cleanups:**

* Removed an unnecessary call to `projectResultsTableService.getData()` after creating a result, likely to avoid redundant data fetching.