### PR TITLE
Ac 1170 us10 redirect after preliminary oicr submission and adjust oicr detail view

### DIFF
--- a/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.ts
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.ts
@@ -399,7 +399,6 @@ export class CreateOicrFormComponent {
               this.allModalsService.closeModal('createResult');
               this.getResultsService.updateList();
               this.createResultManagementService.currentRequestedResultCode.set(null);
-              this.projectResultsTableService.getData();
               this.cache.projectResultsSearchValue.set(this.createResultManagementService.createOicrBody().base_information.title);
               this.createResultManagementService.clearOicrBody();
             };

--- a/research-indicators/src/app/shared/components/download-oicr-template/download-oicr-template.component.ts
+++ b/research-indicators/src/app/shared/components/download-oicr-template/download-oicr-template.component.ts
@@ -43,7 +43,8 @@ export class DownloadOicrTemplateComponent implements OnInit {
     ['1209379648', 'other_projects_text', 'text'],
     ['-504483', 'regions_countries_text', 'text'],
     ['1308358992', 'main_levers_text', 'text'],
-    ['539860219', 'others_levers_text', 'text']
+    ['539860219', 'others_levers_text', 'text'],
+    ['-264317297', 'handle_link', 'text']
   ] as const;
 
   fieldsToProcess: FieldToProcess[] = this.fieldConfig.map(([dropdownId, attribute, type]) => ({


### PR DESCRIPTION
This pull request introduces enhancements to the `AllianceNavbarComponent` and a minor update to the `DownloadOicrTemplateComponent`. The main focus is on improving navigation handling for the `/projects` and `/project-detail` routes, ensuring better active state management, and updating routing logic in the navbar. Additionally, a new field is added to the OICR template component.

### Navigation and Active State Improvements

* The navbar now dynamically sets `[routerLinkActiveOptions]` to `{ exact: false }` for the `/projects` route, allowing child routes to be considered active, and adds a hidden router link for `/project-detail` to better handle navigation highlighting.
* Added logic to track whether the user is on `/projects` or `/project-detail` routes using a new `isProjectsOrDetailActiveFlag` property, which is updated on navigation events and exposed via the `isProjectsOrDetailActive()` method. This uses `NavigationEnd` and `ChangeDetectorRef` for accurate state updates. [[1]](diffhunk://#diff-d2ba809d00a4049913f5615c5ccecf2d728660a9b04f4dcb361e24936ffa946dR58-R59) [[2]](diffhunk://#diff-d2ba809d00a4049913f5615c5ccecf2d728660a9b04f4dcb361e24936ffa946dR68-R85)
* Updated imports to include `NavigationEnd` and `ChangeDetectorRef` to support the new navigation tracking logic.

### OICR Template Field Update

* Added a new field `handle_link` to the list of fields processed by the `DownloadOicrTemplateComponent`, expanding the template's data handling capabilities.