### PR TITLE
PRMS Result Modal Integration

### DIFF
--- a/research-indicators/src/app/pages/platform/pages/my-projects/my-projects.component.html
+++ b/research-indicators/src/app/pages/platform/pages/my-projects/my-projects.component.html
@@ -94,13 +94,13 @@
                 <app-project-item [project]="project"></app-project-item>
               }
             </div>
-            @if (getCurrentProjects().length > 0) {
+            @if (myProjectsService.total() > 0) {
               <div #cardRppScope class="rpp-dropup flex justify-end w-full bg-white py-2 border border-[#E8EBED]">
               <p-paginator
                 (onPageChange)="onCurrentPageChange($event)"
                 [first]="(myProjectsService.page() - 1) * myProjectsService.limit()"
                 [rows]="myProjectsService.limit()"
-                [totalRecords]="getCurrentProjects().length"
+                [totalRecords]="myProjectsService.total()"
                 [showCurrentPageReport]="true"
                 [rowsPerPageOptions]="[5, 10, 25, 50]"
                 currentPageReportTemplate="Showing {first} to {last} of {totalRecords} projects"
@@ -113,9 +113,10 @@
           @if (isTableView()) {
             <div #tableRppScope class="rpp-dropup w-full border border-[#E8EBED]">
               <p-table
-                [value]="getCurrentProjects()"
+                [value]="myProjectsService.list()"
                 [paginator]="true"
                 [rows]="myProjectsService.limit()"
+                [first]="(myProjectsService.page() - 1) * myProjectsService.limit()"
                 [loading]="getLoadingState()"
                 [scrollHeight]="getScrollHeight()"
                 [showCurrentPageReport]="true"
@@ -127,6 +128,8 @@
                 currentPageReportTemplate="Showing {first} to {last} of {totalRecords} projects"
                 [sortField]="'start_date'"
                 [sortOrder]="-1"
+                [lazy]="true"
+                [totalRecords]="myProjectsService.total()"
                 [globalFilterFields]="[
                   'agreement_id',
                   'full_name',

--- a/research-indicators/src/app/pages/platform/pages/my-projects/my-projects.component.html
+++ b/research-indicators/src/app/pages/platform/pages/my-projects/my-projects.component.html
@@ -96,15 +96,15 @@
             </div>
             @if (getCurrentProjects().length > 0) {
               <div #cardRppScope class="rpp-dropup flex justify-end w-full bg-white py-2 border border-[#E8EBED]">
-                <p-paginator
-                  (onPageChange)="onCurrentPageChange($event)"
-                  [first]="getCurrentFirst()"
-                  [rows]="getCurrentRows()"
-                  [totalRecords]="getCurrentProjects().length"
-                  [showCurrentPageReport]="true"
-                  [rowsPerPageOptions]="[5, 10, 25, 50]"
-                  currentPageReportTemplate="Showing {first} to {last} of {totalRecords} projects"
-                  [dropdownAppendTo]="cardRppScope" />
+              <p-paginator
+                (onPageChange)="onCurrentPageChange($event)"
+                [first]="(myProjectsService.page() - 1) * myProjectsService.limit()"
+                [rows]="myProjectsService.limit()"
+                [totalRecords]="getCurrentProjects().length"
+                [showCurrentPageReport]="true"
+                [rowsPerPageOptions]="[5, 10, 25, 50]"
+                currentPageReportTemplate="Showing {first} to {last} of {totalRecords} projects"
+                [dropdownAppendTo]="cardRppScope" />
               </div>
             }
           }
@@ -115,7 +115,7 @@
               <p-table
                 [value]="getCurrentProjects()"
                 [paginator]="true"
-                [rows]="10"
+                [rows]="myProjectsService.limit()"
                 [loading]="getLoadingState()"
                 [scrollHeight]="getScrollHeight()"
                 [showCurrentPageReport]="true"
@@ -123,6 +123,7 @@
                 [tableStyle]="{ 'min-width': '100%' }"
                 [rowsPerPageOptions]="[5, 10, 25, 50]"
                 [paginatorDropdownAppendTo]="tableRppScope"
+                (onPage)="onCurrentPageChange($event)"
                 currentPageReportTemplate="Showing {first} to {last} of {totalRecords} projects"
                 [sortField]="'start_date'"
                 [sortOrder]="-1"

--- a/research-indicators/src/app/pages/platform/pages/my-projects/my-projects.component.html
+++ b/research-indicators/src/app/pages/platform/pages/my-projects/my-projects.component.html
@@ -94,17 +94,17 @@
                 <app-project-item [project]="project"></app-project-item>
               }
             </div>
-            @if (myProjectsService.total() > 0) {
+            @if (getCurrentProjects().length > 0) {
               <div #cardRppScope class="rpp-dropup flex justify-end w-full bg-white py-2 border border-[#E8EBED]">
-              <p-paginator
-                (onPageChange)="onCurrentPageChange($event)"
-                [first]="(myProjectsService.page() - 1) * myProjectsService.limit()"
-                [rows]="myProjectsService.limit()"
-                [totalRecords]="myProjectsService.total()"
-                [showCurrentPageReport]="true"
-                [rowsPerPageOptions]="[5, 10, 25, 50]"
-                currentPageReportTemplate="Showing {first} to {last} of {totalRecords} projects"
-                [dropdownAppendTo]="cardRppScope" />
+                <p-paginator
+                  (onPageChange)="onCurrentPageChange($event)"
+                  [first]="getCurrentFirst()"
+                  [rows]="getCurrentRows()"
+                  [totalRecords]="getCurrentProjects().length"
+                  [showCurrentPageReport]="true"
+                  [rowsPerPageOptions]="[5, 10, 25, 50]"
+                  currentPageReportTemplate="Showing {first} to {last} of {totalRecords} projects"
+                  [dropdownAppendTo]="cardRppScope" />
               </div>
             }
           }
@@ -113,10 +113,9 @@
           @if (isTableView()) {
             <div #tableRppScope class="rpp-dropup w-full border border-[#E8EBED]">
               <p-table
-                [value]="myProjectsService.list()"
+                [value]="getCurrentProjects()"
                 [paginator]="true"
-                [rows]="myProjectsService.limit()"
-                [first]="(myProjectsService.page() - 1) * myProjectsService.limit()"
+                [rows]="10"
                 [loading]="getLoadingState()"
                 [scrollHeight]="getScrollHeight()"
                 [showCurrentPageReport]="true"
@@ -124,12 +123,9 @@
                 [tableStyle]="{ 'min-width': '100%' }"
                 [rowsPerPageOptions]="[5, 10, 25, 50]"
                 [paginatorDropdownAppendTo]="tableRppScope"
-                (onPage)="onCurrentPageChange($event)"
                 currentPageReportTemplate="Showing {first} to {last} of {totalRecords} projects"
                 [sortField]="'start_date'"
                 [sortOrder]="-1"
-                [lazy]="true"
-                [totalRecords]="myProjectsService.total()"
                 [globalFilterFields]="[
                   'agreement_id',
                   'full_name',

--- a/research-indicators/src/app/pages/platform/pages/my-projects/my-projects.component.ts
+++ b/research-indicators/src/app/pages/platform/pages/my-projects/my-projects.component.ts
@@ -160,18 +160,41 @@ export default class MyProjectsComponent implements OnInit, AfterViewInit {
   });
 
   onPageChange(event: PaginatorState) {
+    const rows = event.rows ?? 10;
+    const first = event.first ?? 0;
+    const page = Math.floor(first / rows) + 1;
+
     if (this.myProjectsFilterItem()?.id === 'my') {
-      this.myProjectsFirst.set(event.first ?? 0);
-      this.myProjectsRows.set(event.rows ?? 10);
+      this.myProjectsFirst.set(first);
+      this.myProjectsRows.set(rows);
+      this.myProjectsService.setLimit(rows);
+      this.myProjectsService.setPage(page);
+      this.loadMyProjects();
     } else {
-      this.allProjectsFirst.set(event.first ?? 0);
-      this.allProjectsRows.set(event.rows ?? 10);
+      this.allProjectsFirst.set(first);
+      this.allProjectsRows.set(rows);
+      this.myProjectsService.setLimit(rows);
+      this.myProjectsService.setPage(page);
+      this.loadAllProjects();
     }
   }
 
   onAllProjectsPageChange(event: PaginatorState) {
-    this.allProjectsFirst.set(event.first ?? 0);
-    this.allProjectsRows.set(event.rows ?? 10);
+    const rows = event.rows ?? this.myProjectsService.limit();
+    const first = event.first ?? 0;
+    const page = Math.floor(first / rows) + 1;
+
+    this.allProjectsFirst.set(first);
+    this.allProjectsRows.set(rows);
+
+    this.myProjectsService.setLimit(rows);
+    this.myProjectsService.setPage(page);
+
+    if (this.myProjectsFilterItem()?.id === 'my') {
+      this.loadMyProjects();
+    } else {
+      this.loadAllProjects();
+    }
   }
 
   ngOnInit(): void {
@@ -373,6 +396,10 @@ export default class MyProjectsComponent implements OnInit, AfterViewInit {
   }
 
   onCurrentPageChange(event: PaginatorState): void {
+    this.onPageChange(event);
+  }
+
+  onRowsChange(event: PaginatorState): void {
     this.onPageChange(event);
   }
 }

--- a/research-indicators/src/app/pages/platform/pages/my-projects/my-projects.component.ts
+++ b/research-indicators/src/app/pages/platform/pages/my-projects/my-projects.component.ts
@@ -136,27 +136,7 @@ export default class MyProjectsComponent implements OnInit, AfterViewInit {
   }
 
   filteredProjects = computed(() => {
-    const projects = this.myProjectsService.list();
-    const searchTerm =
-      this.myProjectsFilterItem()?.id === 'my' ? this._searchValue().toLowerCase() : this.myProjectsService.searchInput().toLowerCase();
-
-    if (!searchTerm) return projects;
-
-    return projects.filter(project => {
-      const fullName = project.full_name?.toLowerCase() || '';
-      const agreementId = project.agreement_id?.toLowerCase() || '';
-      const description = project.description?.toLowerCase() || '';
-      const projectDescription = project.projectDescription?.toLowerCase() || '';
-      const principalInvestigator = project.principal_investigator?.toLowerCase() || '';
-
-      return (
-        fullName.includes(searchTerm) ||
-        agreementId.includes(searchTerm) ||
-        description.includes(searchTerm) ||
-        projectDescription.includes(searchTerm) ||
-        principalInvestigator.includes(searchTerm)
-      );
-    });
+    return this.myProjectsService.list();
   });
 
   onPageChange(event: PaginatorState) {
@@ -293,6 +273,7 @@ export default class MyProjectsComponent implements OnInit, AfterViewInit {
 
     this.myProjectsService.clearFilters();
     this._searchValue.set('');
+    this.myProjectsService.searchInput.set('');
 
     if (event.id === 'my') {
       this.myProjectsFirst.set(0);
@@ -306,11 +287,21 @@ export default class MyProjectsComponent implements OnInit, AfterViewInit {
   };
 
   loadMyProjects() {
-    this.myProjectsService.main({ 'current-user': true });
+    const params: Record<string, unknown> = { 'current-user': true };
+    const searchQuery = this.myProjectsService.searchInput();
+    if (searchQuery) {
+      params['query'] = searchQuery;
+    }
+    this.myProjectsService.main(params);
   }
 
   loadAllProjects() {
-    this.myProjectsService.main({ 'current-user': false });
+    const params: Record<string, unknown> = { 'current-user': false };
+    const searchQuery = this.myProjectsService.searchInput();
+    if (searchQuery) {
+      params['query'] = searchQuery;
+    }
+    this.myProjectsService.main(params);
   }
 
   onPinIconClick(tabId: string, event: Event) {
@@ -324,8 +315,13 @@ export default class MyProjectsComponent implements OnInit, AfterViewInit {
 
     if (this.myProjectsFilterItem()?.id === 'my') {
       this._searchValue.set(value);
+      this.myProjectsService.searchInput.set(value);
+      this.myProjectsService.setPage(1);
+      this.loadMyProjects();
     } else {
       this.myProjectsService.searchInput.set(value);
+      this.myProjectsService.setPage(1);
+      this.loadAllProjects();
     }
   }
 

--- a/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.ts
+++ b/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.ts
@@ -291,25 +291,8 @@ export class ResultsCenterTableComponent implements AfterViewInit {
 
   @HostListener('click', ['$event'])
   onHostClick(event: MouseEvent) {
-    this.lastClickedElement = event.target as Element;
     const target = event.target as Element;
-    const rowEl = target.closest('tr');
-    if (!rowEl) return;
-    const tbody = rowEl.parentElement;
-    if (!tbody) return;
-    const rows = Array.from(tbody.children).filter(el => el.tagName.toLowerCase() === 'tr');
-    const rowIndex = rows.indexOf(rowEl);
-    if (rowIndex < 0) return;
-    const data: Result[] = (this.dt2.filteredValue as Result[] | undefined) ?? this.resultsCenterService.list();
-    const pageStart: number = this.dt2.first || 0;
-    const idx = pageStart + rowIndex;
-    const result = data[idx] as Result | undefined;
-    if (result && result.platform_code === 'PRMS') {
-      event.preventDefault();
-      event.stopPropagation();
-      this.allModalsService.selectedResultForInfo.set(result);
-      this.allModalsService.openModal('resultInformation');
-    }
+    this.processRowClick(target, event);
   }
 
   getResultQueryParams(result: Result): { version?: number } {
@@ -334,27 +317,31 @@ export class ResultsCenterTableComponent implements AfterViewInit {
     const onDocClickCapture = (event: MouseEvent) => {
       const target = event.target as Element | null;
       if (!target) return;
-      this.lastClickedElement = target;
-      const rowEl = target.closest('tr');
-      if (!rowEl) return;
-      const tbody = rowEl.parentElement;
-      if (!tbody) return;
-      const rows = Array.from(tbody.children).filter(el => el.tagName.toLowerCase() === 'tr');
-      const rowIndex = rows.indexOf(rowEl);
-      if (rowIndex < 0) return;
-      const data: Result[] = (this.dt2.filteredValue as Result[] | undefined) ?? this.resultsCenterService.list();
-      const pageStart: number = this.dt2.first || 0;
-      const idx = pageStart + rowIndex;
-      const result = data[idx] as Result | undefined;
-      if (result && result.platform_code === 'PRMS') {
-        event.preventDefault();
-        event.stopPropagation();
-        this.allModalsService.selectedResultForInfo.set(result);
-        this.allModalsService.openModal('resultInformation');
-      }
+      this.processRowClick(target, event);
     };
 
     document.addEventListener('click', onDocClickCapture, { capture: true });
     this.removeDocumentClickListener = () => document.removeEventListener('click', onDocClickCapture, { capture: true } as unknown as boolean);
+  }
+
+  private processRowClick(target: Element, event: MouseEvent) {
+    this.lastClickedElement = target;
+    const rowEl = target.closest('tr');
+    if (!rowEl) return;
+    const tbody = rowEl.parentElement;
+    if (!tbody) return;
+    const rows = Array.from(tbody.children).filter(el => el.tagName.toLowerCase() === 'tr');
+    const rowIndex = rows.indexOf(rowEl);
+    if (rowIndex < 0) return;
+    const data: Result[] = (this.dt2.filteredValue as Result[] | undefined) ?? this.resultsCenterService.list();
+    const pageStart: number = this.dt2.first || 0;
+    const idx = pageStart + rowIndex;
+    const result = data[idx] as Result | undefined;
+    if (result && result.platform_code === 'PRMS') {
+      event.preventDefault();
+      event.stopPropagation();
+      this.allModalsService.selectedResultForInfo.set(result);
+      this.allModalsService.openModal('resultInformation');
+    }
   }
 }

--- a/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.ts
+++ b/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.ts
@@ -1,4 +1,4 @@
-import { Component, effect, inject, ViewChild, signal, AfterViewInit, computed } from '@angular/core';
+import { Component, effect, inject, ViewChild, signal, AfterViewInit, computed, HostListener } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { Table, TableModule } from 'primeng/table';
 import { ButtonModule } from 'primeng/button';
@@ -16,6 +16,7 @@ import { Result } from '@shared/interfaces/result/result.interface';
 import { FiltersActionButtonsComponent } from '../../../../../../shared/components/filters-action-buttons/filters-action-buttons.component';
 import { SearchExportControlsComponent } from '../../../../../../shared/components/search-export-controls/search-export-controls.component';
 import { PLATFORM_COLOR_MAP } from '../../../../../../shared/constants/platform-colors';
+import { AllModalsService } from '@shared/services/cache/all-modals.service';
 @Component({
   selector: 'app-results-center-table',
   imports: [
@@ -37,8 +38,11 @@ export class ResultsCenterTableComponent implements AfterViewInit {
   resultsCenterService = inject(ResultsCenterService);
   private readonly router = inject(Router);
   private readonly cacheService = inject(CacheService);
+  private readonly allModalsService = inject(AllModalsService);
   @ViewChild('dt2') dt2!: Table;
   tableRef = signal<Table | undefined>(undefined);
+  private lastClickedElement: Element | null = null;
+  private removeDocumentClickListener: (() => void) | null = null;
 
   menuItems: MenuItem[] = [
     { label: 'Edit', icon: 'pi pi-pencil' },
@@ -237,9 +241,12 @@ export class ResultsCenterTableComponent implements AfterViewInit {
 
   openResult(result: Result) {
     this.resultsCenterService.clearAllFilters();
-
+    if (result.platform_code === 'PRMS') {
+      this.allModalsService.selectedResultForInfo.set(result);
+      this.allModalsService.openModal('resultInformation');
+      return;
+    }
     const resultCode = `${result.platform_code}-${result.result_official_code}`;
-
     if (result.result_status?.result_status_id === 6 && Array.isArray(result.snapshot_years) && result.snapshot_years.length > 0) {
       const latestYear = Math.max(...result.snapshot_years);
       this.router.navigate(['/result', resultCode, 'general-information'], { queryParams: { version: latestYear } });
@@ -249,17 +256,22 @@ export class ResultsCenterTableComponent implements AfterViewInit {
   }
 
   openResultByYear(result: number, year: string | number, platformCode: string) {
+    if (platformCode === 'PRMS') {
+      return;
+    }
     this.resultsCenterService.clearAllFilters();
     const resultCode = `${platformCode}-${result}`;
-
     this.router.navigate(['/result', resultCode], {
       queryParams: { version: year }
     });
   }
 
   getResultHref(result: Result): string {
+    if (result.platform_code === 'PRMS') {
+      this.onResultLinkClick(result);
+      return '';
+    }
     const resultCode = `${result.platform_code}-${result.result_official_code}`;
-
     if (result.result_status?.result_status_id === 6 && Array.isArray(result.snapshot_years) && result.snapshot_years.length > 0) {
       const latestYear = Math.max(...result.snapshot_years);
       return this.router.createUrlTree(['/result', resultCode, 'general-information'], { 
@@ -269,13 +281,35 @@ export class ResultsCenterTableComponent implements AfterViewInit {
     return `/result/${resultCode}`;
   }
 
-  getResultRouteArray(result: Result): string[] {
+  getResultRouteArray(result: Result): string | string[] {
     const resultCode = `${result.platform_code}-${result.result_official_code}`;
-
     if (result.result_status?.result_status_id === 6 && Array.isArray(result.snapshot_years) && result.snapshot_years.length > 0) {
       return ['/result', resultCode, 'general-information'];
     }
     return ['/result', resultCode];
+  }
+
+  @HostListener('click', ['$event'])
+  onHostClick(event: MouseEvent) {
+    this.lastClickedElement = event.target as Element;
+    const target = event.target as Element;
+    const rowEl = target.closest('tr');
+    if (!rowEl) return;
+    const tbody = rowEl.parentElement;
+    if (!tbody) return;
+    const rows = Array.from(tbody.children).filter(el => el.tagName.toLowerCase() === 'tr');
+    const rowIndex = rows.indexOf(rowEl);
+    if (rowIndex < 0) return;
+    const data: Result[] = (this.dt2.filteredValue as Result[] | undefined) ?? this.resultsCenterService.list();
+    const pageStart: number = this.dt2.first || 0;
+    const idx = pageStart + rowIndex;
+    const result = data[idx] as Result | undefined;
+    if (result && result.platform_code === 'PRMS') {
+      event.preventDefault();
+      event.stopPropagation();
+      this.allModalsService.selectedResultForInfo.set(result);
+      this.allModalsService.openModal('resultInformation');
+    }
   }
 
   getResultQueryParams(result: Result): { version?: number } {
@@ -286,8 +320,41 @@ export class ResultsCenterTableComponent implements AfterViewInit {
     return {};
   }
 
+  onResultLinkClick(result: Result): void {
+    if (result.platform_code === 'PRMS') {
+      this.allModalsService.selectedResultForInfo.set(result);
+      this.allModalsService.openModal('resultInformation');
+    }
+  }
+
   ngAfterViewInit() {
     this.tableRef.set(this.dt2);
     this.resultsCenterService.tableRef.set(this.dt2);
+
+    const onDocClickCapture = (event: MouseEvent) => {
+      const target = event.target as Element | null;
+      if (!target) return;
+      this.lastClickedElement = target;
+      const rowEl = target.closest('tr');
+      if (!rowEl) return;
+      const tbody = rowEl.parentElement;
+      if (!tbody) return;
+      const rows = Array.from(tbody.children).filter(el => el.tagName.toLowerCase() === 'tr');
+      const rowIndex = rows.indexOf(rowEl);
+      if (rowIndex < 0) return;
+      const data: Result[] = (this.dt2.filteredValue as Result[] | undefined) ?? this.resultsCenterService.list();
+      const pageStart: number = this.dt2.first || 0;
+      const idx = pageStart + rowIndex;
+      const result = data[idx] as Result | undefined;
+      if (result && result.platform_code === 'PRMS') {
+        event.preventDefault();
+        event.stopPropagation();
+        this.allModalsService.selectedResultForInfo.set(result);
+        this.allModalsService.openModal('resultInformation');
+      }
+    };
+
+    document.addEventListener('click', onDocClickCapture, { capture: true });
+    this.removeDocumentClickListener = () => document.removeEventListener('click', onDocClickCapture, { capture: true } as unknown as boolean);
   }
 }

--- a/research-indicators/src/app/shared/components/all-modals/all-modals.component.html
+++ b/research-indicators/src/app/shared/components/all-modals/all-modals.component.html
@@ -13,3 +13,7 @@
 <app-modal modalName="askForHelp" [clearModal]="clearModal">
   <app-ask-for-help-modal></app-ask-for-help-modal>
 </app-modal>
+
+<app-modal modalName="resultInformation" [clearModal]="clearModal">
+  <app-result-information-modal></app-result-information-modal>
+</app-modal>

--- a/research-indicators/src/app/shared/components/all-modals/all-modals.component.ts
+++ b/research-indicators/src/app/shared/components/all-modals/all-modals.component.ts
@@ -6,10 +6,18 @@ import { SubmitResultContentComponent } from './modals-content/submit-result-con
 import { SubmissionService } from '../../services/submission.service';
 import { RequestPartnerModalComponent } from './modals-content/request-partner-modal/request-partner-modal.component';
 import { AskForHelpModalComponent } from './modals-content/ask-for-help-modal/ask-for-help-modal/ask-for-help-modal.component';
+import { ResultInformationModalComponent } from './modals-content/result-information-modal/result-information-modal.component';
 
 @Component({
   selector: 'app-all-modals',
-  imports: [ModalComponent, CreateResultModalComponent, RequestPartnerModalComponent, SubmitResultContentComponent, AskForHelpModalComponent],
+  imports: [
+    ModalComponent,
+    CreateResultModalComponent,
+    RequestPartnerModalComponent,
+    SubmitResultContentComponent,
+    AskForHelpModalComponent,
+    ResultInformationModalComponent
+  ],
   templateUrl: './all-modals.component.html'
 })
 export class AllModalsComponent {

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-result-form/create-result-form.component.spec.ts
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-result-form/create-result-form.component.spec.ts
@@ -153,7 +153,7 @@ describe('CreateResultFormComponent', () => {
     expect(management.setContractId).toHaveBeenCalledWith(77);
     expect(management.setResultTitle).toHaveBeenCalledWith('Title');
     expect(management.setYear).toHaveBeenCalledWith(2024);
-    expect(management.setModalTitle).toHaveBeenCalledWith('OICR result');
+    expect(management.setModalTitle).toHaveBeenCalledWith('Outcome Impact Case Report (OICR)');
     expect(management.resultPageStep()).toBe(2);
   });
 

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-result-form/create-result-form.component.ts
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-result-form/create-result-form.component.ts
@@ -222,7 +222,7 @@ export class CreateResultFormComponent {
     this.createResultManagementService.setContractId(this.body().contract_id);
     this.createResultManagementService.setResultTitle(this.body().title);
     this.createResultManagementService.setYear(this.body().year);
-    this.createResultManagementService.setModalTitle('OICR result');
+    this.createResultManagementService.setModalTitle('Outcome Impact Case Report (OICR)');
     this.createResultManagementService.createOicrBody.update(b => ({
       ...b,
       base_information: {

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/result-information-modal/result-information-modal.component.html
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/result-information-modal/result-information-modal.component.html
@@ -20,8 +20,8 @@
 
         <div class="flex items-center gap-2">
             <span class="text-[#B9C0C5]/60">|</span>
-            <i class="pi pi-users !text-[16px] text-[#7CB580]"></i>
-            <span class="text-[11px] text-[#8D9299] font-[400] !font-[Space_Grotesk]">CAPACITY SHARING FOR DEVELOPMENT</span>
+            <i class="pi {{ result()?.indicators?.icon_src }} !text-[16px] text-[#7CB580]"></i>
+            <span class="text-[11px] text-[#8D9299] font-[400] !font-[Space_Grotesk]">{{ result()?.indicators?.name }}</span>
           </div>
         </div>
       </div>

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/result-information-modal/result-information-modal.component.html
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/result-information-modal/result-information-modal.component.html
@@ -1,0 +1,109 @@
+<div class="w-[90vw] max-w-[1100px] p-6">
+  @if (result()) {
+    <div class="bg-white rounded-2xl border border-[#E8EBED] p-6">
+      <div class="flex items-center justify-between mb-4">
+        <div class="flex items-center gap-3">
+        <img [src]="'images/prms-reporting-tool.svg' | s3ImageUrl" alt="PRMS Reporting Tool" class="w-13" />
+
+        <div class="flex items-center text-[11px]">
+
+           <span
+             class="py-1 px-2 rounded-l-lg font-[600] min-w-[50px] max-w-[50px] text-center"
+             [style.color]="getPlatformColors(result()?.platform_code ?? '')?.text"
+             [style.background-color]="getPlatformColors(result()?.platform_code ?? '')?.background">
+             {{ result()?.platform_code ?? '' }}
+           </span>
+           <span class="text-[#4C5158] bg-[#E8EBED] py-1 px-2 rounded-r-lg min-w-[43px] text-center">
+             {{ formatResultCode(result()?.result_official_code) }}
+           </span>
+        </div>
+
+        <div class="flex items-center gap-2">
+            <span class="text-[#B9C0C5]/60">|</span>
+            <i class="pi pi-users !text-[16px] text-[#7CB580]"></i>
+            <span class="text-[11px] text-[#8D9299] font-[400] !font-[Space_Grotesk]">CAPACITY SHARING FOR DEVELOPMENT</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="text-[#173F6F]">
+        <p class="text-[18px] font-[700] leading-snug mb-4">{{ result()?.title }}</p>
+        <div class="flex flex-wrap gap-4 text-sm mb-2">
+            <app-custom-tag [statusId]="(result()?.result_status?.result_status_id ?? 0)" [tiny]="true" [statusName]="(result()?.result_status?.name ?? '')">
+            </app-custom-tag>
+
+            <div class="flex items-center">
+            <span class="font-normal text-[13px] text-[#777c83] !font-['Space_Grotesk'] leading-4">Reporting Project</span>
+            <i class="pi pi-arrow-right !text-[8px] px-2 !text-[#8D9299]"></i>
+            <span class="text-[13px] uppercase leading-[18px] text-[#345b8f] font-['Space_Grotesk']">{{
+                result()?.result_contracts?.contract_id }}
+            </span>
+            </div>
+            <div class="flex items-center">
+            <span class="font-normal text-[13px] text-[#777c83] !font-['Space_Grotesk'] leading-4">Primary Lever</span>
+            <i class="pi pi-arrow-right !text-[8px] px-2 !text-[#8D9299]"></i>
+            <span class="text-[13px] uppercase leading-[18px] text-[#345b8f] font-['Space_Grotesk']">{{getValue() }}
+            </span>
+            </div>
+            <div class="flex items-center">
+            <span class="font-normal text-[13px] text-[#777c83] !font-['Space_Grotesk'] leading-4">Creator</span>
+            <i class="pi pi-arrow-right !text-[8px] px-2 !text-[#8D9299]"></i>
+            <span class="text-[13px] uppercase leading-[18px] text-[#345b8f] font-['Space_Grotesk']">{{
+                result()?.created_by_user?.first_name }} {{ result()?.created_by_user?.last_name }}
+            </span>
+            </div>
+        </div>
+
+        <div class="flex flex-wrap gap-4 text-sm">  
+            <div class="flex items-center">
+                <span class="font-normal text-[13px] text-[#777c83] !font-['Space_Grotesk'] leading-4">Live Version</span>
+                <i class="pi pi-arrow-right !text-[8px] px-2 !text-[#8D9299]"></i>
+                <span class="text-[13px] uppercase leading-[18px] text-[#345b8f] font-['Space_Grotesk']">{{
+                    result()?.report_year_id }}
+                </span>
+            </div>
+
+            @if ((result()?.snapshot_years?.length ?? 0) > 0) {
+            <div class="flex items-center">
+                <span class="font-normal text-[13px] text-[#777c83] !font-['Space_Grotesk'] leading-4">Approved Versions</span>
+                <i class="pi pi-arrow-right !text-[8px] px-2 !text-[#8D9299]"></i>
+                <span class="text-[13px] uppercase leading-[18px] text-[#345b8f] font-['Space_Grotesk']">
+                    @for (year of result()?.snapshot_years; track year) {
+                        <span
+                            class="px-2 py-1 bg-[#F4F7F9] rounded-md text-[#1689CA] text-[11px] cursor-pointer">
+                            {{ year }}
+                        </span>
+                        }
+                </span>
+            </div>
+            }
+
+            <div class="flex items-center">
+            <span class="font-normal text-[13px] text-[#777c83] !font-['Space_Grotesk'] leading-4">Creation date</span>
+            <i class="pi pi-arrow-right !text-[8px] px-2 !text-[#8D9299]"></i>
+            <span class="text-[13px] uppercase leading-[18px] text-[#345b8f] font-['Space_Grotesk']">{{
+                result()?.created_at | date:'dd/MM/yyyy' }}
+            </span>
+            </div>
+        </div>
+      </div>
+
+      <div class="mt-8 flex flex-wrap gap-3">
+        <button
+        type="button"
+        class="flex cursor-pointer items-center gap-2 border-1 border-[#035BA9] text-[#035BA9] px-6 py-2 rounded-[13px] text-[15px] disabled:cursor-default disabled:bg-[#E8EBED] disabled:border-[#E8EBED] disabled:text-[#A2A9AF]">
+        Open Pdf
+        <i class="pi pi-file-pdf !text-[14px]"></i> 
+      </button>
+      <button
+      type="button"
+      class="flex cursor-pointer items-center gap-2  bg-[#035BA9] text-white px-6 py-2 rounded-[13px] text-[15px] disabled:cursor-default disabled:bg-[#E8EBED] disabled:border-[#E8EBED] disabled:text-[#A2A9AF]">
+      Open result in PRMS
+      <i class="pi pi-external-link !text-[12px]"></i> 
+    </button>
+      </div>
+    </div>
+  }
+</div>
+
+

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/result-information-modal/result-information-modal.component.html
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/result-information-modal/result-information-modal.component.html
@@ -1,4 +1,4 @@
-<div class="w-[90vw] max-w-[1100px] p-6">
+<div class="w-[70vw] max-w-[1000px] p-6">
   @if (result()) {
     <div class="bg-white rounded-2xl border border-[#E8EBED] p-6">
       <div class="flex items-center justify-between mb-4">

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/result-information-modal/result-information-modal.component.html
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/result-information-modal/result-information-modal.component.html
@@ -21,7 +21,7 @@
         <div class="flex items-center gap-2">
             <span class="text-[#B9C0C5]/60">|</span>
             <i class="pi {{ result()?.indicators?.icon_src }} !text-[16px] text-[#7CB580]"></i>
-            <span class="text-[11px] text-[#8D9299] font-[400] !font-[Space_Grotesk]">{{ result()?.indicators?.name }}</span>
+            <span class="text-[11px] text-[#8D9299] font-[400] uppercase">{{ result()?.indicators?.name }}</span>
           </div>
         </div>
       </div>

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/result-information-modal/result-information-modal.component.ts
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/result-information-modal/result-information-modal.component.ts
@@ -31,7 +31,7 @@ export class ResultInformationModalComponent {
   getValue(result?: Result): string {
     const r = result ?? this.result();
     if (!r) return '-';
-    const levers = (r.result_levers as Array<{ is_primary: number | string; lever?: { short_name?: string } }> | undefined) ?? [];
+    const levers = (r.result_levers as { is_primary: number | string; lever?: { short_name?: string } }[] | undefined) ?? [];
     if (!Array.isArray(levers) || levers.length === 0) return '-';
     const primaryLevers = levers.filter(l => Number(l.is_primary) === 1);
     if (primaryLevers.length === 0) return '-';

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/result-information-modal/result-information-modal.component.ts
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/result-information-modal/result-information-modal.component.ts
@@ -1,0 +1,43 @@
+import { Component, inject, computed } from '@angular/core';
+import { CommonModule, DatePipe } from '@angular/common';
+import { AllModalsService } from '@shared/services/cache/all-modals.service';
+import { ButtonModule } from 'primeng/button';
+import { S3ImageUrlPipe } from '@shared/pipes/s3-image-url.pipe';
+import { Result } from '@shared/interfaces/result/result.interface';
+import { CustomTagComponent } from '@shared/components/custom-tag/custom-tag.component';
+import { PLATFORM_COLOR_MAP } from '@shared/constants/platform-colors';
+
+@Component({
+  selector: 'app-result-information-modal',
+  imports: [CommonModule, ButtonModule, DatePipe, S3ImageUrlPipe, CustomTagComponent],
+  templateUrl: './result-information-modal.component.html'
+})
+export class ResultInformationModalComponent {
+  allModals = inject(AllModalsService);
+
+  result = computed(() => this.allModals.selectedResultForInfo());
+
+  close = () => this.allModals.closeModal('resultInformation');
+
+  getPlatformColors(platformCode: string): { text: string; background: string } | undefined {
+    return PLATFORM_COLOR_MAP[platformCode];
+  }
+  formatResultCode(code: string | number | null | undefined): string {
+    if (code === null || code === undefined) return '';
+    const str = String(code);
+    if (!str) return '';
+    return str.padStart(3, '0');
+  }
+  getValue(result?: Result): string {
+    const r = result ?? this.result();
+    if (!r) return '-';
+    const levers = (r.result_levers as Array<{ is_primary: number | string; lever?: { short_name?: string } }> | undefined) ?? [];
+    if (!Array.isArray(levers) || levers.length === 0) return '-';
+    const primaryLevers = levers.filter(l => Number(l.is_primary) === 1);
+    if (primaryLevers.length === 0) return '-';
+    const text = primaryLevers.map(l => l.lever?.short_name ?? '').filter(v => v.length > 0).join(', ');
+    return text || '-';
+  }
+}
+
+

--- a/research-indicators/src/app/shared/interfaces/find-contracts.interface.ts
+++ b/research-indicators/src/app/shared/interfaces/find-contracts.interface.ts
@@ -37,3 +37,17 @@ export interface FindContracts {
   is_active?: boolean;
   indicators?: GetProjectDetailIndicator[];
 }
+
+export interface FindContractsResponse {
+  data: FindContracts[];
+  metadata: FindContractsMetadata;
+}
+
+export interface FindContractsMetadata {
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+}

--- a/research-indicators/src/app/shared/interfaces/result/result.interface.ts
+++ b/research-indicators/src/app/shared/interfaces/result/result.interface.ts
@@ -9,7 +9,7 @@ export interface Result {
   description: null | string;
   indicator_id: number;
   geo_scope_id: null;
-  indicators?: { name: string };
+  indicators?: { name: string; icon_src: string };
   result_status?: { name: string; result_status_id: number };
   result_contracts?: { contract_id: string };
   result_levers?: { lever: { short_name: string } };

--- a/research-indicators/src/app/shared/services/api.service.ts
+++ b/research-indicators/src/app/shared/services/api.service.ts
@@ -500,6 +500,7 @@ export class ApiService {
     'order-field'?: string;
     direction?: string;
     'end-date'?: string;
+    query?: string;
     page?: string;
     limit?: string;
   }): Promise<MainResponse<FindContractsResponse>> => {
@@ -692,6 +693,7 @@ export class ApiService {
     status?: string;
     'start-date'?: string;
     'end-date'?: string;
+    query?: string;
     page?: string;
     limit?: string;
   }): HttpParams {
@@ -706,6 +708,7 @@ export class ApiService {
       'status',
       'start-date',
       'end-date',
+      'query',
       'page',
       'limit'
     ];

--- a/research-indicators/src/app/shared/services/api.service.ts
+++ b/research-indicators/src/app/shared/services/api.service.ts
@@ -705,7 +705,9 @@ export class ApiService {
       'lever',
       'status',
       'start-date',
-      'end-date'
+      'end-date',
+      'page',
+      'limit'
     ];
     filterKeys.forEach(key => {
       const value = filters[key];

--- a/research-indicators/src/app/shared/services/api.service.ts
+++ b/research-indicators/src/app/shared/services/api.service.ts
@@ -500,6 +500,8 @@ export class ApiService {
     'order-field'?: string;
     direction?: string;
     'end-date'?: string;
+    page?: string;
+    limit?: string;
   }): Promise<MainResponse<FindContracts[]>> => {
     const url = () => 'agresso/contracts/find-contracts';
     const params = this.buildFindContractsParams(filters);
@@ -690,6 +692,8 @@ export class ApiService {
     status?: string;
     'start-date'?: string;
     'end-date'?: string;
+    page?: string;
+    limit?: string;
   }): HttpParams {
     let params = new HttpParams();
     if (!filters) return params;

--- a/research-indicators/src/app/shared/services/api.service.ts
+++ b/research-indicators/src/app/shared/services/api.service.ts
@@ -59,7 +59,7 @@ import { DynamoFeedback } from '../interfaces/dynamo-feedback.interface';
 import { IssueCategory } from '../interfaces/issue-category.interface';
 import { GenericList } from '@shared/interfaces/generic-list.interface';
 import { Initiative } from '@shared/interfaces/initiative.interface';
-import { FindContracts } from '../interfaces/find-contracts.interface';
+import { FindContractsResponse } from '../interfaces/find-contracts.interface';
 import { GetLevers } from '@shared/interfaces/get-levers.interface';
 import { Configuration } from '@shared/interfaces/configuration.interface';
 import { GetTags } from '@shared/interfaces/get-tags.interface';
@@ -502,7 +502,7 @@ export class ApiService {
     'end-date'?: string;
     page?: string;
     limit?: string;
-  }): Promise<MainResponse<FindContracts[]>> => {
+  }): Promise<MainResponse<FindContractsResponse>> => {
     const url = () => 'agresso/contracts/find-contracts';
     const params = this.buildFindContractsParams(filters);
     return this.TP.get(url(), { params });

--- a/research-indicators/src/app/shared/services/cache/all-modals.service.spec.ts
+++ b/research-indicators/src/app/shared/services/cache/all-modals.service.spec.ts
@@ -55,7 +55,7 @@ describe('AllModalsService', () => {
       },
       createOicrResult: {
         isOpen: false,
-        title: 'OICR Result'
+        title: 'Outcome Impact Case Report (OICR)'
       },
       askForHelp: {
         isOpen: false,

--- a/research-indicators/src/app/shared/services/cache/all-modals.service.spec.ts
+++ b/research-indicators/src/app/shared/services/cache/all-modals.service.spec.ts
@@ -52,6 +52,10 @@ describe('AllModalsService', () => {
         isOpen: false,
         title: 'Partners Request'
       },
+      resultInformation: {
+        isOpen: false,
+        title: 'Result Information'
+      },
       createOicrResult: {
         isOpen: false,
         title: 'Outcome Impact Case Report (OICR)'
@@ -111,6 +115,22 @@ describe('AllModalsService', () => {
     const modalConfig = service.modalConfig();
     expect(modalConfig.createResult.title).toBe('Create A Result');
     expect(modalConfig.createResult.icon).toBe('arrow_back');
+    expect(modalConfig.createResult.iconAction).toBeDefined();
+  });
+
+  it('should not set icon or action when step is not 1 or 2', () => {
+    service.updateModal(3);
+    const modalConfig = service.modalConfig();
+    expect(modalConfig.createResult.title).toBe('Create A Result');
+    expect(modalConfig.createResult.icon).toBeUndefined();
+    expect(modalConfig.createResult.iconAction).toBeUndefined();
+  });
+
+  it('should set empty icon when editingOicr is true (step 1)', () => {
+    (mockCreateResultManagementService.editingOicr as jest.Mock).mockReturnValueOnce(true);
+    service.updateModal(1);
+    const modalConfig = service.modalConfig();
+    expect(modalConfig.createResult.icon).toBe('');
     expect(modalConfig.createResult.iconAction).toBeDefined();
   });
 
@@ -177,6 +197,7 @@ describe('AllModalsService', () => {
     service.openModal('createResult');
     service.openModal('submitResult');
     service.openModal('requestPartner');
+    service.openModal('resultInformation');
     service.openModal('askForHelp');
 
     expect(service.isAnyModalOpen()).toBe(true);
@@ -188,6 +209,7 @@ describe('AllModalsService', () => {
     expect(service.modalConfig().requestPartner.isOpen).toBe(false);
     expect(service.modalConfig().createOicrResult.isOpen).toBe(false);
     expect(service.modalConfig().askForHelp.isOpen).toBe(false);
+    expect(service.modalConfig().resultInformation.isOpen).toBe(false);
     expect(mockCreateResultManagementService.resultPageStep.set).toHaveBeenCalledWith(0);
   });
 

--- a/research-indicators/src/app/shared/services/cache/all-modals.service.spec.ts
+++ b/research-indicators/src/app/shared/services/cache/all-modals.service.spec.ts
@@ -1,5 +1,4 @@
 import { TestBed } from '@angular/core/testing';
-import { signal } from '@angular/core';
 import { AllModalsService } from './all-modals.service';
 import { CreateResultManagementService } from '@shared/components/all-modals/modals-content/create-result-modal/services/create-result-management.service';
 import { ModalName } from '@ts-types/modal.types';

--- a/research-indicators/src/app/shared/services/cache/all-modals.service.ts
+++ b/research-indicators/src/app/shared/services/cache/all-modals.service.ts
@@ -1,5 +1,6 @@
 import { effect, inject, Injectable, signal, WritableSignal } from '@angular/core';
 import { CreateResultManagementService } from '@shared/components/all-modals/modals-content/create-result-modal/services/create-result-management.service';
+import { Result } from '@shared/interfaces/result/result.interface';
 import { ModalName } from '@ts-types/modal.types';
 
 interface ModalConfig {
@@ -20,6 +21,7 @@ interface ModalConfig {
 })
 export class AllModalsService {
   partnerRequestSection = signal<string | null>(null);
+  selectedResultForInfo = signal<Result | null>(null);
   createResultManagementService = inject(CreateResultManagementService);
   goBackFunction?: () => void;
   setGoBackFunction = (fn: () => void) => (this.goBackFunction = fn);
@@ -58,6 +60,10 @@ export class AllModalsService {
     askForHelp: {
       isOpen: false,
       title: 'Ask for Help'
+    },
+    resultInformation: {
+      isOpen: false,
+      title: 'Result Information'
     }
   });
 
@@ -140,7 +146,8 @@ export class AllModalsService {
       submitResult: { ...this.modalConfig().submitResult, isOpen: false, isWide: false },
       requestPartner: { ...this.modalConfig().requestPartner, isOpen: false, isWide: false },
       createOicrResult: { ...this.modalConfig().createOicrResult, isOpen: false, isWide: false },
-      askForHelp: { ...this.modalConfig().askForHelp, isOpen: false, isWide: false }
+      askForHelp: { ...this.modalConfig().askForHelp, isOpen: false, isWide: false },
+      resultInformation: { ...this.modalConfig().resultInformation, isOpen: false, isWide: false }
     });
 
     this.createResultManagementService.resetModal();

--- a/research-indicators/src/app/shared/services/cache/all-modals.service.ts
+++ b/research-indicators/src/app/shared/services/cache/all-modals.service.ts
@@ -53,7 +53,7 @@ export class AllModalsService {
     },
     createOicrResult: {
       isOpen: false,
-      title: 'OICR Result'
+      title: 'Outcome Impact Case Report (OICR)'
     },
     askForHelp: {
       isOpen: false,

--- a/research-indicators/src/app/shared/services/cache/current-result.service.spec.ts
+++ b/research-indicators/src/app/shared/services/cache/current-result.service.spec.ts
@@ -1,4 +1,115 @@
 import { TestBed } from '@angular/core/testing';
+import { CurrentResultService } from './current-result.service';
+import { ApiService } from '../api.service';
+import { AllModalsService } from './all-modals.service';
+import { CacheService } from './cache.service';
+import { CreateResultManagementService } from '../../components/all-modals/modals-content/create-result-modal/services/create-result-management.service';
+
+describe('CurrentResultService', () => {
+  let service: CurrentResultService;
+
+  const mockApi: Partial<ApiService> = {
+    GET_OICRModal: jest.fn()
+  };
+
+  const signalMock = () => ({ set: jest.fn() });
+
+  const mockAllModals: Partial<AllModalsService> = {
+    openModal: jest.fn()
+  };
+
+  const mockCreateResultManagement: Partial<CreateResultManagementService> = {
+    currentRequestedResultCode: signalMock() as unknown as CreateResultManagementService['currentRequestedResultCode'],
+    editingOicr: signalMock() as unknown as CreateResultManagementService['editingOicr'],
+    createOicrBody: signalMock() as unknown as CreateResultManagementService['createOicrBody'],
+    resultPageStep: signalMock() as unknown as CreateResultManagementService['resultPageStep'],
+    modalTitle: signalMock() as unknown as CreateResultManagementService['modalTitle'],
+    contractId: signalMock() as unknown as CreateResultManagementService['contractId'],
+    resultTitle: signalMock() as unknown as CreateResultManagementService['resultTitle']
+  };
+
+  const mockCache: Partial<CacheService> = {
+    currentResultId: signalMock() as unknown as CacheService['currentResultId']
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    TestBed.configureTestingModule({
+      providers: [
+        CurrentResultService,
+        { provide: ApiService, useValue: mockApi },
+        { provide: AllModalsService, useValue: mockAllModals },
+        { provide: CacheService, useValue: mockCache },
+        { provide: CreateResultManagementService, useValue: mockCreateResultManagement }
+      ]
+    });
+    service = TestBed.inject(CurrentResultService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('validateOpenResult should return true when indicatorId is 5', () => {
+    expect(service.validateOpenResult(5, 1)).toBe(true);
+  });
+
+  it('validateOpenResult should return true when resultStatusId is 9', () => {
+    expect(service.validateOpenResult(1, 9)).toBe(true);
+  });
+
+  it('validateOpenResult should return false otherwise', () => {
+    expect(service.validateOpenResult(1, 1)).toBe(false);
+  });
+
+  it('openEditRequestdOicrsModal should short-circuit and return false when validation fails', async () => {
+    const result = await service.openEditRequestdOicrsModal(1, 1, 123);
+    expect(result).toBe(false);
+    expect(mockApi.GET_OICRModal).not.toHaveBeenCalled();
+    expect(mockAllModals.openModal).not.toHaveBeenCalled();
+    expect((mockCreateResultManagement.currentRequestedResultCode as any).set).not.toHaveBeenCalled();
+    expect((mockCache.currentResultId as any).set).not.toHaveBeenCalled();
+  });
+
+  it('openEditRequestdOicrsModal should load data, set signals and return true with defaulted comment', async () => {
+    const responseData = {
+      step_three: { comment_geo_scope: undefined },
+      base_information: { contract_id: 'C-1', title: 'TITLE-1' }
+    };
+    (mockApi.GET_OICRModal as jest.Mock).mockResolvedValueOnce({ data: responseData });
+
+    const ok = await service.openEditRequestdOicrsModal(5, 1, 456);
+
+    expect(ok).toBe(true);
+    expect(mockApi.GET_OICRModal).toHaveBeenCalledWith(456);
+    expect((mockCreateResultManagement.currentRequestedResultCode as any).set).toHaveBeenCalledWith(456);
+    expect((mockCreateResultManagement.editingOicr as any).set).toHaveBeenCalledWith(true);
+    const createOicrSetArg = (mockCreateResultManagement.createOicrBody as any).set.mock.calls[0][0];
+    expect(createOicrSetArg.step_three.comment_geo_scope).toBe('');
+    expect(mockAllModals.openModal).toHaveBeenCalledWith('createResult');
+    expect((mockCreateResultManagement.resultPageStep as any).set).toHaveBeenCalledWith(2);
+    expect((mockCreateResultManagement.modalTitle as any).set).toHaveBeenCalledWith('Outcome Impact Case Report (OICR)');
+    expect((mockCreateResultManagement.contractId as any).set).toHaveBeenCalledWith('C-1');
+    expect((mockCreateResultManagement.resultTitle as any).set).toHaveBeenCalledWith('TITLE-1');
+    expect((mockCache.currentResultId as any).set).toHaveBeenCalledWith(456);
+  });
+
+  it('openEditRequestdOicrsModal should preserve existing comment_geo_scope', async () => {
+    const responseData = {
+      step_three: { comment_geo_scope: 'existing' },
+      base_information: { contract_id: 'C-2', title: 'TITLE-2' }
+    };
+    (mockApi.GET_OICRModal as jest.Mock).mockResolvedValueOnce({ data: responseData });
+
+    const ok = await service.openEditRequestdOicrsModal(5, 1, 789);
+
+    expect(ok).toBe(true);
+    const setArg = (mockCreateResultManagement.createOicrBody as any).set.mock.calls[0][0];
+    expect(setArg.step_three.comment_geo_scope).toBe('existing');
+  });
+});
+
+import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 import { CurrentResultService } from './current-result.service';

--- a/research-indicators/src/app/shared/services/cache/roles.service.spec.ts
+++ b/research-indicators/src/app/shared/services/cache/roles.service.spec.ts
@@ -1,16 +1,72 @@
 import { TestBed } from '@angular/core/testing';
-
 import { RolesService } from './roles.service';
+import { CacheService } from './cache.service';
+import { CreateResultManagementService } from '../../components/all-modals/modals-content/create-result-modal/services/create-result-management.service';
 
 describe('RolesService', () => {
   let service: RolesService;
 
+  let userRoles: Array<{ role_id: number }>;
+  let editingOicr: boolean;
+
+  const mockCacheService: Partial<CacheService> = {
+    dataCache: jest.fn((): any => ({
+      user: { user_role_list: userRoles }
+    })) as unknown as CacheService['dataCache']
+  };
+
+  const mockCreateResultManagementService: Partial<CreateResultManagementService> = {
+    editingOicr: jest.fn(() => editingOicr) as unknown as CreateResultManagementService['editingOicr']
+  };
+
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    userRoles = [];
+    editingOicr = false;
+
+    TestBed.configureTestingModule({
+      providers: [
+        RolesService,
+        { provide: CacheService, useValue: mockCacheService },
+        { provide: CreateResultManagementService, useValue: mockCreateResultManagementService }
+      ]
+    });
+
     service = TestBed.inject(RolesService);
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('isAdmin should be true when role_id 9 is present', () => {
+    userRoles = [{ role_id: 2 }, { role_id: 9 }];
+    expect(service.isAdmin()).toBe(true);
+  });
+
+  it('isAdmin should be false when role_id 9 is absent', () => {
+    userRoles = [{ role_id: 2 }, { role_id: 3 }];
+    expect(service.isAdmin()).toBe(false);
+  });
+
+  it('canEditOicr should be true when not editing (regardless of admin)', () => {
+    // Not editing → always true
+    editingOicr = false;
+    userRoles = [{ role_id: 3 }];
+    expect(service.canEditOicr()).toBe(true);
+
+    userRoles = [{ role_id: 9 }];
+    expect(service.canEditOicr()).toBe(true);
+  });
+
+  it('canEditOicr should be true when editing and user is admin', () => {
+    editingOicr = true;
+    userRoles = [{ role_id: 9 }];
+    expect(service.canEditOicr()).toBe(true);
+  });
+
+  it('canEditOicr should be false when editing and user is not admin', () => {
+    editingOicr = true;
+    userRoles = [{ role_id: 2 }];
+    expect(service.canEditOicr()).toBe(false);
   });
 });

--- a/research-indicators/src/app/shared/services/get-metadata.service.spec.ts
+++ b/research-indicators/src/app/shared/services/get-metadata.service.spec.ts
@@ -1,37 +1,35 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { Router } from '@angular/router';
-
 import { GetMetadataService } from './get-metadata.service';
 import { ApiService } from './api.service';
 import { CacheService } from './cache/cache.service';
+import { Router } from '@angular/router';
 
 describe('GetMetadataService', () => {
   let service: GetMetadataService;
-  let apiMock: any;
-  let cacheMock: any;
-  let routerMock: any;
+
+  const mockApi: Partial<ApiService> = {
+    GET_Metadata: jest.fn()
+  };
+
+  const mockCache: Partial<CacheService> = {
+    currentMetadata: { set: jest.fn() } as any,
+    currentResultId: { set: jest.fn() } as any
+  };
+
+  const mockRouter: Partial<Router> = {
+    navigate: jest.fn()
+  } as any;
 
   beforeEach(() => {
-    apiMock = {
-      GET_Metadata: jest.fn()
-    };
-    cacheMock = {
-      currentMetadata: { set: jest.fn() },
-      currentResultId: { set: jest.fn() }
-    };
-    routerMock = { navigate: jest.fn() };
-
+    jest.clearAllMocks();
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
       providers: [
         GetMetadataService,
-        { provide: ApiService, useValue: apiMock },
-        { provide: CacheService, useValue: cacheMock },
-        { provide: Router, useValue: routerMock }
+        { provide: ApiService, useValue: mockApi },
+        { provide: CacheService, useValue: mockCache },
+        { provide: Router, useValue: mockRouter }
       ]
     });
-
     service = TestBed.inject(GetMetadataService);
   });
 
@@ -39,47 +37,86 @@ describe('GetMetadataService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('update returns canOpen true and sets metadata if status is 200', async () => {
-    apiMock.GET_Metadata.mockResolvedValue({ status: 200, data: { foo: 'bar' } });
-    const result = await service.update(1);
-    expect(apiMock.GET_Metadata).toHaveBeenCalledWith(1, undefined);
-    expect(cacheMock.currentMetadata.set).toHaveBeenCalledWith({ foo: 'bar' });
-    expect(result.canOpen).toBe(true);
+  describe('update', () => {
+    it('should navigate and return canOpen false when status is not 200', async () => {
+      (mockApi.GET_Metadata as jest.Mock).mockResolvedValueOnce({ status: 404 });
+
+      const res = await service.update(123, null);
+
+      expect(mockApi.GET_Metadata).toHaveBeenCalledWith(123, undefined);
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['/results-center']);
+      expect(res).toEqual({ canOpen: false });
+    });
+
+    it('should set cache and return fields when status is 200', async () => {
+      const data = {
+        result_official_code: 111,
+        indicator_id: 5,
+        status_id: 9,
+        result_title: 'Some Title',
+        result_contract_id: 'C-1'
+      };
+      (mockApi.GET_Metadata as jest.Mock).mockResolvedValueOnce({ status: 200, data });
+
+      const res = await service.update(456, 'STAR');
+
+      expect(mockApi.GET_Metadata).toHaveBeenCalledWith(456, 'STAR');
+      expect((mockCache.currentMetadata as any).set).toHaveBeenCalledWith(data);
+      expect(res).toEqual({
+        canOpen: true,
+        result_official_code: 111,
+        indicator_id: 5,
+        status_id: 9,
+        result_contract_id: 'C-1',
+        result_title: 'Some Title'
+      });
+    });
+
+    it('should navigate and return canOpen false when response is undefined', async () => {
+      (mockApi.GET_Metadata as jest.Mock).mockResolvedValueOnce(undefined);
+
+      const res = await service.update(789);
+
+      expect(mockApi.GET_Metadata).toHaveBeenCalledWith(789, undefined);
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['/results-center']);
+      expect(res).toEqual({ canOpen: false });
+    });
+
+    it('should handle 200 status with undefined data', async () => {
+      (mockApi.GET_Metadata as jest.Mock).mockResolvedValueOnce({ status: 200, data: undefined });
+
+      const res = await service.update(999);
+
+      expect(mockApi.GET_Metadata).toHaveBeenCalledWith(999, undefined);
+      expect((mockCache.currentMetadata as any).set).toHaveBeenCalledWith(undefined);
+      expect(res).toEqual({
+        canOpen: true,
+        result_official_code: undefined,
+        indicator_id: undefined,
+        status_id: undefined,
+        result_contract_id: undefined,
+        result_title: undefined
+      });
+    });
   });
 
-  it('update returns canOpen false and navigates if status is not 200', async () => {
-    apiMock.GET_Metadata.mockResolvedValue({ status: 404 });
-    const result = await service.update(2);
-    expect(apiMock.GET_Metadata).toHaveBeenCalledWith(2, undefined);
-    expect(routerMock.navigate).toHaveBeenCalledWith(['/results-center']);
-    expect(result.canOpen).toBe(false);
+  describe('formatText', () => {
+    it('should return empty string when less than two words', () => {
+      expect(service.formatText('Single')).toBe('');
+      expect(service.formatText('')).toBe('');
+    });
+
+    it('should return concatenated formatted parts', () => {
+      const out = service.formatText('hello world');
+      expect(out).toBe('HelWor');
+    });
   });
 
-  it('update returns canOpen false and navigates if response is undefined', async () => {
-    apiMock.GET_Metadata.mockResolvedValue(undefined);
-    const result = await service.update(3);
-    expect(routerMock.navigate).toHaveBeenCalledWith(['/results-center']);
-    expect(result.canOpen).toBe(false);
-  });
-
-  it('formatText returns formatted string correctly', () => {
-    expect(service.formatText('Hello World')).toBe('HelWor');
-    expect(service.formatText('Angular Test')).toBe('AngTes');
-    expect(service.formatText('A B')).toBe('AB');
-    expect(service.formatText('OneWord')).toBe('');
-    expect(service.formatText('  ')).toBe('');
-    expect(service.formatText('foo bar baz')).toBe('FooBaz');
-  });
-
-  it('clearMetadata should reset metadata and resultId', () => {
-    service.clearMetadata();
-    expect(cacheMock.currentMetadata.set).toHaveBeenCalledWith({});
-    expect(cacheMock.currentResultId.set).toHaveBeenCalledWith(0);
-  });
-
-  it('clearMetadata should not throw if signals are undefined', () => {
-    service.cache.currentMetadata = undefined as any;
-    service.cache.currentResultId = undefined as any;
-    expect(() => service.clearMetadata()).not.toThrow();
+  describe('clearMetadata', () => {
+    it('should reset metadata and result id', () => {
+      service.clearMetadata();
+      expect((mockCache.currentMetadata as any).set).toHaveBeenCalledWith({});
+      expect((mockCache.currentResultId as any).set).toHaveBeenCalledWith(0);
+    });
   });
 });

--- a/research-indicators/src/app/shared/services/my-projects.service.spec.ts
+++ b/research-indicators/src/app/shared/services/my-projects.service.spec.ts
@@ -2,7 +2,6 @@ import { TestBed } from '@angular/core/testing';
 import { MyProjectsService, MyProjectsFilters } from './my-projects.service';
 import { ApiService } from './api.service';
 import { CacheService } from './cache/cache.service';
-import { MultiselectComponent } from '../components/custom-fields/multiselect/multiselect.component';
 import { MenuItem } from 'primeng/api';
 
 describe('MyProjectsService', () => {
@@ -10,58 +9,41 @@ describe('MyProjectsService', () => {
   let mockApiService: any;
   let mockCacheService: any;
 
-  const mockFindContractsResponse = {
-    data: [
-      {
-        agreement_id: 'A001',
-        projectDescription: 'Test Project',
-        description: 'Test Description',
-        project_lead_description: 'Test Lead',
-        principal_investigator: 'Test PI',
-        lever_name: 'Test Lever',
-        lever: {
-          short_name: 'TL',
-          name: 'Test Lever'
-        }
-      },
-      {
-        agreement_id: 'A002',
-        projectDescription: 'Test Project 2',
-        description: 'Test Description 2',
-        project_lead_description: 'Test Lead 2',
-        principal_investigator: null,
-        lever_name: null,
-        lever: 'Test Lever String'
+  const mockFindContractsResponseData = [
+    {
+      agreement_id: 'A001',
+      projectDescription: 'Test Project',
+      description: 'Test Description',
+      project_lead_description: 'Test Lead',
+      principal_investigator: 'Test PI',
+      lever_name: 'Test Lever',
+      lever: {
+        short_name: 'TL',
+        name: 'Test Lever'
       }
-    ]
-  };
-
-  function buildResponse(dataValue: any, meta?: Partial<{ total: number; page: number; limit: number; totalPages: number; hasNextPage: boolean; hasPreviousPage: boolean }>) {
-    return {
-      data: {
-        data: dataValue,
-        metadata: {
-          total: Array.isArray(dataValue) ? dataValue.length : 0,
-          page: 1,
-          limit: 10,
-          totalPages: 1,
-          hasNextPage: false,
-          hasPreviousPage: false,
-          ...(meta || {})
-        }
-      },
-      status: 200,
-      description: 'ok',
-      timestamp: new Date().toISOString(),
-      path: '/find-contracts',
-      successfulRequest: true,
-      errorDetail: { errors: '', detail: '', description: '' }
-    } as const;
-  }
+    },
+    {
+      agreement_id: 'A002',
+      projectDescription: 'Test Project 2',
+      description: 'Test Description 2',
+      project_lead_description: 'Test Lead 2',
+      principal_investigator: null,
+      lever_name: null,
+      lever: 'Test Lever String'
+    }
+  ];
 
   beforeEach(() => {
     mockApiService = {
-      GET_FindContracts: jest.fn().mockResolvedValue(buildResponse(mockFindContractsResponse.data))
+      GET_FindContracts: jest.fn().mockResolvedValue({
+        data: { data: mockFindContractsResponseData },
+        status: 200,
+        description: 'ok',
+        timestamp: new Date().toISOString(),
+        path: '/find-contracts',
+        successfulRequest: true,
+        errorDetail: { errors: '', detail: '', description: '' }
+      })
     };
 
     mockCacheService = {
@@ -230,7 +212,7 @@ describe('MyProjectsService', () => {
     it('should fetch and process data successfully', async () => {
       await service.main();
 
-      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(expect.objectContaining({ page: '1', limit: '10' }));
+      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(undefined);
       expect(service.loading()).toBe(false);
       expect(service.list()).toHaveLength(2);
 
@@ -246,7 +228,15 @@ describe('MyProjectsService', () => {
     });
 
     it('should handle API response without data', async () => {
-      mockApiService.GET_FindContracts.mockResolvedValueOnce(buildResponse(undefined));
+      mockApiService.GET_FindContracts.mockResolvedValueOnce({
+        data: undefined,
+        status: 200,
+        description: 'ok',
+        timestamp: '',
+        path: '',
+        successfulRequest: true,
+        errorDetail: { errors: '', detail: '', description: '' }
+      });
 
       await service.main();
 
@@ -255,7 +245,15 @@ describe('MyProjectsService', () => {
     });
 
     it('should handle API response with null data', async () => {
-      mockApiService.GET_FindContracts.mockResolvedValueOnce(buildResponse(null));
+      mockApiService.GET_FindContracts.mockResolvedValueOnce({
+        data: null,
+        status: 200,
+        description: 'ok',
+        timestamp: '',
+        path: '',
+        successfulRequest: true,
+        errorDetail: { errors: '', detail: '', description: '' }
+      });
 
       await service.main();
 
@@ -264,7 +262,15 @@ describe('MyProjectsService', () => {
     });
 
     it('should handle API response with undefined data', async () => {
-      mockApiService.GET_FindContracts.mockResolvedValueOnce(buildResponse(undefined));
+      mockApiService.GET_FindContracts.mockResolvedValueOnce({
+        data: undefined,
+        status: 200,
+        description: 'ok',
+        timestamp: '',
+        path: '',
+        successfulRequest: true,
+        errorDetail: { errors: '', detail: '', description: '' }
+      });
 
       await service.main();
 
@@ -273,7 +279,15 @@ describe('MyProjectsService', () => {
     });
 
     it('should handle API response with false data', async () => {
-      mockApiService.GET_FindContracts.mockResolvedValueOnce(buildResponse(false as unknown as any[]));
+      mockApiService.GET_FindContracts.mockResolvedValueOnce({
+        data: false as unknown as any[],
+        status: 200,
+        description: 'ok',
+        timestamp: '',
+        path: '',
+        successfulRequest: true,
+        errorDetail: { errors: '', detail: '', description: '' }
+      });
 
       await service.main();
 
@@ -282,7 +296,15 @@ describe('MyProjectsService', () => {
     });
 
     it('should handle API response with empty string data', async () => {
-      mockApiService.GET_FindContracts.mockResolvedValueOnce(buildResponse('' as unknown as any[]));
+      mockApiService.GET_FindContracts.mockResolvedValueOnce({
+        data: '' as unknown as any[],
+        status: 200,
+        description: 'ok',
+        timestamp: '',
+        path: '',
+        successfulRequest: true,
+        errorDetail: { errors: '', detail: '', description: '' }
+      });
 
       await service.main();
 
@@ -291,7 +313,15 @@ describe('MyProjectsService', () => {
     });
 
     it('should handle API response with empty array data', async () => {
-      mockApiService.GET_FindContracts.mockResolvedValueOnce(buildResponse([]));
+      mockApiService.GET_FindContracts.mockResolvedValueOnce({
+        data: [],
+        status: 200,
+        description: 'ok',
+        timestamp: '',
+        path: '',
+        successfulRequest: true,
+        errorDetail: { errors: '', detail: '', description: '' }
+      });
 
       await service.main();
 
@@ -309,7 +339,15 @@ describe('MyProjectsService', () => {
     });
 
     it('should handle API response with non-array data', async () => {
-      mockApiService.GET_FindContracts.mockResolvedValueOnce(buildResponse('not-an-array' as unknown as any[]));
+      mockApiService.GET_FindContracts.mockResolvedValueOnce({
+        data: 'not-an-array' as unknown as any[],
+        status: 200,
+        description: 'ok',
+        timestamp: '',
+        path: '',
+        successfulRequest: true,
+        errorDetail: { errors: '', detail: '', description: '' }
+      });
 
       await service.main();
 
@@ -318,7 +356,15 @@ describe('MyProjectsService', () => {
     });
 
     it('should handle API response with zero data', async () => {
-      mockApiService.GET_FindContracts.mockResolvedValueOnce(buildResponse(0 as unknown as any[]));
+      mockApiService.GET_FindContracts.mockResolvedValueOnce({
+        data: 0 as unknown as any[],
+        status: 200,
+        description: 'ok',
+        timestamp: '',
+        path: '',
+        successfulRequest: true,
+        errorDetail: { errors: '', detail: '', description: '' }
+      });
 
       await service.main();
 
@@ -327,7 +373,15 @@ describe('MyProjectsService', () => {
     });
 
     it('should handle API response with NaN data', async () => {
-      mockApiService.GET_FindContracts.mockResolvedValueOnce(buildResponse(NaN as unknown as any[]));
+      mockApiService.GET_FindContracts.mockResolvedValueOnce({
+        data: NaN as unknown as any[],
+        status: 200,
+        description: 'ok',
+        timestamp: '',
+        path: '',
+        successfulRequest: true,
+        errorDetail: { errors: '', detail: '', description: '' }
+      });
 
       await service.main();
 
@@ -455,11 +509,12 @@ describe('MyProjectsService', () => {
       const customParams = { 'test-param': 'test-value' };
       await service.main(customParams);
 
-      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(expect.objectContaining({ 'test-param': 'test-value', page: '1', limit: '10' }));
+      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(customParams);
     });
 
     it('should handle item with no principal_investigator and no project_lead_description', async () => {
-      const mockResponse = buildResponse([
+    const mockResponse = {
+      data: { data: [
           {
             agreement_id: 'A003',
             projectDescription: 'Test Project 3',
@@ -467,8 +522,15 @@ describe('MyProjectsService', () => {
             project_lead_description: null,
             principal_investigator: null,
             lever_name: 'Test Lever 3'
-          }
-        ]);
+        }
+      ] },
+        status: 200,
+        description: 'ok',
+        timestamp: '',
+        path: '',
+        successfulRequest: true,
+        errorDetail: { errors: '', detail: '', description: '' }
+      };
       mockApiService.GET_FindContracts.mockResolvedValueOnce(mockResponse);
 
       await service.main();
@@ -479,7 +541,8 @@ describe('MyProjectsService', () => {
     });
 
     it('should handle item with empty principal_investigator but valid project_lead_description', async () => {
-      const mockResponse = buildResponse([
+    const mockResponse = {
+      data: { data: [
           {
             agreement_id: 'A004',
             projectDescription: 'Test Project 4',
@@ -487,8 +550,15 @@ describe('MyProjectsService', () => {
             project_lead_description: 'Valid Lead Description',
             principal_investigator: '',
             lever_name: 'Test Lever 4'
-          }
-        ]);
+        }
+      ] },
+        status: 200,
+        description: 'ok',
+        timestamp: '',
+        path: '',
+        successfulRequest: true,
+        errorDetail: { errors: '', detail: '', description: '' }
+      };
       mockApiService.GET_FindContracts.mockResolvedValueOnce(mockResponse);
 
       await service.main();
@@ -499,7 +569,8 @@ describe('MyProjectsService', () => {
     });
 
     it('should handle item with undefined principal_investigator but valid project_lead_description', async () => {
-      const mockResponse = buildResponse([
+    const mockResponse = {
+      data: { data: [
           {
             agreement_id: 'A005',
             projectDescription: 'Test Project 5',
@@ -507,8 +578,15 @@ describe('MyProjectsService', () => {
             project_lead_description: 'Valid Lead Description',
             principal_investigator: undefined,
             lever_name: 'Test Lever 5'
-          }
-        ]);
+        }
+      ] },
+        status: 200,
+        description: 'ok',
+        timestamp: '',
+        path: '',
+        successfulRequest: true,
+        errorDetail: { errors: '', detail: '', description: '' }
+      };
       mockApiService.GET_FindContracts.mockResolvedValueOnce(mockResponse);
 
       await service.main();
@@ -519,7 +597,8 @@ describe('MyProjectsService', () => {
     });
 
     it('should handle item with valid principal_investigator', async () => {
-      const mockResponse = buildResponse([
+    const mockResponse = {
+      data: { data: [
           {
             agreement_id: 'A006',
             projectDescription: 'Test Project 6',
@@ -527,8 +606,15 @@ describe('MyProjectsService', () => {
             project_lead_description: 'Lead Description',
             principal_investigator: 'Valid Principal Investigator',
             lever_name: 'Test Lever 6'
-          }
-        ]);
+        }
+      ] },
+        status: 200,
+        description: 'ok',
+        timestamp: '',
+        path: '',
+        successfulRequest: true,
+        errorDetail: { errors: '', detail: '', description: '' }
+      };
       mockApiService.GET_FindContracts.mockResolvedValueOnce(mockResponse);
 
       await service.main();
@@ -539,7 +625,8 @@ describe('MyProjectsService', () => {
     });
 
     it('should handle item with empty principal_investigator and empty project_lead_description', async () => {
-      const mockResponse = buildResponse([
+    const mockResponse = {
+      data: { data: [
           {
             agreement_id: 'A007',
             projectDescription: 'Test Project 7',
@@ -547,8 +634,15 @@ describe('MyProjectsService', () => {
             project_lead_description: '',
             principal_investigator: '',
             lever_name: 'Test Lever 7'
-          }
-        ]);
+        }
+      ] },
+        status: 200,
+        description: 'ok',
+        timestamp: '',
+        path: '',
+        successfulRequest: true,
+        errorDetail: { errors: '', detail: '', description: '' }
+      };
       mockApiService.GET_FindContracts.mockResolvedValueOnce(mockResponse);
 
       await service.main();
@@ -559,7 +653,8 @@ describe('MyProjectsService', () => {
     });
 
     it('should handle item with false principal_investigator but valid project_lead_description', async () => {
-      const mockResponse = buildResponse([
+    const mockResponse = {
+      data: { data: [
           {
             agreement_id: 'A008',
             projectDescription: 'Test Project 8',
@@ -567,8 +662,15 @@ describe('MyProjectsService', () => {
             project_lead_description: 'Valid Lead Description',
             principal_investigator: false,
             lever_name: 'Test Lever 8'
-          }
-        ]);
+        }
+      ] },
+        status: 200,
+        description: 'ok',
+        timestamp: '',
+        path: '',
+        successfulRequest: true,
+        errorDetail: { errors: '', detail: '', description: '' }
+      };
       mockApiService.GET_FindContracts.mockResolvedValueOnce(mockResponse);
 
       await service.main();
@@ -579,7 +681,8 @@ describe('MyProjectsService', () => {
     });
 
     it('should handle item with 0 principal_investigator but valid project_lead_description', async () => {
-      const mockResponse = buildResponse([
+    const mockResponse = {
+      data: { data: [
           {
             agreement_id: 'A009',
             projectDescription: 'Test Project 9',
@@ -587,8 +690,15 @@ describe('MyProjectsService', () => {
             project_lead_description: 'Valid Lead Description',
             principal_investigator: 0,
             lever_name: 'Test Lever 9'
-          }
-        ]);
+        }
+      ] },
+        status: 200,
+        description: 'ok',
+        timestamp: '',
+        path: '',
+        successfulRequest: true,
+        errorDetail: { errors: '', detail: '', description: '' }
+      };
       mockApiService.GET_FindContracts.mockResolvedValueOnce(mockResponse);
 
       await service.main();
@@ -596,93 +706,6 @@ describe('MyProjectsService', () => {
       expect(service.list()).toHaveLength(1);
       const item = service.list()[0] as any;
       expect(item.display_principal_investigator).toBe('Valid Lead Description');
-    });
-
-    it('should use metadata values for pagination and set page/limits', async () => {
-      const data = mockFindContractsResponse.data;
-      mockApiService.GET_FindContracts.mockResolvedValueOnce(buildResponse(data, {
-        total: 3129,
-        page: 2,
-        limit: 25,
-        totalPages: 126,
-        hasNextPage: true,
-        hasPreviousPage: true
-      }));
-
-      await service.main();
-
-      expect(service.total()).toBe(3129);
-      expect(service.limit()).toBe(25);
-      expect(service.page()).toBe(2);
-      expect(service.totalPages()).toBe(126);
-      expect(service.hasNextPage()).toBe(true);
-      expect(service.hasPreviousPage()).toBe(true);
-    });
-
-    it('should fallback when meta.limit is invalid and compute totalPages', async () => {
-      // current default limit is 10; set to 15 first to ensure fallback respects current limit
-      service.setLimit(15);
-      const data = new Array(30).fill(0).map((_, i) => ({
-        agreement_id: `B${i}`,
-        projectDescription: 'P',
-        description: 'D',
-        project_lead_description: 'L'
-      }));
-      mockApiService.GET_FindContracts.mockResolvedValueOnce(buildResponse(data, {
-        total: NaN as unknown as number,
-        page: 1,
-        limit: 0, // invalid, should fallback to current limit (15)
-        // omit totalPages so it is computed as ceil(total/limit)
-      }));
-
-      await service.main();
-
-      // total falls back to payload.data.length (30)
-      expect(service.total()).toBe(30);
-      // limit falls back to current limit (15)
-      expect(service.limit()).toBe(15);
-      // In this environment, totalPages falls back to at least 1 when computed
-      expect(service.totalPages()).toBe(1);
-      // hasNextPage/hasPreviousPage come from fallback expressions
-      expect(service.hasNextPage()).toBe(false);
-      expect(service.hasPreviousPage()).toBe(false);
-    });
-
-    it('should respect meta.totalPages and explicit hasNext/hasPrevious flags', async () => {
-      const data = mockFindContractsResponse.data;
-      mockApiService.GET_FindContracts.mockResolvedValueOnce(buildResponse(data, {
-        total: 999,
-        page: 3,
-        limit: 10,
-        totalPages: 5,
-        hasNextPage: false,
-        hasPreviousPage: true
-      }));
-
-      await service.main();
-
-      expect(service.total()).toBe(999);
-      expect(service.page()).toBe(3);
-      expect(service.limit()).toBe(10);
-      expect(service.totalPages()).toBe(5);
-      expect(service.hasNextPage()).toBe(false);
-      expect(service.hasPreviousPage()).toBe(true);
-    });
-
-    it('should ignore invalid meta.page (<=0) and keep current page', async () => {
-      service.setPage(4);
-      const data = mockFindContractsResponse.data;
-      mockApiService.GET_FindContracts.mockResolvedValueOnce(buildResponse(data, {
-        total: 100,
-        page: 0,
-        limit: 10,
-        totalPages: 10
-      }));
-
-      await service.main();
-
-      expect(service.page()).toBe(4);
-      expect(service.totalPages()).toBe(10);
     });
   });
 
@@ -699,10 +722,10 @@ describe('MyProjectsService', () => {
 
       service.applyFilters();
 
-      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(expect.objectContaining({
+      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith({
         'current-user': false,
         'contract-code': 'A001'
-      }));
+      });
       expect(service.appliedFilters().contractCode).toBe('A001');
     });
 
@@ -714,10 +737,10 @@ describe('MyProjectsService', () => {
 
       service.applyFilters();
 
-      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(expect.objectContaining({
+      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith({
         'current-user': false,
         'project-name': 'Test Project'
-      }));
+      });
       expect(service.appliedFilters().projectName).toBe('Test Project');
     });
 
@@ -729,10 +752,10 @@ describe('MyProjectsService', () => {
 
       service.applyFilters();
 
-      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(expect.objectContaining({
+      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith({
         'current-user': false,
         'principal-investigator': 'Test PI'
-      }));
+      });
       expect(service.appliedFilters().principalInvestigator).toBe('Test PI');
     });
 
@@ -747,10 +770,10 @@ describe('MyProjectsService', () => {
 
       service.applyFilters();
 
-      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(expect.objectContaining({
+      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith({
         'current-user': false,
         lever: '1,2'
-      }));
+      });
       expect(service.appliedFilters().levers).toHaveLength(2);
     });
 
@@ -765,10 +788,10 @@ describe('MyProjectsService', () => {
 
       service.applyFilters();
 
-      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(expect.objectContaining({
+      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith({
         'current-user': false,
         status: 'active,inactive'
-      }));
+      });
       expect(service.appliedFilters().statusCodes).toHaveLength(2);
     });
 
@@ -780,10 +803,10 @@ describe('MyProjectsService', () => {
 
       service.applyFilters();
 
-      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(expect.objectContaining({
+      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith({
         'current-user': false,
         'start-date': '2024-01-01T00:00:00.000'
-      }));
+      });
       expect(service.appliedFilters().startDate).toBe('2024-01-01');
     });
 
@@ -795,10 +818,10 @@ describe('MyProjectsService', () => {
 
       service.applyFilters();
 
-      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(expect.objectContaining({
+      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith({
         'current-user': false,
         'end-date': '2024-12-31T00:00:00.000'
-      }));
+      });
       expect(service.appliedFilters().endDate).toBe('2024-12-31');
     });
 
@@ -812,12 +835,12 @@ describe('MyProjectsService', () => {
 
       service.applyFilters();
 
-      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(expect.objectContaining({
+      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith({
         'current-user': false,
         'contract-code': 'A001',
         'project-name': 'Test Project',
         lever: '1'
-      }));
+      });
     });
 
     it('should apply filters for my projects', () => {
@@ -829,10 +852,10 @@ describe('MyProjectsService', () => {
 
       service.applyFilters();
 
-      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(expect.objectContaining({
+      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith({
         'current-user': true,
         'contract-code': 'A001'
-      }));
+      });
     });
   });
 
@@ -855,15 +878,6 @@ describe('MyProjectsService', () => {
 
       // contractCode (1) + projectName (1) + levers (2) + status (1) = 5
       expect(service.countFiltersSelected()).toBe('5');
-    });
-
-    it('should handle undefined arrays using nullish coalescing', () => {
-      service.tableFilters.set({
-        ...(new MyProjectsFilters() as any),
-        levers: undefined,
-        statusCodes: undefined
-      } as any);
-      expect(service.countFiltersSelected()).toBeUndefined();
     });
   });
 
@@ -889,160 +903,6 @@ describe('MyProjectsService', () => {
         ])
       );
     });
-
-    it('should use lever id when short_name is empty', () => {
-      service.appliedFilters.set({
-        ...new MyProjectsFilters(),
-        levers: [{ id: 7, short_name: '' }]
-      });
-
-      const activeFilters = service.getActiveFilters();
-      const lever = activeFilters.find(i => i.label === 'LEVER');
-      expect(lever?.value).toBe('7');
-    });
-  });
-
-  describe('getActiveFilters formatDate coverage', () => {
-    it('should format valid dates and passthrough invalid dates', () => {
-      service.appliedFilters.set({
-        ...new MyProjectsFilters(),
-        startDate: 'invalid-date',
-        endDate: '2024-01-02T12:00:00.000Z'
-      });
-
-      const items = service.getActiveFilters();
-      const start = items.find(i => i.label === 'START DATE');
-      const end = items.find(i => i.label === 'END DATE');
-      expect(start?.value).toBe('invalid-date');
-      expect(end?.value).toBe('Jan, 02 /2024');
-    });
-  });
-
-  describe('removeFilter', () => {
-    it('should no-op for unknown label and not call applyFilters', () => {
-      const prev = service.tableFilters();
-      const spy = jest.spyOn(service, 'applyFilters');
-      (service as any).removeFilter('UNKNOWN', 1);
-      expect(service.tableFilters()).toEqual(prev);
-      expect(spy).not.toHaveBeenCalled();
-      spy.mockRestore();
-    });
-
-    it('should remove by id for STATUS and handle removeById error', () => {
-      const removeMock = jest.fn().mockImplementation(() => {
-        throw new Error('remove error');
-      });
-      const mockMultiselect = { removeById: removeMock } as unknown as MultiselectComponent;
-      service.multiselectRefs.set({ status: mockMultiselect } as any);
-      service.tableFilters.set({
-        ...new MyProjectsFilters(),
-        statusCodes: [{ name: 'Active', value: 'active' }]
-      });
-      const spy = jest.spyOn(service, 'applyFilters').mockImplementation(() => undefined);
-
-      (service as any).removeFilter('STATUS', 'active');
-
-      expect(removeMock).toHaveBeenCalledWith('active');
-      expect(service.tableFilters().statusCodes.length).toBe(0);
-      expect(spy).toHaveBeenCalled();
-      spy.mockRestore();
-    });
-
-    it('should clear control when id is null and handle clear error', () => {
-      const clearMock = jest.fn().mockImplementation(() => {
-        throw new Error('clear error');
-      });
-      const mockMultiselect = { clear: clearMock } as unknown as MultiselectComponent;
-      service.multiselectRefs.set({ lever: mockMultiselect } as any);
-      service.tableFilters.set({
-        ...new MyProjectsFilters(),
-        levers: [{ id: 1, short_name: 'L1' }]
-      });
-      const spy = jest.spyOn(service, 'applyFilters').mockImplementation(() => undefined);
-
-      (service as any).removeFilter('LEVER');
-
-      expect(clearMock).toHaveBeenCalled();
-      expect(service.tableFilters().levers.length).toBe(0);
-      expect(spy).toHaveBeenCalled();
-      spy.mockRestore();
-    });
-
-    it('should clear contractCode filter', () => {
-      const spy = jest.spyOn(service, 'applyFilters').mockImplementation(() => undefined);
-      service.tableFilters.set({ ...new MyProjectsFilters(), contractCode: 'X123' });
-      (service as any).removeFilter('CONTRACT CODE');
-      expect(service.tableFilters().contractCode).toBe('');
-      expect(spy).toHaveBeenCalled();
-      spy.mockRestore();
-    });
-
-    it('should clear projectName filter', () => {
-      const spy = jest.spyOn(service, 'applyFilters').mockImplementation(() => undefined);
-      service.tableFilters.set({ ...new MyProjectsFilters(), projectName: 'ABC' });
-      (service as any).removeFilter('PROJECT NAME');
-      expect(service.tableFilters().projectName).toBe('');
-      expect(spy).toHaveBeenCalled();
-      spy.mockRestore();
-    });
-
-    it('should clear principalInvestigator filter', () => {
-      const spy = jest.spyOn(service, 'applyFilters').mockImplementation(() => undefined);
-      service.tableFilters.set({ ...new MyProjectsFilters(), principalInvestigator: 'PI' });
-      (service as any).removeFilter('PRINCIPAL INVESTIGATOR');
-      expect(service.tableFilters().principalInvestigator).toBe('');
-      expect(spy).toHaveBeenCalled();
-      spy.mockRestore();
-    });
-
-    it('should clear startDate filter', () => {
-      const spy = jest.spyOn(service, 'applyFilters').mockImplementation(() => undefined);
-      service.tableFilters.set({ ...new MyProjectsFilters(), startDate: '2024-01-01' });
-      (service as any).removeFilter('START DATE');
-      expect(service.tableFilters().startDate).toBe('');
-      expect(spy).toHaveBeenCalled();
-      spy.mockRestore();
-    });
-
-    it('should clear endDate filter', () => {
-      const spy = jest.spyOn(service, 'applyFilters').mockImplementation(() => undefined);
-      service.tableFilters.set({ ...new MyProjectsFilters(), endDate: '2024-12-31' });
-      (service as any).removeFilter('END DATE');
-      expect(service.tableFilters().endDate).toBe('');
-      expect(spy).toHaveBeenCalled();
-      spy.mockRestore();
-    });
-
-    it('should remove lever by id and keep others', () => {
-      const spy = jest.spyOn(service, 'applyFilters').mockImplementation(() => undefined);
-      service.tableFilters.set({
-        ...new MyProjectsFilters(),
-        levers: [
-          { id: 1, short_name: 'L1' },
-          { id: 2, short_name: 'L2' }
-        ]
-      });
-
-      (service as any).removeFilter('LEVER', 2);
-
-      expect(service.tableFilters().levers).toEqual([{ id: 1, short_name: 'L1' }]);
-      expect(spy).toHaveBeenCalled();
-      spy.mockRestore();
-    });
-  });
-
-  describe('setPage and setLimit normalization', () => {
-    it('should normalize invalid numbers', () => {
-      service.setPage(-5);
-      expect(service.page()).toBe(1);
-      service.setPage(3.8);
-      expect(service.page()).toBe(3);
-
-      service.setLimit(0);
-      expect(service.limit()).toBe(10);
-      service.setLimit(7.6);
-      expect(service.limit()).toBe(7);
-    });
   });
 
   describe('onActiveItemChange', () => {
@@ -1055,7 +915,7 @@ describe('MyProjectsService', () => {
       expect(service.tableFilters()).toEqual(new MyProjectsFilters());
       expect(service.appliedFilters()).toEqual(new MyProjectsFilters());
       expect(service.searchInput()).toBe('');
-      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(expect.objectContaining({ 'current-user': true }));
+      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith({ 'current-user': true });
     });
   });
 
@@ -1122,7 +982,7 @@ describe('MyProjectsService', () => {
       expect(service.tableFilters()).toEqual(new MyProjectsFilters());
       expect(service.appliedFilters()).toEqual(new MyProjectsFilters());
       expect(service.searchInput()).toBe('');
-      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(expect.objectContaining({ 'current-user': false }));
+      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith({ 'current-user': false });
     });
   });
 
@@ -1133,7 +993,7 @@ describe('MyProjectsService', () => {
       expect(service.tableFilters()).toEqual(new MyProjectsFilters());
       expect(service.appliedFilters()).toEqual(new MyProjectsFilters());
       expect(service.searchInput()).toBe('');
-      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(expect.objectContaining({ 'current-user': false }));
+      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith({ 'current-user': false });
     });
   });
 
@@ -1141,7 +1001,7 @@ describe('MyProjectsService', () => {
     it('should refresh data', () => {
       service.refresh();
 
-      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(expect.objectContaining({ 'current-user': false }));
+      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith({ 'current-user': false });
     });
   });
 

--- a/research-indicators/src/app/shared/services/my-projects.service.spec.ts
+++ b/research-indicators/src/app/shared/services/my-projects.service.spec.ts
@@ -36,17 +36,32 @@ describe('MyProjectsService', () => {
     ]
   };
 
+  function buildResponse(dataValue: any, meta?: Partial<{ total: number; page: number; limit: number; totalPages: number; hasNextPage: boolean; hasPreviousPage: boolean }>) {
+    return {
+      data: {
+        data: dataValue,
+        metadata: {
+          total: Array.isArray(dataValue) ? dataValue.length : 0,
+          page: 1,
+          limit: 10,
+          totalPages: 1,
+          hasNextPage: false,
+          hasPreviousPage: false,
+          ...(meta || {})
+        }
+      },
+      status: 200,
+      description: 'ok',
+      timestamp: new Date().toISOString(),
+      path: '/find-contracts',
+      successfulRequest: true,
+      errorDetail: { errors: '', detail: '', description: '' }
+    } as const;
+  }
+
   beforeEach(() => {
     mockApiService = {
-      GET_FindContracts: jest.fn().mockResolvedValue({
-        data: mockFindContractsResponse.data,
-        status: 200,
-        description: 'ok',
-        timestamp: new Date().toISOString(),
-        path: '/find-contracts',
-        successfulRequest: true,
-        errorDetail: { errors: '', detail: '', description: '' }
-      })
+      GET_FindContracts: jest.fn().mockResolvedValue(buildResponse(mockFindContractsResponse.data))
     };
 
     mockCacheService = {
@@ -215,7 +230,7 @@ describe('MyProjectsService', () => {
     it('should fetch and process data successfully', async () => {
       await service.main();
 
-      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(undefined);
+      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(expect.objectContaining({ page: '1', limit: '10' }));
       expect(service.loading()).toBe(false);
       expect(service.list()).toHaveLength(2);
 
@@ -231,15 +246,7 @@ describe('MyProjectsService', () => {
     });
 
     it('should handle API response without data', async () => {
-      mockApiService.GET_FindContracts.mockResolvedValueOnce({
-        data: undefined,
-        status: 200,
-        description: 'ok',
-        timestamp: '',
-        path: '',
-        successfulRequest: true,
-        errorDetail: { errors: '', detail: '', description: '' }
-      });
+      mockApiService.GET_FindContracts.mockResolvedValueOnce(buildResponse(undefined));
 
       await service.main();
 
@@ -248,15 +255,7 @@ describe('MyProjectsService', () => {
     });
 
     it('should handle API response with null data', async () => {
-      mockApiService.GET_FindContracts.mockResolvedValueOnce({
-        data: null,
-        status: 200,
-        description: 'ok',
-        timestamp: '',
-        path: '',
-        successfulRequest: true,
-        errorDetail: { errors: '', detail: '', description: '' }
-      });
+      mockApiService.GET_FindContracts.mockResolvedValueOnce(buildResponse(null));
 
       await service.main();
 
@@ -265,15 +264,7 @@ describe('MyProjectsService', () => {
     });
 
     it('should handle API response with undefined data', async () => {
-      mockApiService.GET_FindContracts.mockResolvedValueOnce({
-        data: undefined,
-        status: 200,
-        description: 'ok',
-        timestamp: '',
-        path: '',
-        successfulRequest: true,
-        errorDetail: { errors: '', detail: '', description: '' }
-      });
+      mockApiService.GET_FindContracts.mockResolvedValueOnce(buildResponse(undefined));
 
       await service.main();
 
@@ -282,15 +273,7 @@ describe('MyProjectsService', () => {
     });
 
     it('should handle API response with false data', async () => {
-      mockApiService.GET_FindContracts.mockResolvedValueOnce({
-        data: false as unknown as any[],
-        status: 200,
-        description: 'ok',
-        timestamp: '',
-        path: '',
-        successfulRequest: true,
-        errorDetail: { errors: '', detail: '', description: '' }
-      });
+      mockApiService.GET_FindContracts.mockResolvedValueOnce(buildResponse(false as unknown as any[]));
 
       await service.main();
 
@@ -299,15 +282,7 @@ describe('MyProjectsService', () => {
     });
 
     it('should handle API response with empty string data', async () => {
-      mockApiService.GET_FindContracts.mockResolvedValueOnce({
-        data: '' as unknown as any[],
-        status: 200,
-        description: 'ok',
-        timestamp: '',
-        path: '',
-        successfulRequest: true,
-        errorDetail: { errors: '', detail: '', description: '' }
-      });
+      mockApiService.GET_FindContracts.mockResolvedValueOnce(buildResponse('' as unknown as any[]));
 
       await service.main();
 
@@ -316,15 +291,7 @@ describe('MyProjectsService', () => {
     });
 
     it('should handle API response with empty array data', async () => {
-      mockApiService.GET_FindContracts.mockResolvedValueOnce({
-        data: [],
-        status: 200,
-        description: 'ok',
-        timestamp: '',
-        path: '',
-        successfulRequest: true,
-        errorDetail: { errors: '', detail: '', description: '' }
-      });
+      mockApiService.GET_FindContracts.mockResolvedValueOnce(buildResponse([]));
 
       await service.main();
 
@@ -342,15 +309,7 @@ describe('MyProjectsService', () => {
     });
 
     it('should handle API response with non-array data', async () => {
-      mockApiService.GET_FindContracts.mockResolvedValueOnce({
-        data: 'not-an-array' as unknown as any[],
-        status: 200,
-        description: 'ok',
-        timestamp: '',
-        path: '',
-        successfulRequest: true,
-        errorDetail: { errors: '', detail: '', description: '' }
-      });
+      mockApiService.GET_FindContracts.mockResolvedValueOnce(buildResponse('not-an-array' as unknown as any[]));
 
       await service.main();
 
@@ -359,15 +318,7 @@ describe('MyProjectsService', () => {
     });
 
     it('should handle API response with zero data', async () => {
-      mockApiService.GET_FindContracts.mockResolvedValueOnce({
-        data: 0 as unknown as any[],
-        status: 200,
-        description: 'ok',
-        timestamp: '',
-        path: '',
-        successfulRequest: true,
-        errorDetail: { errors: '', detail: '', description: '' }
-      });
+      mockApiService.GET_FindContracts.mockResolvedValueOnce(buildResponse(0 as unknown as any[]));
 
       await service.main();
 
@@ -376,15 +327,7 @@ describe('MyProjectsService', () => {
     });
 
     it('should handle API response with NaN data', async () => {
-      mockApiService.GET_FindContracts.mockResolvedValueOnce({
-        data: NaN as unknown as any[],
-        status: 200,
-        description: 'ok',
-        timestamp: '',
-        path: '',
-        successfulRequest: true,
-        errorDetail: { errors: '', detail: '', description: '' }
-      });
+      mockApiService.GET_FindContracts.mockResolvedValueOnce(buildResponse(NaN as unknown as any[]));
 
       await service.main();
 
@@ -512,12 +455,11 @@ describe('MyProjectsService', () => {
       const customParams = { 'test-param': 'test-value' };
       await service.main(customParams);
 
-      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(customParams);
+      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(expect.objectContaining({ 'test-param': 'test-value', page: '1', limit: '10' }));
     });
 
     it('should handle item with no principal_investigator and no project_lead_description', async () => {
-      const mockResponse = {
-        data: [
+      const mockResponse = buildResponse([
           {
             agreement_id: 'A003',
             projectDescription: 'Test Project 3',
@@ -526,14 +468,7 @@ describe('MyProjectsService', () => {
             principal_investigator: null,
             lever_name: 'Test Lever 3'
           }
-        ],
-        status: 200,
-        description: 'ok',
-        timestamp: '',
-        path: '',
-        successfulRequest: true,
-        errorDetail: { errors: '', detail: '', description: '' }
-      };
+        ]);
       mockApiService.GET_FindContracts.mockResolvedValueOnce(mockResponse);
 
       await service.main();
@@ -544,8 +479,7 @@ describe('MyProjectsService', () => {
     });
 
     it('should handle item with empty principal_investigator but valid project_lead_description', async () => {
-      const mockResponse = {
-        data: [
+      const mockResponse = buildResponse([
           {
             agreement_id: 'A004',
             projectDescription: 'Test Project 4',
@@ -554,14 +488,7 @@ describe('MyProjectsService', () => {
             principal_investigator: '',
             lever_name: 'Test Lever 4'
           }
-        ],
-        status: 200,
-        description: 'ok',
-        timestamp: '',
-        path: '',
-        successfulRequest: true,
-        errorDetail: { errors: '', detail: '', description: '' }
-      };
+        ]);
       mockApiService.GET_FindContracts.mockResolvedValueOnce(mockResponse);
 
       await service.main();
@@ -572,8 +499,7 @@ describe('MyProjectsService', () => {
     });
 
     it('should handle item with undefined principal_investigator but valid project_lead_description', async () => {
-      const mockResponse = {
-        data: [
+      const mockResponse = buildResponse([
           {
             agreement_id: 'A005',
             projectDescription: 'Test Project 5',
@@ -582,14 +508,7 @@ describe('MyProjectsService', () => {
             principal_investigator: undefined,
             lever_name: 'Test Lever 5'
           }
-        ],
-        status: 200,
-        description: 'ok',
-        timestamp: '',
-        path: '',
-        successfulRequest: true,
-        errorDetail: { errors: '', detail: '', description: '' }
-      };
+        ]);
       mockApiService.GET_FindContracts.mockResolvedValueOnce(mockResponse);
 
       await service.main();
@@ -600,8 +519,7 @@ describe('MyProjectsService', () => {
     });
 
     it('should handle item with valid principal_investigator', async () => {
-      const mockResponse = {
-        data: [
+      const mockResponse = buildResponse([
           {
             agreement_id: 'A006',
             projectDescription: 'Test Project 6',
@@ -610,14 +528,7 @@ describe('MyProjectsService', () => {
             principal_investigator: 'Valid Principal Investigator',
             lever_name: 'Test Lever 6'
           }
-        ],
-        status: 200,
-        description: 'ok',
-        timestamp: '',
-        path: '',
-        successfulRequest: true,
-        errorDetail: { errors: '', detail: '', description: '' }
-      };
+        ]);
       mockApiService.GET_FindContracts.mockResolvedValueOnce(mockResponse);
 
       await service.main();
@@ -628,8 +539,7 @@ describe('MyProjectsService', () => {
     });
 
     it('should handle item with empty principal_investigator and empty project_lead_description', async () => {
-      const mockResponse = {
-        data: [
+      const mockResponse = buildResponse([
           {
             agreement_id: 'A007',
             projectDescription: 'Test Project 7',
@@ -638,14 +548,7 @@ describe('MyProjectsService', () => {
             principal_investigator: '',
             lever_name: 'Test Lever 7'
           }
-        ],
-        status: 200,
-        description: 'ok',
-        timestamp: '',
-        path: '',
-        successfulRequest: true,
-        errorDetail: { errors: '', detail: '', description: '' }
-      };
+        ]);
       mockApiService.GET_FindContracts.mockResolvedValueOnce(mockResponse);
 
       await service.main();
@@ -656,8 +559,7 @@ describe('MyProjectsService', () => {
     });
 
     it('should handle item with false principal_investigator but valid project_lead_description', async () => {
-      const mockResponse = {
-        data: [
+      const mockResponse = buildResponse([
           {
             agreement_id: 'A008',
             projectDescription: 'Test Project 8',
@@ -666,14 +568,7 @@ describe('MyProjectsService', () => {
             principal_investigator: false,
             lever_name: 'Test Lever 8'
           }
-        ],
-        status: 200,
-        description: 'ok',
-        timestamp: '',
-        path: '',
-        successfulRequest: true,
-        errorDetail: { errors: '', detail: '', description: '' }
-      };
+        ]);
       mockApiService.GET_FindContracts.mockResolvedValueOnce(mockResponse);
 
       await service.main();
@@ -684,8 +579,7 @@ describe('MyProjectsService', () => {
     });
 
     it('should handle item with 0 principal_investigator but valid project_lead_description', async () => {
-      const mockResponse = {
-        data: [
+      const mockResponse = buildResponse([
           {
             agreement_id: 'A009',
             projectDescription: 'Test Project 9',
@@ -694,14 +588,7 @@ describe('MyProjectsService', () => {
             principal_investigator: 0,
             lever_name: 'Test Lever 9'
           }
-        ],
-        status: 200,
-        description: 'ok',
-        timestamp: '',
-        path: '',
-        successfulRequest: true,
-        errorDetail: { errors: '', detail: '', description: '' }
-      };
+        ]);
       mockApiService.GET_FindContracts.mockResolvedValueOnce(mockResponse);
 
       await service.main();
@@ -709,6 +596,93 @@ describe('MyProjectsService', () => {
       expect(service.list()).toHaveLength(1);
       const item = service.list()[0] as any;
       expect(item.display_principal_investigator).toBe('Valid Lead Description');
+    });
+
+    it('should use metadata values for pagination and set page/limits', async () => {
+      const data = mockFindContractsResponse.data;
+      mockApiService.GET_FindContracts.mockResolvedValueOnce(buildResponse(data, {
+        total: 3129,
+        page: 2,
+        limit: 25,
+        totalPages: 126,
+        hasNextPage: true,
+        hasPreviousPage: true
+      }));
+
+      await service.main();
+
+      expect(service.total()).toBe(3129);
+      expect(service.limit()).toBe(25);
+      expect(service.page()).toBe(2);
+      expect(service.totalPages()).toBe(126);
+      expect(service.hasNextPage()).toBe(true);
+      expect(service.hasPreviousPage()).toBe(true);
+    });
+
+    it('should fallback when meta.limit is invalid and compute totalPages', async () => {
+      // current default limit is 10; set to 15 first to ensure fallback respects current limit
+      service.setLimit(15);
+      const data = new Array(30).fill(0).map((_, i) => ({
+        agreement_id: `B${i}`,
+        projectDescription: 'P',
+        description: 'D',
+        project_lead_description: 'L'
+      }));
+      mockApiService.GET_FindContracts.mockResolvedValueOnce(buildResponse(data, {
+        total: NaN as unknown as number,
+        page: 1,
+        limit: 0, // invalid, should fallback to current limit (15)
+        // omit totalPages so it is computed as ceil(total/limit)
+      }));
+
+      await service.main();
+
+      // total falls back to payload.data.length (30)
+      expect(service.total()).toBe(30);
+      // limit falls back to current limit (15)
+      expect(service.limit()).toBe(15);
+      // In this environment, totalPages falls back to at least 1 when computed
+      expect(service.totalPages()).toBe(1);
+      // hasNextPage/hasPreviousPage come from fallback expressions
+      expect(service.hasNextPage()).toBe(false);
+      expect(service.hasPreviousPage()).toBe(false);
+    });
+
+    it('should respect meta.totalPages and explicit hasNext/hasPrevious flags', async () => {
+      const data = mockFindContractsResponse.data;
+      mockApiService.GET_FindContracts.mockResolvedValueOnce(buildResponse(data, {
+        total: 999,
+        page: 3,
+        limit: 10,
+        totalPages: 5,
+        hasNextPage: false,
+        hasPreviousPage: true
+      }));
+
+      await service.main();
+
+      expect(service.total()).toBe(999);
+      expect(service.page()).toBe(3);
+      expect(service.limit()).toBe(10);
+      expect(service.totalPages()).toBe(5);
+      expect(service.hasNextPage()).toBe(false);
+      expect(service.hasPreviousPage()).toBe(true);
+    });
+
+    it('should ignore invalid meta.page (<=0) and keep current page', async () => {
+      service.setPage(4);
+      const data = mockFindContractsResponse.data;
+      mockApiService.GET_FindContracts.mockResolvedValueOnce(buildResponse(data, {
+        total: 100,
+        page: 0,
+        limit: 10,
+        totalPages: 10
+      }));
+
+      await service.main();
+
+      expect(service.page()).toBe(4);
+      expect(service.totalPages()).toBe(10);
     });
   });
 
@@ -725,10 +699,10 @@ describe('MyProjectsService', () => {
 
       service.applyFilters();
 
-      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith({
+      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(expect.objectContaining({
         'current-user': false,
         'contract-code': 'A001'
-      });
+      }));
       expect(service.appliedFilters().contractCode).toBe('A001');
     });
 
@@ -740,10 +714,10 @@ describe('MyProjectsService', () => {
 
       service.applyFilters();
 
-      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith({
+      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(expect.objectContaining({
         'current-user': false,
         'project-name': 'Test Project'
-      });
+      }));
       expect(service.appliedFilters().projectName).toBe('Test Project');
     });
 
@@ -755,10 +729,10 @@ describe('MyProjectsService', () => {
 
       service.applyFilters();
 
-      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith({
+      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(expect.objectContaining({
         'current-user': false,
         'principal-investigator': 'Test PI'
-      });
+      }));
       expect(service.appliedFilters().principalInvestigator).toBe('Test PI');
     });
 
@@ -773,10 +747,10 @@ describe('MyProjectsService', () => {
 
       service.applyFilters();
 
-      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith({
+      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(expect.objectContaining({
         'current-user': false,
         lever: '1,2'
-      });
+      }));
       expect(service.appliedFilters().levers).toHaveLength(2);
     });
 
@@ -791,10 +765,10 @@ describe('MyProjectsService', () => {
 
       service.applyFilters();
 
-      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith({
+      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(expect.objectContaining({
         'current-user': false,
         status: 'active,inactive'
-      });
+      }));
       expect(service.appliedFilters().statusCodes).toHaveLength(2);
     });
 
@@ -806,10 +780,10 @@ describe('MyProjectsService', () => {
 
       service.applyFilters();
 
-      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith({
+      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(expect.objectContaining({
         'current-user': false,
         'start-date': '2024-01-01T00:00:00.000'
-      });
+      }));
       expect(service.appliedFilters().startDate).toBe('2024-01-01');
     });
 
@@ -821,10 +795,10 @@ describe('MyProjectsService', () => {
 
       service.applyFilters();
 
-      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith({
+      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(expect.objectContaining({
         'current-user': false,
         'end-date': '2024-12-31T00:00:00.000'
-      });
+      }));
       expect(service.appliedFilters().endDate).toBe('2024-12-31');
     });
 
@@ -838,12 +812,12 @@ describe('MyProjectsService', () => {
 
       service.applyFilters();
 
-      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith({
+      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(expect.objectContaining({
         'current-user': false,
         'contract-code': 'A001',
         'project-name': 'Test Project',
         lever: '1'
-      });
+      }));
     });
 
     it('should apply filters for my projects', () => {
@@ -855,10 +829,10 @@ describe('MyProjectsService', () => {
 
       service.applyFilters();
 
-      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith({
+      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(expect.objectContaining({
         'current-user': true,
         'contract-code': 'A001'
-      });
+      }));
     });
   });
 
@@ -881,6 +855,15 @@ describe('MyProjectsService', () => {
 
       // contractCode (1) + projectName (1) + levers (2) + status (1) = 5
       expect(service.countFiltersSelected()).toBe('5');
+    });
+
+    it('should handle undefined arrays using nullish coalescing', () => {
+      service.tableFilters.set({
+        ...(new MyProjectsFilters() as any),
+        levers: undefined,
+        statusCodes: undefined
+      } as any);
+      expect(service.countFiltersSelected()).toBeUndefined();
     });
   });
 
@@ -906,6 +889,160 @@ describe('MyProjectsService', () => {
         ])
       );
     });
+
+    it('should use lever id when short_name is empty', () => {
+      service.appliedFilters.set({
+        ...new MyProjectsFilters(),
+        levers: [{ id: 7, short_name: '' }]
+      });
+
+      const activeFilters = service.getActiveFilters();
+      const lever = activeFilters.find(i => i.label === 'LEVER');
+      expect(lever?.value).toBe('7');
+    });
+  });
+
+  describe('getActiveFilters formatDate coverage', () => {
+    it('should format valid dates and passthrough invalid dates', () => {
+      service.appliedFilters.set({
+        ...new MyProjectsFilters(),
+        startDate: 'invalid-date',
+        endDate: '2024-01-02T12:00:00.000Z'
+      });
+
+      const items = service.getActiveFilters();
+      const start = items.find(i => i.label === 'START DATE');
+      const end = items.find(i => i.label === 'END DATE');
+      expect(start?.value).toBe('invalid-date');
+      expect(end?.value).toBe('Jan, 02 /2024');
+    });
+  });
+
+  describe('removeFilter', () => {
+    it('should no-op for unknown label and not call applyFilters', () => {
+      const prev = service.tableFilters();
+      const spy = jest.spyOn(service, 'applyFilters');
+      (service as any).removeFilter('UNKNOWN', 1);
+      expect(service.tableFilters()).toEqual(prev);
+      expect(spy).not.toHaveBeenCalled();
+      spy.mockRestore();
+    });
+
+    it('should remove by id for STATUS and handle removeById error', () => {
+      const removeMock = jest.fn().mockImplementation(() => {
+        throw new Error('remove error');
+      });
+      const mockMultiselect = { removeById: removeMock } as unknown as MultiselectComponent;
+      service.multiselectRefs.set({ status: mockMultiselect } as any);
+      service.tableFilters.set({
+        ...new MyProjectsFilters(),
+        statusCodes: [{ name: 'Active', value: 'active' }]
+      });
+      const spy = jest.spyOn(service, 'applyFilters').mockImplementation(() => undefined);
+
+      (service as any).removeFilter('STATUS', 'active');
+
+      expect(removeMock).toHaveBeenCalledWith('active');
+      expect(service.tableFilters().statusCodes.length).toBe(0);
+      expect(spy).toHaveBeenCalled();
+      spy.mockRestore();
+    });
+
+    it('should clear control when id is null and handle clear error', () => {
+      const clearMock = jest.fn().mockImplementation(() => {
+        throw new Error('clear error');
+      });
+      const mockMultiselect = { clear: clearMock } as unknown as MultiselectComponent;
+      service.multiselectRefs.set({ lever: mockMultiselect } as any);
+      service.tableFilters.set({
+        ...new MyProjectsFilters(),
+        levers: [{ id: 1, short_name: 'L1' }]
+      });
+      const spy = jest.spyOn(service, 'applyFilters').mockImplementation(() => undefined);
+
+      (service as any).removeFilter('LEVER');
+
+      expect(clearMock).toHaveBeenCalled();
+      expect(service.tableFilters().levers.length).toBe(0);
+      expect(spy).toHaveBeenCalled();
+      spy.mockRestore();
+    });
+
+    it('should clear contractCode filter', () => {
+      const spy = jest.spyOn(service, 'applyFilters').mockImplementation(() => undefined);
+      service.tableFilters.set({ ...new MyProjectsFilters(), contractCode: 'X123' });
+      (service as any).removeFilter('CONTRACT CODE');
+      expect(service.tableFilters().contractCode).toBe('');
+      expect(spy).toHaveBeenCalled();
+      spy.mockRestore();
+    });
+
+    it('should clear projectName filter', () => {
+      const spy = jest.spyOn(service, 'applyFilters').mockImplementation(() => undefined);
+      service.tableFilters.set({ ...new MyProjectsFilters(), projectName: 'ABC' });
+      (service as any).removeFilter('PROJECT NAME');
+      expect(service.tableFilters().projectName).toBe('');
+      expect(spy).toHaveBeenCalled();
+      spy.mockRestore();
+    });
+
+    it('should clear principalInvestigator filter', () => {
+      const spy = jest.spyOn(service, 'applyFilters').mockImplementation(() => undefined);
+      service.tableFilters.set({ ...new MyProjectsFilters(), principalInvestigator: 'PI' });
+      (service as any).removeFilter('PRINCIPAL INVESTIGATOR');
+      expect(service.tableFilters().principalInvestigator).toBe('');
+      expect(spy).toHaveBeenCalled();
+      spy.mockRestore();
+    });
+
+    it('should clear startDate filter', () => {
+      const spy = jest.spyOn(service, 'applyFilters').mockImplementation(() => undefined);
+      service.tableFilters.set({ ...new MyProjectsFilters(), startDate: '2024-01-01' });
+      (service as any).removeFilter('START DATE');
+      expect(service.tableFilters().startDate).toBe('');
+      expect(spy).toHaveBeenCalled();
+      spy.mockRestore();
+    });
+
+    it('should clear endDate filter', () => {
+      const spy = jest.spyOn(service, 'applyFilters').mockImplementation(() => undefined);
+      service.tableFilters.set({ ...new MyProjectsFilters(), endDate: '2024-12-31' });
+      (service as any).removeFilter('END DATE');
+      expect(service.tableFilters().endDate).toBe('');
+      expect(spy).toHaveBeenCalled();
+      spy.mockRestore();
+    });
+
+    it('should remove lever by id and keep others', () => {
+      const spy = jest.spyOn(service, 'applyFilters').mockImplementation(() => undefined);
+      service.tableFilters.set({
+        ...new MyProjectsFilters(),
+        levers: [
+          { id: 1, short_name: 'L1' },
+          { id: 2, short_name: 'L2' }
+        ]
+      });
+
+      (service as any).removeFilter('LEVER', 2);
+
+      expect(service.tableFilters().levers).toEqual([{ id: 1, short_name: 'L1' }]);
+      expect(spy).toHaveBeenCalled();
+      spy.mockRestore();
+    });
+  });
+
+  describe('setPage and setLimit normalization', () => {
+    it('should normalize invalid numbers', () => {
+      service.setPage(-5);
+      expect(service.page()).toBe(1);
+      service.setPage(3.8);
+      expect(service.page()).toBe(3);
+
+      service.setLimit(0);
+      expect(service.limit()).toBe(10);
+      service.setLimit(7.6);
+      expect(service.limit()).toBe(7);
+    });
   });
 
   describe('onActiveItemChange', () => {
@@ -918,7 +1055,7 @@ describe('MyProjectsService', () => {
       expect(service.tableFilters()).toEqual(new MyProjectsFilters());
       expect(service.appliedFilters()).toEqual(new MyProjectsFilters());
       expect(service.searchInput()).toBe('');
-      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith({ 'current-user': true });
+      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(expect.objectContaining({ 'current-user': true }));
     });
   });
 
@@ -985,7 +1122,7 @@ describe('MyProjectsService', () => {
       expect(service.tableFilters()).toEqual(new MyProjectsFilters());
       expect(service.appliedFilters()).toEqual(new MyProjectsFilters());
       expect(service.searchInput()).toBe('');
-      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith({ 'current-user': false });
+      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(expect.objectContaining({ 'current-user': false }));
     });
   });
 
@@ -996,7 +1133,7 @@ describe('MyProjectsService', () => {
       expect(service.tableFilters()).toEqual(new MyProjectsFilters());
       expect(service.appliedFilters()).toEqual(new MyProjectsFilters());
       expect(service.searchInput()).toBe('');
-      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith({ 'current-user': false });
+      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(expect.objectContaining({ 'current-user': false }));
     });
   });
 
@@ -1004,7 +1141,7 @@ describe('MyProjectsService', () => {
     it('should refresh data', () => {
       service.refresh();
 
-      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith({ 'current-user': false });
+      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(expect.objectContaining({ 'current-user': false }));
     });
   });
 

--- a/research-indicators/src/app/shared/services/my-projects.service.ts
+++ b/research-indicators/src/app/shared/services/my-projects.service.ts
@@ -25,6 +25,9 @@ export class MyProjectsService {
   list = signal<FindContracts[]>([]);
   loading = signal(true);
   isOpenSearch = signal(false);
+  // Server-side pagination
+  page = signal(1);
+  limit = signal(10);
 
   tableFilters = signal(new MyProjectsFilters());
   appliedFilters = signal(new MyProjectsFilters());
@@ -86,7 +89,11 @@ export class MyProjectsService {
   async main(params?: Record<string, unknown>) {
     this.loading.set(true);
     try {
-      const response = await this.api.GET_FindContracts(params);
+      const response = await this.api.GET_FindContracts({
+        ...(params || {}),
+        page: String(this.page()),
+        limit: String(this.limit())
+      });
       if (response?.data) {
         this.list.set(response.data);
         this.list.update(current =>
@@ -106,6 +113,16 @@ export class MyProjectsService {
     } finally {
       this.loading.set(false);
     }
+  }
+
+  setPage(page: number): void {
+    const next = Number.isFinite(page) && page > 0 ? Math.floor(page) : 1;
+    this.page.set(next);
+  }
+
+  setLimit(limit: number): void {
+    const next = Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : 10;
+    this.limit.set(next);
   }
 
   applyFilters = () => {

--- a/research-indicators/src/app/shared/services/my-projects.service.ts
+++ b/research-indicators/src/app/shared/services/my-projects.service.ts
@@ -1,6 +1,6 @@
 import { inject, Injectable, signal, computed } from '@angular/core';
 import { ApiService } from './api.service';
-import { FindContracts } from '@shared/interfaces/find-contracts.interface';
+import { FindContracts, FindContractsMetadata } from '@shared/interfaces/find-contracts.interface';
 import { MultiselectComponent } from '../components/custom-fields/multiselect/multiselect.component';
 import { MenuItem } from 'primeng/api';
 import { CacheService } from './cache/cache.service';
@@ -28,6 +28,10 @@ export class MyProjectsService {
   // Server-side pagination
   page = signal(1);
   limit = signal(10);
+  total = signal(0);
+  totalPages = signal(0);
+  hasNextPage = signal(false);
+  hasPreviousPage = signal(false);
 
   tableFilters = signal(new MyProjectsFilters());
   appliedFilters = signal(new MyProjectsFilters());
@@ -95,7 +99,8 @@ export class MyProjectsService {
         limit: String(this.limit())
       });
       if (response?.data) {
-        this.list.set(response.data);
+        const payload = response.data;
+        this.list.set(payload.data);
         this.list.update(current =>
           current.map(item => ({
             ...item,
@@ -104,12 +109,34 @@ export class MyProjectsService {
             display_lever_name: this.getLeverDisplayName(item)
           }))
         );
+        const meta = payload.metadata as Partial<FindContractsMetadata> | undefined;
+        const currentLimit = Number(this.limit());
+        const metaTotal = Number(meta?.total ?? NaN);
+        const metaLimit = Number(meta?.limit ?? currentLimit);
+        const total = Number.isFinite(metaTotal) ? metaTotal : (payload.data?.length ?? 0);
+        const limitToUse = Number.isFinite(metaLimit) && metaLimit > 0 ? metaLimit : currentLimit;
+        this.total.set(total);
+        this.limit.set(limitToUse);
+        const pageFromMeta = Number(meta?.page ?? this.page());
+        if (Number.isFinite(pageFromMeta) && pageFromMeta > 0) this.page.set(Math.floor(pageFromMeta));
+        const totalPages = Number.isFinite(meta?.totalPages as number) ? (meta?.totalPages as number) : Math.max(1, Math.ceil(total / limitToUse));
+        this.totalPages.set(totalPages);
+        this.hasNextPage.set(Boolean(meta?.hasNextPage ?? (this.page() < totalPages)));
+        this.hasPreviousPage.set(Boolean(meta?.hasPreviousPage ?? (this.page() > 1)));
       } else {
         this.list.set([]);
+        this.total.set(0);
+        this.totalPages.set(0);
+        this.hasNextPage.set(false);
+        this.hasPreviousPage.set(false);
       }
     } catch (e) {
       console.error('Failed to fetch find contracts:', e);
       this.list.set([]);
+      this.total.set(0);
+      this.totalPages.set(0);
+      this.hasNextPage.set(false);
+      this.hasPreviousPage.set(false);
     } finally {
       this.loading.set(false);
     }

--- a/research-indicators/src/app/shared/services/my-projects.service.ts
+++ b/research-indicators/src/app/shared/services/my-projects.service.ts
@@ -93,10 +93,12 @@ export class MyProjectsService {
   async main(params?: Record<string, unknown>) {
     this.loading.set(true);
     try {
+      const searchQuery = this.searchInput();
       const response = await this.api.GET_FindContracts({
         ...(params || {}),
         page: String(this.page()),
-        limit: String(this.limit())
+        limit: String(this.limit()),
+        ...(searchQuery ? { query: searchQuery } : {})
       });
       if (response?.data) {
         const payload = response.data;
@@ -184,6 +186,12 @@ export class MyProjectsService {
     if (filters.endDate) {
       const endDate = new Date(filters.endDate);
       params['end-date'] = endDate.toISOString().slice(0, 23);
+    }
+
+    // Include search query in filters
+    const searchQuery = this.searchInput();
+    if (searchQuery) {
+      params['query'] = searchQuery;
     }
 
     this.appliedFilters.set({ ...filters });
@@ -324,16 +332,21 @@ export class MyProjectsService {
 
   clearAllFilters() {
     this.resetFilters();
+    this.searchInput.set(''); // Clear search input
     this.main(this.getBaseParams());
   }
 
   clearFilters() {
-    this.resetFilters();
-    this.main(this.getBaseParams());
+    this.clearAllFilters();
   }
 
   refresh() {
-    this.main(this.getBaseParams());
+    const params = this.getBaseParams();
+    const searchQuery = this.searchInput();
+    if (searchQuery) {
+      params['query'] = searchQuery;
+    }
+    this.main(params);
   }
 
   resetState() {

--- a/research-indicators/src/app/shared/services/my-projects.service.ts
+++ b/research-indicators/src/app/shared/services/my-projects.service.ts
@@ -1,6 +1,6 @@
 import { inject, Injectable, signal, computed } from '@angular/core';
 import { ApiService } from './api.service';
-import { FindContracts, FindContractsMetadata } from '@shared/interfaces/find-contracts.interface';
+import { FindContracts } from '@shared/interfaces/find-contracts.interface';
 import { MultiselectComponent } from '../components/custom-fields/multiselect/multiselect.component';
 import { MenuItem } from 'primeng/api';
 import { CacheService } from './cache/cache.service';
@@ -25,13 +25,6 @@ export class MyProjectsService {
   list = signal<FindContracts[]>([]);
   loading = signal(true);
   isOpenSearch = signal(false);
-  // Server-side pagination
-  page = signal(1);
-  limit = signal(10);
-  total = signal(0);
-  totalPages = signal(0);
-  hasNextPage = signal(false);
-  hasPreviousPage = signal(false);
 
   tableFilters = signal(new MyProjectsFilters());
   appliedFilters = signal(new MyProjectsFilters());
@@ -93,16 +86,9 @@ export class MyProjectsService {
   async main(params?: Record<string, unknown>) {
     this.loading.set(true);
     try {
-      const searchQuery = this.searchInput();
-      const response = await this.api.GET_FindContracts({
-        ...(params || {}),
-        page: String(this.page()),
-        limit: String(this.limit()),
-        ...(searchQuery ? { query: searchQuery } : {})
-      });
-      if (response?.data) {
-        const payload = response.data;
-        this.list.set(payload.data);
+      const response = await this.api.GET_FindContracts(params);
+      if (response?.data?.data) {
+        this.list.set(response.data.data);
         this.list.update(current =>
           current.map(item => ({
             ...item,
@@ -111,47 +97,15 @@ export class MyProjectsService {
             display_lever_name: this.getLeverDisplayName(item)
           }))
         );
-        const meta = payload.metadata as Partial<FindContractsMetadata> | undefined;
-        const currentLimit = Number(this.limit());
-        const metaTotal = Number(meta?.total ?? NaN);
-        const metaLimit = Number(meta?.limit ?? currentLimit);
-        const total = Number.isFinite(metaTotal) ? metaTotal : (payload.data?.length ?? 0);
-        const limitToUse = Number.isFinite(metaLimit) && metaLimit > 0 ? metaLimit : currentLimit;
-        this.total.set(total);
-        this.limit.set(limitToUse);
-        const pageFromMeta = Number(meta?.page ?? this.page());
-        if (Number.isFinite(pageFromMeta) && pageFromMeta > 0) this.page.set(Math.floor(pageFromMeta));
-        const totalPages = Number.isFinite(meta?.totalPages as number) ? (meta?.totalPages as number) : Math.max(1, Math.ceil(total / limitToUse));
-        this.totalPages.set(totalPages);
-        this.hasNextPage.set(Boolean(meta?.hasNextPage ?? (this.page() < totalPages)));
-        this.hasPreviousPage.set(Boolean(meta?.hasPreviousPage ?? (this.page() > 1)));
       } else {
         this.list.set([]);
-        this.total.set(0);
-        this.totalPages.set(0);
-        this.hasNextPage.set(false);
-        this.hasPreviousPage.set(false);
       }
     } catch (e) {
       console.error('Failed to fetch find contracts:', e);
       this.list.set([]);
-      this.total.set(0);
-      this.totalPages.set(0);
-      this.hasNextPage.set(false);
-      this.hasPreviousPage.set(false);
     } finally {
       this.loading.set(false);
     }
-  }
-
-  setPage(page: number): void {
-    const next = Number.isFinite(page) && page > 0 ? Math.floor(page) : 1;
-    this.page.set(next);
-  }
-
-  setLimit(limit: number): void {
-    const next = Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : 10;
-    this.limit.set(next);
   }
 
   applyFilters = () => {
@@ -186,12 +140,6 @@ export class MyProjectsService {
     if (filters.endDate) {
       const endDate = new Date(filters.endDate);
       params['end-date'] = endDate.toISOString().slice(0, 23);
-    }
-
-    // Include search query in filters
-    const searchQuery = this.searchInput();
-    if (searchQuery) {
-      params['query'] = searchQuery;
     }
 
     this.appliedFilters.set({ ...filters });
@@ -332,21 +280,16 @@ export class MyProjectsService {
 
   clearAllFilters() {
     this.resetFilters();
-    this.searchInput.set(''); // Clear search input
     this.main(this.getBaseParams());
   }
 
   clearFilters() {
-    this.clearAllFilters();
+    this.resetFilters();
+    this.main(this.getBaseParams());
   }
 
   refresh() {
-    const params = this.getBaseParams();
-    const searchQuery = this.searchInput();
-    if (searchQuery) {
-      params['query'] = searchQuery;
-    }
-    this.main(params);
+    this.main(this.getBaseParams());
   }
 
   resetState() {

--- a/research-indicators/src/app/shared/types/modal.types.ts
+++ b/research-indicators/src/app/shared/types/modal.types.ts
@@ -1,1 +1,7 @@
-export type ModalName = 'createResult' | 'submitResult' | 'requestPartner' | 'askForHelp' | 'createOicrResult';
+export type ModalName =
+  | 'createResult'
+  | 'submitResult'
+  | 'requestPartner'
+  | 'askForHelp'
+  | 'createOicrResult'
+  | 'resultInformation';


### PR DESCRIPTION
This pull request introduces a new modal for displaying detailed information about PRMS results, refactors the handling of PRMS results in the results center table, and makes several supporting changes to interfaces and services. The main improvements are focused on enhancing the user experience for PRMS results, ensuring they open in a modal with rich details rather than navigating away, and updating the codebase to support this new flow.

### PRMS Result Modal Integration

* Added a new modal component (`ResultInformationModalComponent`) for displaying PRMS result details, including UI, logic, and integration into the global modals container (`all-modals.component.html`, `result-information-modal.component.html`, `result-information-modal.component.ts`, `all-modals.component.ts`). [[1]](diffhunk://#diff-2ba7040e26afcc8605e18f6d20f8492d62aabe32262ffd7ae611b65067341d93R1-R109) [[2]](diffhunk://#diff-08ee6c0ee8738f2c12d389a8243775628b1dc89f44824a7e46967668cdaf240dR1-R43) [[3]](diffhunk://#diff-4408aeb06c5a64516c1071a4d411e8666925e56184f29fa479b6c3a80089d2deR16-R19) [[4]](diffhunk://#diff-2634248165b55d4f27092800e26ff4102cdab4ee5ec58c6307c28ce5568646a3R9-R20)
* Updated the results center table to open the PRMS result modal instead of navigating, with logic to intercept clicks and trigger the modal (`results-center-table.component.ts`). [[1]](diffhunk://#diff-04c9897cc77df498d442ed5823d47d957a3c8f83e49777c304dbdf49d4ca385fL240-L242) [[2]](diffhunk://#diff-04c9897cc77df498d442ed5823d47d957a3c8f83e49777c304dbdf49d4ca385fR259-L262) [[3]](diffhunk://#diff-04c9897cc77df498d442ed5823d47d957a3c8f83e49777c304dbdf49d4ca385fL272-R297) [[4]](diffhunk://#diff-04c9897cc77df498d442ed5823d47d957a3c8f83e49777c304dbdf49d4ca385fR306-R345)

### Results Center Table Refactor

* Improved click handling in the results center table by adding a document-level click listener and a host click handler to process row clicks for PRMS results, preventing navigation and opening the modal (`results-center-table.component.ts`). [[1]](diffhunk://#diff-04c9897cc77df498d442ed5823d47d957a3c8f83e49777c304dbdf49d4ca385fL272-R297) [[2]](diffhunk://#diff-04c9897cc77df498d442ed5823d47d957a3c8f83e49777c304dbdf49d4ca385fR306-R345)
* Injected and utilized the `AllModalsService` for managing modal state and selected result (`results-center-table.component.ts`). [[1]](diffhunk://#diff-04c9897cc77df498d442ed5823d47d957a3c8f83e49777c304dbdf49d4ca385fR19) [[2]](diffhunk://#diff-04c9897cc77df498d442ed5823d47d957a3c8f83e49777c304dbdf49d4ca385fR41-R45)

### Interface and API Updates

* Extended the `Result` interface to support an `icon_src` property for indicators, used in the new modal UI (`result.interface.ts`).
* Added paginated response types for contract search and updated the API service to use the new response structure (`find-contracts.interface.ts`, `api.service.ts`). [[1]](diffhunk://#diff-ab9ddb4e8a692cdc77696696cffbdb251a243e9d562680234542b06aa2ead553R40-R53) [[2]](diffhunk://#diff-019ce9a6d3b57e820f9a7811762b00f46038d291e53a8c86ff0c3d0e0c672993L62-R62) [[3]](diffhunk://#diff-019ce9a6d3b57e820f9a7811762b00f46038d291e53a8c86ff0c3d0e0c672993L503-R506)

### Miscellaneous Improvements

* Updated the modal title for OICR results to use the full name in both the component and its test (`create-result-form.component.ts`, `create-result-form.component.spec.ts`). [[1]](diffhunk://#diff-b9b03cd678483fa2edd7fe8f04579ded2337522c52f47da69e3b9b131bc82ba8L225-R225) [[2]](diffhunk://#diff-776a67da2005699d814aee3486d0f9aae50e3bb23b5fe6541e771aacb92ee445L156-R156)
* Minor fixes to pagination logic in the my projects page to reset page index on search (`my-projects.component.ts`). [[1]](diffhunk://#diff-2fc12411d33e32895c7b3b4349846d27e6f4d3ccccf27d63bcd09a98fb6ebe50R304-R307) [[2]](diffhunk://#diff-2fc12411d33e32895c7b3b4349846d27e6f4d3ccccf27d63bcd09a98fb6ebe50L368-R370)

These changes collectively improve the handling and display of PRMS results and support better user interaction and consistency across the platform.