### PR TITLE
Global Target multiselect and validation in OICR Impact Areas

### DIFF
--- a/research-indicators/src/app/pages/platform/pages/my-projects/my-projects.component.html
+++ b/research-indicators/src/app/pages/platform/pages/my-projects/my-projects.component.html
@@ -115,6 +115,7 @@
                 [value]="getCurrentProjects()"
                 [paginator]="true"
                 [lazy]="true"
+                [lazyLoadOnInit]="false"
                 [rows]="getCurrentRows()"
                 [loading]="getLoadingState()"
                 [showCurrentPageReport]="true"

--- a/research-indicators/src/app/pages/platform/pages/my-projects/my-projects.component.html
+++ b/research-indicators/src/app/pages/platform/pages/my-projects/my-projects.component.html
@@ -5,29 +5,24 @@
     <div class="bg-white border-b border-[#E8EBED]">
       <div class="flex items-center gap-0">
         @for (item of orderedFilterItems(); track item.id) {
-          <div
-            class="flex items-center gap-2 px-5 py-3 cursor-pointer border-b-1 border-transparent transition-all duration-200 relative hover:bg-gray-50"
-            [class]="myProjectsFilterItem()?.id === item.id ? 'border-b-[#035BA9]' : ''"
-            (keydown.enter)="onActiveItemChange(item)"
-            (click)="onActiveItemChange(item)">
-            <button
-              type="button"
-              class="bg-[#E8EBED] cursor-pointer p-1 rounded-full flex items-center justify-center min-w-6 min-h-6"
-              (click)="onPinIconClick(item.id, $event)"
-              [disabled]="loadingPin()"
-              title="Pin tab">
-              @if (isPinned(item.id)) {
-                <img [src]="'icons/pin-outline.svg' | s3ImageUrl" alt="pin logo" class="w-3 h-3" />
-              } @else {
-                <img [src]="'icons/pin.svg' | s3ImageUrl" alt="pin logo" class="w-3 h-3" />
-              }
-            </button>
-            <span
-              class="text-[14px] xl:text-[16px] pl-2 transition-colors font-semibold duration-200 py-1"
-              [class]="myProjectsFilterItem()?.id === item.id ? 'text-[#035BA9]' : ' text-gray-500'">
-              {{ item.label }}
-            </span>
-          </div>
+        <div
+          class="flex items-center gap-2 px-5 py-3 cursor-pointer border-b-1 border-transparent transition-all duration-200 relative hover:bg-gray-50"
+          [class]="myProjectsFilterItem()?.id === item.id ? 'border-b-[#035BA9]' : ''"
+          (keydown.enter)="onActiveItemChange(item)" (click)="onActiveItemChange(item)">
+          <button type="button"
+            class="bg-[#E8EBED] cursor-pointer p-1 rounded-full flex items-center justify-center min-w-6 min-h-6"
+            (click)="onPinIconClick(item.id, $event)" [disabled]="loadingPin()" title="Pin tab">
+            @if (isPinned(item.id)) {
+            <img [src]="'icons/pin-outline.svg' | s3ImageUrl" alt="pin logo" class="w-3 h-3" />
+            } @else {
+            <img [src]="'icons/pin.svg' | s3ImageUrl" alt="pin logo" class="w-3 h-3" />
+            }
+          </button>
+          <span class="text-[14px] xl:text-[16px] pl-2 transition-colors font-semibold duration-200 py-1"
+            [class]="myProjectsFilterItem()?.id === item.id ? 'text-[#035BA9]' : ' text-gray-500'">
+            {{ item.label }}
+          </span>
+        </div>
         }
       </div>
     </div>
@@ -36,101 +31,78 @@
     <div class="w-full">
       <div class="flex flex-col">
         <div class="flex flex-col px-5 py-3">
-          <span class="text-[14px] text-[#777C83] pb-2"
-            >{{
-              selectedTab() === 'my'
-                ? 'Projects will appear here when you are assigned as the Principal Investigator of the project contract in Agresso, or if you have contributed at least one result to the project.'
-                : 'Find any project from the organization.'
+          <span class="text-[14px] text-[#777C83] pb-2">{{
+            selectedTab() === 'my'
+            ? 'Projects will appear here when you are assigned as the Principal Investigator of the project contract in
+            Agresso, or if you have contributed at least one result to the project.'
+            : 'Find any project from the organization.'
             }}
           </span>
 
           <div class="flex items-center justify-between w-full">
-            <app-search-export-controls
-              [applyLabel]="applyFiltersLabel"
+            <app-search-export-controls [applyLabel]="applyFiltersLabel"
               [badge]="myProjectsService.countFiltersSelected()"
-              [showOverlayDot]="!!myProjectsService.countFiltersSelected()"
-              [showClear]="true"
+              [showOverlayDot]="!!myProjectsService.countFiltersSelected()" [showClear]="true"
               [searchValue]="myProjectsFilterItem()?.id === 'my' ? searchValue : myProjectsService.searchInput()"
               [searchPlaceholder]="'Find a project by code, title or principal investigator'"
-              (searchChange)="setSearchInputFilter($event)"
-              (apply)="showFiltersSidebar()"
+              (searchChange)="setSearchInputFilter($event)" (apply)="showFiltersSidebar()"
               (clear)="handleClearFilters()">
             </app-search-export-controls>
 
-            <app-filters-action-buttons
-              [showViewToggleButtons]="true"
-              [isTableView]="isTableView()"
-              (tableView)="toggleTableView()"
-              (cardView)="toggleCardView()">
+            <app-filters-action-buttons [showViewToggleButtons]="true" [isTableView]="isTableView()"
+              (tableView)="toggleTableView()" (cardView)="toggleCardView()">
             </app-filters-action-buttons>
           </div>
 
           @if (myProjectsService.hasFilters()) {
-            <div class="flex flex-wrap gap-2 mt-2 mb-1 items-center">
-              <span class="font-[450] text-[14px]" style="color: #8d9299; font-family: 'Space Grotesk', sans-serif">Results filtered by</span>
-              <i class="pi pi-arrow-right !text-[12px]" style="color: #8d9299"></i>
-              @for (filter of myProjectsService.getActiveFilters(); track filter.label + (filter.id || '')) {
-                <div class="flex items-center bg-[#E8EBED] rounded-xl px-2 py-1 gap-2">
-                  <span class="text-[#4C5158] text-sm">{{ filter.value || filter.label }}</span>
-                  <i
-                    class="pi pi-times-circle cursor-pointer text-[#6B7280] hover:text-[#111827]"
-                    (keydown.enter)="handleRemoveFilter(filter.label, filter.id)"
-                    (click)="handleRemoveFilter(filter.label, filter.id)"></i>
-                </div>
-              }
+          <div class="flex flex-wrap gap-2 mt-2 mb-1 items-center">
+            <span class="font-[450] text-[14px]"
+              style="color: #8d9299; font-family: 'Space Grotesk', sans-serif">Results filtered by</span>
+            <i class="pi pi-arrow-right !text-[12px]" style="color: #8d9299"></i>
+            @for (filter of myProjectsService.getActiveFilters(); track filter.label + (filter.id || '')) {
+            <div class="flex items-center bg-[#E8EBED] rounded-xl px-2 py-1 gap-2">
+              <span class="text-[#4C5158] text-sm">{{ filter.value || filter.label }}</span>
+              <i class="pi pi-times-circle cursor-pointer text-[#6B7280] hover:text-[#111827]"
+                (keydown.enter)="handleRemoveFilter(filter.label, filter.id)"
+                (click)="handleRemoveFilter(filter.label, filter.id)"></i>
             </div>
+            }
+          </div>
           }
         </div>
 
         <!-- Conditional views -->
         @if (getLoadingState()) {
-          <app-custom-progress-bar></app-custom-progress-bar>
+        <app-custom-progress-bar></app-custom-progress-bar>
         } @else {
-          <!-- Card view -->
-          @if (!isTableView()) {
-            <div class="analyze-result-content max-h-[calc(90vh-300px)] overflow-y-auto">
-              @for (project of filteredProjects(); track project.agreement_id) {
-                <app-project-item [project]="project"></app-project-item>
-              }
-            </div>
-            @if (getCurrentProjects().length > 0) {
-              <div #cardRppScope class="rpp-dropup flex justify-end w-full bg-white py-2 border border-[#E8EBED]">
-                <p-paginator
-                  (onPageChange)="onCurrentPageChange($event)"
-                  [first]="getCurrentFirst()"
-                  [rows]="getCurrentRows()"
-                  [totalRecords]="myProjectsService.totalRecords()"
-                  [showCurrentPageReport]="true"
-                  [rowsPerPageOptions]="[5, 10, 25, 50]"
-                  currentPageReportTemplate="Showing {first} to {last} of {totalRecords} projects"
-                  [dropdownAppendTo]="cardRppScope" />
-              </div>
-            }
+        <!-- Card view -->
+        @if (!isTableView()) {
+        <div class="analyze-result-content max-h-[calc(90vh-300px)] overflow-y-auto">
+          @for (project of filteredProjects(); track project.agreement_id) {
+          <app-project-item [project]="project"></app-project-item>
           }
+        </div>
+        @if (getCurrentProjects().length > 0) {
+        <div #cardRppScope class="rpp-dropup flex justify-end w-full bg-white py-2 border border-[#E8EBED]">
+          <p-paginator (onPageChange)="onCurrentPageChange($event)" [first]="getCurrentFirst()"
+            [rows]="getCurrentRows()" [totalRecords]="myProjectsService.totalRecords()" [showCurrentPageReport]="true"
+            [rowsPerPageOptions]="[5, 10, 25, 50]"
+            currentPageReportTemplate="Showing {first} to {last} of {totalRecords} projects"
+            [dropdownAppendTo]="cardRppScope" />
+        </div>
+        }
+        }
 
-          <!-- Table view -->
-          @if (isTableView()) {
-            <div #tableRppScope class="rpp-dropup w-full border border-[#E8EBED]">
-              <p-table
-                [value]="getCurrentProjects()"
-                [paginator]="true"
-                [lazy]="true"
-                [lazyLoadOnInit]="false"
-                [rows]="getCurrentRows()"
-                [loading]="getLoadingState()"
-                [showCurrentPageReport]="true"
-                [scrollable]="true"
-                [tableStyle]="{ 'min-width': '100%' }"
-                [rowsPerPageOptions]="[5, 10, 25, 50]"
-                [totalRecords]="myProjectsService.totalRecords()"
-                [first]="getCurrentFirst()"
-                (onPage)="onCurrentPageChange($event)"
-                (onSort)="onSort($event)"
-                [paginatorDropdownAppendTo]="tableRppScope"
-                currentPageReportTemplate="Showing {first} to {last} of {totalRecords} projects"
-                [sortField]="sortField()"
-                [sortOrder]="sortOrder()"
-                [globalFilterFields]="[
+        <!-- Table view -->
+        @if (isTableView()) {
+        <div #tableRppScope class="rpp-dropup w-full border border-[#E8EBED]">
+          <p-table [value]="getCurrentProjects()" [paginator]="true" [lazy]="true" [lazyLoadOnInit]="false"
+            [rows]="getCurrentRows()" [loading]="getLoadingState()" [showCurrentPageReport]="true" [scrollable]="true"
+            [tableStyle]="{ 'min-width': '100%' }" [rowsPerPageOptions]="[5, 10, 25, 50]"
+            [totalRecords]="myProjectsService.totalRecords()" [first]="getCurrentFirst()"
+            (onPage)="onCurrentPageChange($event)" (onSort)="onSort($event)" [paginatorDropdownAppendTo]="tableRppScope"
+            currentPageReportTemplate="Showing {first} to {last} of {totalRecords} projects" [sortField]="sortField()"
+            [sortOrder]="sortOrder()" [globalFilterFields]="[
                   'agreement_id',
                   'full_name',
                   'contract_status',
@@ -138,239 +110,186 @@
                   'display_lever_name',
                   'start_date',
                   'end_date'
-                ]"
-                styleClass="p-datatable-gridlines table-custom-styles p-datatable-hoverable-rows">
-                <ng-template pTemplate="header">
-                  <tr>
-                    <th class="!text-[#173F6F]" scope="col" pSortableColumn="agreement_id">
-                      <div class="flex items-center font-[500] leading-4.5 gap-2 text-[14px] xl:text-[16px]">
-                        Code
-                        <p-sortIcon field="agreement_id"></p-sortIcon>
-                      </div>
-                    </th>
-                    <th class="!text-[#173F6F]" scope="col" pSortableColumn="description" style="width: 40%">
-                      <div
-                        class="flex items-center font-[500] leading-4.5 gap-2 text-[14px] xl:text-[16px] overflow-hidden line-clamp-3 xl:line-clamp-2">
-                        Project Name
-                        <p-sortIcon field="description"></p-sortIcon>
-                      </div>
-                    </th>
-                    <th class="!text-[#173F6F]" scope="col" pSortableColumn="contract_status">
-                      <div class="font-[500] leading-4.5 gap-2 text-[14px] xl:text-[16px]">
-                        Status
-                        <p-sortIcon field="contract_status"></p-sortIcon>
-                      </div>
-                    </th>
-                    <th class="!text-[#173F6F]" scope="col" pSortableColumn="display_principal_investigator">
-                      <div class="flex items-center font-[500] leading-4.5 gap-2 text-[14px] xl:text-[16px]">
-                        Principal Investigator
-                        <p-sortIcon field="display_principal_investigator"></p-sortIcon>
-                      </div>
-                    </th>
-                    <th class="!text-[#173F6F]" scope="col" pSortableColumn="display_lever_name">
-                      <div class="flex items-center font-[500] leading-4.5 gap-2 text-[14px] xl:text-[16px]">
-                        Lever
-                        <p-sortIcon field="display_lever_name"></p-sortIcon>
-                      </div>
-                    </th>
-                    <th class="!text-[#173F6F]" scope="col" pSortableColumn="lead_center" style="min-width: 200px">
-                      <div class="flex items-center font-[500] leading-4.5 gap-2 text-[14px] xl:text-[16px]">
-                        Lead Center
-                        <p-sortIcon field="lead_center"></p-sortIcon>
-                      </div>
-                    </th>
-                    <th class="!text-[#173F6F]" scope="col" pSortableColumn="start_date" style="min-width: 120px">
-                      <div class="flex items-center font-[500] leading-4.5 gap-2 text-[14px] xl:text-[16px]">
-                        Start Date
-                        <p-sortIcon field="start_date"></p-sortIcon>
-                      </div>
-                    </th>
-                    <th class="!text-[#173F6F]" scope="col" pSortableColumn="end_date" style="min-width: 120px">
-                      <div class="flex items-center font-[500] leading-4.5 gap-2 text-[14px] xl:text-[16px]">
-                        End Date
-                        <p-sortIcon field="end_date"></p-sortIcon>
-                      </div>
-                    </th>
-                  </tr>
-                </ng-template>
-                <ng-template pTemplate="body" let-project>
-                  <tr
-                    (click)="openProject(project)"
-                    (keydown.enter)="openProject(project)"
-                    class="cursor-pointer hover:surface-ground transition-colors duration-150 text-[14px] xl:text-[16px]">
-                    <td>
-                      <a
-                        [routerLink]="['/project-detail', project.agreement_id]"
-                        (click)="$event.stopPropagation()"
-                        class="block"
-                        style="color: inherit; text-decoration: none">
-                        <div class="overflow-hidden line-clamp-2">
-                          {{ project.agreement_id || '-' }}
-                        </div>
-                      </a>
-                    </td>
-                    <td>
-                      <a
-                        [routerLink]="['/project-detail', project.agreement_id]"
-                        (click)="$event.stopPropagation()"
-                        class="block"
-                        style="color: inherit; text-decoration: none">
-                        <div class="overflow-hidden line-clamp-2">
-                          {{ project.description }}
-                        </div>
-                      </a>
-                    </td>
-                    <td>
-                      <a
-                        [routerLink]="['/project-detail', project.agreement_id]"
-                        (click)="$event.stopPropagation()"
-                        class="block"
-                        style="color: inherit; text-decoration: none">
-                        <div class="flex items-center min-h-[40px]">
-                          <app-custom-tag
-                            [statusId]="projectUtils.getStatusDisplay(project).statusId"
-                            [statusName]="projectUtils.getStatusDisplay(project).statusName"></app-custom-tag>
-                        </div>
-                      </a>
-                    </td>
-                    <td>
-                      <a
-                        [routerLink]="['/project-detail', project.agreement_id]"
-                        (click)="$event.stopPropagation()"
-                        class="block"
-                        style="color: inherit; text-decoration: none">
-                        <div class="overflow-hidden line-clamp-2">
-                          {{ project.principal_investigator || project.project_lead_description || '-' }}
-                        </div>
-                      </a>
-                    </td>
-                    <td>
-                      <a
-                        [routerLink]="['/project-detail', project.agreement_id]"
-                        (click)="$event.stopPropagation()"
-                        class="block"
-                        style="color: inherit; text-decoration: none">
-                        <div class="overflow-hidden line-clamp-2">
-                          {{ projectUtils.getLeverName(project) }}
-                        </div>
-                      </a>
-                    </td>
-                    <td>
-                      <a
-                        [routerLink]="['/project-detail', project.agreement_id]"
-                        (click)="$event.stopPropagation()"
-                        class="block"
-                        style="color: inherit; text-decoration: none">
-                        {{ project.ubwClientDescription ? (project.ubwClientDescription) : '-' }}
-                      </a>
-                    </td><td>
-                      <a
-                        [routerLink]="['/project-detail', project.agreement_id]"
-                        (click)="$event.stopPropagation()"
-                        class="block"
-                        style="color: inherit; text-decoration: none">
-                        {{ project.start_date ? (project.start_date | date: 'shortDate') : '-' }}
-                      </a>
-                    </td>
-                    <td>
-                      <a
-                        [routerLink]="['/project-detail', project.agreement_id]"
-                        (click)="$event.stopPropagation()"
-                        class="block"
-                        style="color: inherit; text-decoration: none">
-                        {{ project.end_date ? (project.end_date | date: 'shortDate') : '-' }}
-                      </a>
-                    </td>
-                  </tr>
-                </ng-template>
-                <ng-template pTemplate="emptymessage">
-                  @if (!getLoadingState()) {
-                    <tr>
-                      <td colspan="7" class="text-center p-8">
-                        <div class="flex flex-col items-center gap-4 bg-surface-ground p-6 rounded-xl">
-                          <div class="flex flex-col items-center gap-1">
-                            <img [src]="'images/landing/projects.png' | s3ImageUrl" alt="Empty Projects" class="w-[180px] h-[180px] mb-3" />
-                            <h2 class="text-[#173F6F] text-[16px] font-bold">
-                              {{ myProjectsFilterItem()?.id === 'my' ? 'YOUR PROJECTS LIST IS EMPTY' : 'PROJECTS LIST IS EMPTY' }}
-                            </h2>
-                            <p class="text-[#4C5158] leading-4 text-center text-[14px] max-w-[600px] pt-1">
-                              {{
-                                myProjectsFilterItem()?.id === 'my'
-                                  ? "You haven't created any results for your projects yet. Once you start reporting, your projects will appear here and you will be able to access them easily."
-                                  : 'There are currently no projects in the database. New projects will appear here once they are added to the system.'
-                              }}
-                            </p>
-                          </div>
-                        </div>
-                      </td>
-                    </tr>
-                  }
-                </ng-template>
-              </p-table>
-            </div>
-          }
+                ]" styleClass="p-datatable-gridlines table-custom-styles p-datatable-hoverable-rows">
+            <ng-template pTemplate="header">
+              <tr>
+                <th class="!text-[#173F6F]" scope="col" pSortableColumn="agreement_id">
+                  <div class="flex items-center font-[500] leading-4.5 gap-2 text-[14px] xl:text-[16px]">
+                    Code
+                    <p-sortIcon field="agreement_id"></p-sortIcon>
+                  </div>
+                </th>
+                <th class="!text-[#173F6F]" scope="col" pSortableColumn="description" style="width: 40%">
+                  <div
+                    class="flex items-center font-[500] leading-4.5 gap-2 text-[14px] xl:text-[16px] overflow-hidden line-clamp-3 xl:line-clamp-2">
+                    Project Name
+                    <p-sortIcon field="description"></p-sortIcon>
+                  </div>
+                </th>
+                <th class="!text-[#173F6F]" scope="col" pSortableColumn="contract_status">
+                  <div class="font-[500] leading-4.5 gap-2 text-[14px] xl:text-[16px]">
+                    Status
+                    <p-sortIcon field="contract_status"></p-sortIcon>
+                  </div>
+                </th>
+                <th class="!text-[#173F6F]" scope="col" pSortableColumn="display_principal_investigator">
+                  <div class="flex items-center font-[500] leading-4.5 gap-2 text-[14px] xl:text-[16px]">
+                    Principal Investigator
+                    <p-sortIcon field="display_principal_investigator"></p-sortIcon>
+                  </div>
+                </th>
+                <th class="!text-[#173F6F]" scope="col" pSortableColumn="display_lever_name">
+                  <div class="flex items-center font-[500] leading-4.5 gap-2 text-[14px] xl:text-[16px]">
+                    Lever
+                    <p-sortIcon field="display_lever_name"></p-sortIcon>
+                  </div>
+                </th>
+                <th class="!text-[#173F6F]" scope="col" pSortableColumn="lead_center" style="min-width: 200px">
+                  <div class="flex items-center font-[500] leading-4.5 gap-2 text-[14px] xl:text-[16px]">
+                    Lead Center
+                    <p-sortIcon field="lead_center"></p-sortIcon>
+                  </div>
+                </th>
+                <th class="!text-[#173F6F]" scope="col" pSortableColumn="start_date" style="min-width: 120px">
+                  <div class="flex items-center font-[500] leading-4.5 gap-2 text-[14px] xl:text-[16px]">
+                    Start Date
+                    <p-sortIcon field="start_date"></p-sortIcon>
+                  </div>
+                </th>
+                <th class="!text-[#173F6F]" scope="col" pSortableColumn="end_date" style="min-width: 120px">
+                  <div class="flex items-center font-[500] leading-4.5 gap-2 text-[14px] xl:text-[16px]">
+                    End Date
+                    <p-sortIcon field="end_date"></p-sortIcon>
+                  </div>
+                </th>
+              </tr>
+            </ng-template>
+            <ng-template pTemplate="body" let-project>
+              <tr (click)="openProject(project)" (keydown.enter)="openProject(project)"
+                class="cursor-pointer hover:surface-ground transition-colors duration-150 text-[14px] xl:text-[16px]">
+                <td>
+                  <a [routerLink]="['/project-detail', project.agreement_id]" (click)="$event.stopPropagation()"
+                    class="block" style="color: inherit; text-decoration: none">
+                    <div class="overflow-hidden line-clamp-2">
+                      {{ project.agreement_id || '-' }}
+                    </div>
+                  </a>
+                </td>
+                <td>
+                  <a [routerLink]="['/project-detail', project.agreement_id]" (click)="$event.stopPropagation()"
+                    class="block" style="color: inherit; text-decoration: none">
+                    <div class="overflow-hidden line-clamp-2">
+                      {{ project.description }}
+                    </div>
+                  </a>
+                </td>
+                <td>
+                  <a [routerLink]="['/project-detail', project.agreement_id]" (click)="$event.stopPropagation()"
+                    class="block" style="color: inherit; text-decoration: none">
+                    <div class="flex items-center min-h-[40px]">
+                      <app-custom-tag [statusId]="projectUtils.getStatusDisplay(project).statusId"
+                        [statusName]="projectUtils.getStatusDisplay(project).statusName"></app-custom-tag>
+                    </div>
+                  </a>
+                </td>
+                <td>
+                  <a [routerLink]="['/project-detail', project.agreement_id]" (click)="$event.stopPropagation()"
+                    class="block" style="color: inherit; text-decoration: none">
+                    <div class="overflow-hidden line-clamp-2">
+                      {{ project.principal_investigator || project.project_lead_description || '-' }}
+                    </div>
+                  </a>
+                </td>
+                <td>
+                  <a [routerLink]="['/project-detail', project.agreement_id]" (click)="$event.stopPropagation()"
+                    class="block" style="color: inherit; text-decoration: none">
+                    <div class="overflow-hidden line-clamp-2">
+                      {{ projectUtils.getLeverName(project) }}
+                    </div>
+                  </a>
+                </td>
+                <td>
+                  <a [routerLink]="['/project-detail', project.agreement_id]" (click)="$event.stopPropagation()"
+                    class="block" style="color: inherit; text-decoration: none">
+                    {{ project.ubwClientDescription ? (project.ubwClientDescription) : '-' }}
+                  </a>
+                </td>
+                <td>
+                  <a [routerLink]="['/project-detail', project.agreement_id]" (click)="$event.stopPropagation()"
+                    class="block" style="color: inherit; text-decoration: none">
+                    {{ project.start_date ? (project.start_date | date: 'shortDate') : '-' }}
+                  </a>
+                </td>
+                <td>
+                  <a [routerLink]="['/project-detail', project.agreement_id]" (click)="$event.stopPropagation()"
+                    class="block" style="color: inherit; text-decoration: none">
+                    {{ project.end_date ? (project.end_date | date: 'shortDate') : '-' }}
+                  </a>
+                </td>
+              </tr>
+            </ng-template>
+            <ng-template pTemplate="emptymessage">
+              @if (!getLoadingState()) {
+              <tr>
+                <td colspan="7" class="text-center p-8">
+                  <div class="flex flex-col items-center gap-4 bg-surface-ground p-6 rounded-xl">
+                    <div class="flex flex-col items-center gap-1">
+                      <img [src]="'images/landing/projects.png' | s3ImageUrl" alt="Empty Projects"
+                        class="w-[180px] h-[180px] mb-3" />
+                      <h2 class="text-[#173F6F] text-[16px] font-bold">
+                        {{ myProjectsFilterItem()?.id === 'my' ? 'YOUR PROJECTS LIST IS EMPTY' : 'PROJECTS LIST IS
+                        EMPTY' }}
+                      </h2>
+                      <p class="text-[#4C5158] leading-4 text-center text-[14px] max-w-[600px] pt-1">
+                        {{
+                        myProjectsFilterItem()?.id === 'my'
+                        ? "You haven't created any results for your projects yet. Once you start reporting, your
+                        projects will appear here and you will be able to access them easily."
+                        : 'There are currently no projects in the database. New projects will appear here once they are
+                        added to the system.'
+                        }}
+                      </p>
+                    </div>
+                  </div>
+                </td>
+              </tr>
+              }
+            </ng-template>
+          </p-table>
+        </div>
+        }
         }
       </div>
     </div>
   </div>
 </div>
 
-<app-section-sidebar
-  [title]="'Table Filters'"
-  [description]="'Filter your table data by applying custom criteria.'"
-  [showSignal]="this.myProjectsService.showFiltersSidebar"
-  confirmText="Apply filters"
-  (confirm)="applyFilters()">
+<app-section-sidebar [title]="'Table Filters'" [description]="'Filter your table data by applying custom criteria.'"
+  [showSignal]="this.myProjectsService.showFiltersSidebar" confirmText="Apply filters" (confirm)="applyFilters()">
   <div class="body">
     <div class="mb-6">
-      <app-multiselect
-        #statusSelect
-        label="Status"
-        [signal]="this.myProjectsService.tableFilters"
-        optionLabel="name"
-        appendTo="body"
-        optionValue="value"
-        signalOptionValue="statusCodes"
-        serviceName="projectStatus"
-        scrollHeight="140px"
-        placeholder="Select statuses">
+      <app-multiselect #statusSelect label="Status" [signal]="this.myProjectsService.tableFilters" optionLabel="name"
+        appendTo="body" optionValue="value" signalOptionValue="statusCodes" serviceName="projectStatus"
+        scrollHeight="140px" placeholder="Select statuses">
       </app-multiselect>
     </div>
 
     <div class="mb-6">
-      <app-multiselect
-        #leverSelect
-        label="Lever"
-        [signal]="this.myProjectsService.tableFilters"
-        optionLabel="short_name"
-        optionValue="id"
-        signalOptionValue="levers"
-        serviceName="levers"
+      <app-multiselect #leverSelect label="Lever" [signal]="this.myProjectsService.tableFilters"
+        optionLabel="short_name" optionValue="id" signalOptionValue="levers" serviceName="levers"
         placeholder="Select levers">
       </app-multiselect>
     </div>
 
     <div class="mb-6">
-      <app-calendar-input
-        #startDateSelect
-        label="Start Date"
-        [signal]="this.myProjectsService.tableFilters"
-        optionValue="startDate"
-        [dateFormat]="'MM dd/yy'"
-        placeholder="Select start date"
-        appendTo="body">
+      <app-calendar-input #startDateSelect label="Start Date" [signal]="this.myProjectsService.tableFilters"
+        optionValue="startDate" [dateFormat]="'MM dd/yy'" placeholder="Select start date" appendTo="body">
       </app-calendar-input>
     </div>
 
     <div>
-      <app-calendar-input
-        #endDateSelect
-        label="End Date"
-        [signal]="this.myProjectsService.tableFilters"
-        optionValue="endDate"
-        dateFormat="MM dd/yy"
-        appendTo="body"
-        placeholder="Select end date">
+      <app-calendar-input #endDateSelect label="End Date" [signal]="this.myProjectsService.tableFilters"
+        optionValue="endDate" dateFormat="MM dd/yy" appendTo="body" placeholder="Select end date">
       </app-calendar-input>
     </div>
   </div>

--- a/research-indicators/src/app/pages/platform/pages/my-projects/my-projects.component.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/my-projects/my-projects.component.spec.ts
@@ -1145,11 +1145,12 @@ describe('MyProjectsComponent', () => {
       expect(component.myProjectsRows()).toBe(25);
     });
 
-    it('should set first from event for my tab when only page changes', () => {
+    it('should set first from event for my tab when only page changes (aligned to rows grid)', () => {
+      mockMyProjectsService.totalRecords.set(100);
       component.myProjectsFilterItem.set({ id: 'my', label: 'My Projects' });
       component.myProjectsRows.set(10);
-      component.onPageChange({ first: 15, rows: 10 });
-      expect(component.myProjectsFirst()).toBe(15);
+      component.onPageChange({ first: 20, rows: 10 });
+      expect(component.myProjectsFirst()).toBe(20);
       expect(component.myProjectsRows()).toBe(10);
     });
 
@@ -1411,6 +1412,289 @@ describe('MyProjectsComponent', () => {
       expect(mockMyProjectsService.main).toHaveBeenCalledWith(
         expect.objectContaining({ page: 1, limit: 10 })
       );
+    });
+  });
+
+  describe('coverage: view state, scroll helpers, pagination query', () => {
+    it('restoreViewState returns false and clears storage on invalid JSON', () => {
+      sessionStorage.setItem('my-projects-component-state', 'not-json');
+      const warn = jest.spyOn(console, 'warn').mockImplementation();
+      expect((component as any).restoreViewState()).toBe(false);
+      expect(sessionStorage.getItem('my-projects-component-state')).toBeNull();
+      warn.mockRestore();
+    });
+
+    it('getTableScrollContainer returns null when matching node is not HTMLElement', () => {
+      const host = document.createElement('div');
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      svg.setAttribute('class', 'p-datatable-table-container');
+      host.appendChild(svg);
+      (component as any).tableRppScope = { nativeElement: host };
+      expect((component as any).getTableScrollContainer()).toBeNull();
+    });
+
+    it('readActiveTabScrollTop uses table container scrollTop', () => {
+      const tableContainer = document.createElement('div');
+      tableContainer.className = 'p-datatable-table-container';
+      tableContainer.scrollTop = 17;
+      const host = document.createElement('div');
+      host.appendChild(tableContainer);
+      (component as any).tableRppScope = { nativeElement: host };
+      expect((component as any).readActiveTabScrollTop()).toBe(17);
+    });
+
+    it('readStoredScrollPair returns zeros when JSON parse fails', () => {
+      sessionStorage.setItem('my-projects-component-state', 'x');
+      expect((component as any).readStoredScrollPair()).toEqual({ my: 0, all: 0 });
+    });
+
+    it('mergeScrollPositionsForPersist uses live scroll when container exists (my tab)', () => {
+      sessionStorage.setItem(
+        'my-projects-component-state',
+        JSON.stringify({ tableScrollTopMy: 0, tableScrollTopAll: 9 })
+      );
+      const tableContainer = document.createElement('div');
+      tableContainer.className = 'p-datatable-table-container';
+      tableContainer.scrollTop = 21;
+      const host = document.createElement('div');
+      host.appendChild(tableContainer);
+      (component as any).tableRppScope = { nativeElement: host };
+      component.myProjectsFilterItem.set({ id: 'my', label: 'My Projects' });
+      const r = (component as any).mergeScrollPositionsForPersist();
+      expect(r.scrollMy).toBe(21);
+      expect(r.scrollAll).toBe(9);
+    });
+
+    it('mergeScrollPositionsForPersist uses live scroll for all tab and keeps my from storage', () => {
+      sessionStorage.setItem(
+        'my-projects-component-state',
+        JSON.stringify({ tableScrollTopMy: 3, tableScrollTopAll: 0 })
+      );
+      const tableContainer = document.createElement('div');
+      tableContainer.className = 'p-datatable-table-container';
+      tableContainer.scrollTop = 40;
+      const host = document.createElement('div');
+      host.appendChild(tableContainer);
+      (component as any).tableRppScope = { nativeElement: host };
+      component.myProjectsFilterItem.set({ id: 'all', label: 'All Projects' });
+      const r = (component as any).mergeScrollPositionsForPersist();
+      expect(r.scrollMy).toBe(3);
+      expect(r.scrollAll).toBe(40);
+    });
+
+    it('mergeScrollPositionsForPersist without container uses session scroll only', () => {
+      sessionStorage.setItem(
+        'my-projects-component-state',
+        JSON.stringify({ tableScrollTopMy: 2, tableScrollTopAll: 5 })
+      );
+      const host = document.createElement('div');
+      (component as any).tableRppScope = { nativeElement: host };
+      component.myProjectsFilterItem.set({ id: 'my', label: 'My Projects' });
+      const r = (component as any).mergeScrollPositionsForPersist();
+      expect(r.scrollMy).toBe(2);
+      expect(r.scrollAll).toBe(5);
+    });
+
+    it('onActiveItemChange stores scroll for my tab when switching away', () => {
+      jest.spyOn(component as any, 'readActiveTabScrollTop').mockReturnValue(66);
+      component.isTableView.set(true);
+      component.myProjectsFilterItem.set({ id: 'my', label: 'My Projects' });
+      (component as any).onActiveItemChange({ id: 'all', label: 'All Projects' });
+      expect((component as any).tableScrollTopMy).toBe(66);
+    });
+
+    it('onActiveItemChange stores scroll for all tab when switching away', () => {
+      jest.spyOn(component as any, 'readActiveTabScrollTop').mockReturnValue(77);
+      component.isTableView.set(true);
+      component.myProjectsFilterItem.set({ id: 'all', label: 'All Projects' });
+      (component as any).onActiveItemChange({ id: 'my', label: 'My Projects' });
+      expect((component as any).tableScrollTopAll).toBe(77);
+    });
+
+    it('toggleTableView sets pendingScrollRestore when stored top > 0', () => {
+      (component as any).tableScrollTopMy = 4;
+      component.myProjectsFilterItem.set({ id: 'my', label: 'My Projects' });
+      component.isTableView.set(false);
+      component.toggleTableView();
+      expect((component as any).pendingScrollRestore()).toEqual({ top: 4 });
+    });
+
+    it('toggleCardView saves scrollTop for my tab', () => {
+      jest.spyOn(component as any, 'readActiveTabScrollTop').mockReturnValue(11);
+      component.isTableView.set(true);
+      component.myProjectsFilterItem.set({ id: 'my', label: 'My Projects' });
+      component.toggleCardView();
+      expect((component as any).tableScrollTopMy).toBe(11);
+      expect(component.isTableView()).toBe(false);
+    });
+
+    it('toggleCardView saves scrollTop for all tab', () => {
+      jest.spyOn(component as any, 'readActiveTabScrollTop').mockReturnValue(22);
+      component.isTableView.set(true);
+      component.myProjectsFilterItem.set({ id: 'all', label: 'All Projects' });
+      component.toggleCardView();
+      expect((component as any).tableScrollTopAll).toBe(22);
+    });
+
+    it('updatePendingScrollFromStoredTabScroll clears pending when not table view', () => {
+      (component as any).pendingScrollRestore.set({ top: 1 });
+      component.isTableView.set(false);
+      (component as any).updatePendingScrollFromStoredTabScroll();
+      expect((component as any).pendingScrollRestore()).toBeNull();
+    });
+
+    it('updatePendingScrollFromStoredTabScroll sets pending when table view and top > 0', () => {
+      (component as any).tableScrollTopAll = 6;
+      component.isTableView.set(true);
+      component.myProjectsFilterItem.set({ id: 'all', label: 'All Projects' });
+      (component as any).updatePendingScrollFromStoredTabScroll();
+      expect((component as any).pendingScrollRestore()).toEqual({ top: 6 });
+    });
+
+    it('scheduleTableScrollRestore sets scrollTop when container is found', () => {
+      const el = document.createElement('div');
+      jest.spyOn(component as any, 'getTableScrollContainer').mockReturnValue(el);
+      jest.spyOn(globalThis, 'requestAnimationFrame').mockImplementation((cb: FrameRequestCallback) => {
+        cb(0);
+        return 0;
+      });
+      (component as any).scheduleTableScrollRestore(88);
+      expect(el.scrollTop).toBe(88);
+      jest.restoreAllMocks();
+    });
+
+    it('scheduleTableScrollRestore stops after max attempts without container', () => {
+      jest.spyOn(component as any, 'getTableScrollContainer').mockReturnValue(null);
+      const raf = jest.spyOn(globalThis, 'requestAnimationFrame').mockImplementation((cb: FrameRequestCallback) => {
+        cb(0);
+        return 0;
+      });
+      (component as any).scheduleTableScrollRestore(1);
+      expect(raf.mock.calls.length).toBeGreaterThanOrEqual(41);
+      raf.mockRestore();
+      jest.restoreAllMocks();
+    });
+
+    it('scrollRestoreEffect schedules table scroll when loading done and pending is set', async () => {
+      const spy = jest.spyOn(component as any, 'scheduleTableScrollRestore').mockImplementation();
+      mockMyProjectsService.loading.set(false);
+      component.isTableView.set(true);
+      (component as any).pendingScrollRestore.set({ top: 55 });
+      fixture.detectChanges();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(spy).toHaveBeenCalledWith(55);
+      spy.mockRestore();
+    });
+
+    it('loadMyProjectsWithPagination adds query param when query provided', () => {
+      component.myProjectsFirst.set(0);
+      component.myProjectsRows.set(10);
+      (component as any).loadMyProjectsWithPagination('hello');
+      expect(mockMyProjectsService.main).toHaveBeenCalledWith(
+        expect.objectContaining({ query: 'hello', 'current-user': true })
+      );
+    });
+
+    it('loadAllProjectsWithPagination adds query param when query provided', () => {
+      component.allProjectsFirst.set(0);
+      component.allProjectsRows.set(10);
+      (component as any).loadAllProjectsWithPagination('world');
+      expect(mockMyProjectsService.main).toHaveBeenCalledWith(
+        expect.objectContaining({ query: 'world', 'current-user': false })
+      );
+    });
+
+    it('loadCurrentTabState calls loadMyProjectsWithPagination when my tab and no filters/query', () => {
+      mockMyProjectsService.hasFilters.mockReturnValue(false);
+      mockMyProjectsService.myProjectsFilterItem.set({ id: 'my', label: 'My Projects' });
+      component['_searchValue'].set('');
+      jest.clearAllMocks();
+      (component as any).loadCurrentTabState();
+      expect(mockMyProjectsService.main).toHaveBeenCalled();
+      expect(mockMyProjectsService.applyFilters).not.toHaveBeenCalled();
+    });
+
+    it('loadCurrentTabState calls loadAllProjectsWithPagination when all tab and no filters/query', () => {
+      mockMyProjectsService.hasFilters.mockReturnValue(false);
+      mockMyProjectsService.myProjectsFilterItem.set({ id: 'all', label: 'All Projects' });
+      mockMyProjectsService.searchInput.set('');
+      jest.clearAllMocks();
+      (component as any).loadCurrentTabState();
+      expect(mockMyProjectsService.main).toHaveBeenCalledWith(
+        expect.objectContaining({ 'current-user': false })
+      );
+    });
+
+    it('clampProjectsPaginatorFirst treats undefined first as 0 before flooring', () => {
+      mockMyProjectsService.totalRecords.set(100);
+      expect((component as any).clampProjectsPaginatorFirst(undefined as any, 10)).toBe(0);
+    });
+
+    it('initializeState uses myProjectsFilterItems[0] when restored selectedTab is all', async () => {
+      mockMyProjectsService.restorePersistedState.mockReturnValue(false);
+      sessionStorage.setItem(
+        'my-projects-component-state',
+        JSON.stringify({
+          selectedTab: 'all',
+          myProjectsFirst: 0,
+          myProjectsRows: 10,
+          allProjectsFirst: 0,
+          allProjectsRows: 10,
+          isTableView: true,
+          sortField: 'agreement_id',
+          sortOrder: -1
+        })
+      );
+      jest.spyOn(component as any, 'loadPinnedTabPreference').mockResolvedValue('all');
+      jest.spyOn(component as any, 'loadCurrentTabState').mockImplementation();
+
+      await (component as any).initializeState();
+
+      expect(mockMyProjectsService.myProjectsFilterItem()?.id).toBe('all');
+    });
+
+    it('refreshProjectsWithCurrentContext uses undefined sortField when sortField signal is empty', () => {
+      mockMyProjectsService.hasFilters.mockReturnValue(true);
+      component.sortField.set('');
+      component.myProjectsFilterItem.set({ id: 'all', label: 'All Projects' });
+      jest.clearAllMocks();
+      (component as any).refreshProjectsWithCurrentContext();
+      expect(mockMyProjectsService.applyFilters).toHaveBeenCalledWith(
+        expect.objectContaining({ sortField: undefined })
+      );
+    });
+
+    it('loadMyProjectsWithPagination sets direction DESC when sortOrder is not 1', () => {
+      component.sortField.set('agreement_id');
+      component.sortOrder.set(-1);
+      component.myProjectsFirst.set(0);
+      component.myProjectsRows.set(10);
+      jest.clearAllMocks();
+      (component as any).loadMyProjectsWithPagination();
+      expect(mockMyProjectsService.main).toHaveBeenCalledWith(
+        expect.objectContaining({ direction: 'DESC' })
+      );
+    });
+
+    it('loadMyProjectsWithPagination sets direction ASC when sortOrder is 1', () => {
+      component.sortField.set('agreement_id');
+      component.sortOrder.set(1);
+      component.myProjectsFirst.set(0);
+      component.myProjectsRows.set(10);
+      jest.clearAllMocks();
+      (component as any).loadMyProjectsWithPagination();
+      expect(mockMyProjectsService.main).toHaveBeenCalledWith(
+        expect.objectContaining({ direction: 'ASC' })
+      );
+    });
+
+    it('readStoredScrollPair applies defaults when only one scroll key is stored', () => {
+      sessionStorage.setItem('my-projects-component-state', JSON.stringify({ tableScrollTopMy: 8 }));
+      expect((component as any).readStoredScrollPair()).toEqual({ my: 8, all: 0 });
+
+      sessionStorage.setItem('my-projects-component-state', JSON.stringify({ tableScrollTopAll: 9 }));
+      expect((component as any).readStoredScrollPair()).toEqual({ my: 0, all: 9 });
     });
   });
 });

--- a/research-indicators/src/app/pages/platform/pages/my-projects/my-projects.component.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/my-projects/my-projects.component.spec.ts
@@ -872,11 +872,22 @@ describe('MyProjectsComponent', () => {
   });
 
   describe('onAllProjectsPageChange', () => {
-    it('should update allProjectsFirst and allProjectsRows', () => {
+    it('should use event.first when rows are unchanged', () => {
+      component.allProjectsRows.set(40);
+      component.allProjectsFirst.set(10);
       const event = { first: 30, rows: 40 } as any;
       component.onAllProjectsPageChange(event);
       expect(component.allProjectsFirst()).toBe(30);
       expect(component.allProjectsRows()).toBe(40);
+    });
+
+    it('should align first when rows per page changes', () => {
+      component.allProjectsFirst.set(40);
+      component.allProjectsRows.set(10);
+      const event = { first: 0, rows: 25 } as any;
+      component.onAllProjectsPageChange(event);
+      expect(component.allProjectsFirst()).toBe(25);
+      expect(component.allProjectsRows()).toBe(25);
     });
   });
 
@@ -1030,10 +1041,27 @@ describe('MyProjectsComponent', () => {
   });
 
   describe('onPageChange', () => {
-    it('should set first and rows on page change (with values)', () => {
+    it('should align first from anchor when rows per page changes (not use event.first when Prime sends 0)', () => {
+      component.myProjectsFilterItem.set({ id: 'all', label: 'All Projects' });
+      component.allProjectsFirst.set(40);
+      component.allProjectsRows.set(10);
+      component.onPageChange({ first: 0, rows: 25 });
+      expect(component.allProjectsFirst()).toBe(25);
+      expect(component.allProjectsRows()).toBe(25);
+    });
+
+    it('should set first from event when only the page changes (same rows)', () => {
+      component.myProjectsFilterItem.set({ id: 'all', label: 'All Projects' });
+      component.allProjectsRows.set(10);
+      component.onPageChange({ first: 10, rows: 10 });
+      expect(component.allProjectsFirst()).toBe(10);
+      expect(component.allProjectsRows()).toBe(10);
+    });
+
+    it('should set first and rows on page change when rows unchanged from default (first from event)', () => {
       component.myProjectsFilterItem.set({ id: 'all', label: 'All Projects' });
       component.onPageChange({ first: 10, rows: 20 });
-      expect(component.allProjectsFirst()).toBe(10);
+      expect(component.allProjectsFirst()).toBe(0);
       expect(component.allProjectsRows()).toBe(20);
     });
 
@@ -1044,11 +1072,21 @@ describe('MyProjectsComponent', () => {
       expect(component.allProjectsRows()).toBe(10);
     });
 
-    it('should set first and rows for my projects tab with values', () => {
+    it('should align first for my tab when rows per page changes', () => {
       component.myProjectsFilterItem.set({ id: 'my', label: 'My Projects' });
-      component.onPageChange({ first: 15, rows: 25 });
-      expect(component.myProjectsFirst()).toBe(15);
+      component.myProjectsFirst.set(40);
+      component.myProjectsRows.set(10);
+      component.onPageChange({ first: 0, rows: 25 });
+      expect(component.myProjectsFirst()).toBe(25);
       expect(component.myProjectsRows()).toBe(25);
+    });
+
+    it('should set first from event for my tab when only page changes', () => {
+      component.myProjectsFilterItem.set({ id: 'my', label: 'My Projects' });
+      component.myProjectsRows.set(10);
+      component.onPageChange({ first: 15, rows: 10 });
+      expect(component.myProjectsFirst()).toBe(15);
+      expect(component.myProjectsRows()).toBe(10);
     });
 
     it('should set default values for my projects tab when undefined', () => {
@@ -1059,8 +1097,9 @@ describe('MyProjectsComponent', () => {
     });
   });
 
-  describe('onAllProjectsPageChange', () => {
-    it('should update allProjectsFirst and allProjectsRows with values', () => {
+  describe('onAllProjectsPageChange (defaults)', () => {
+    it('should use event.first when rows unchanged with explicit rows', () => {
+      component.allProjectsRows.set(40);
       const event = { first: 30, rows: 40 } as any;
       component.onAllProjectsPageChange(event);
       expect(component.allProjectsFirst()).toBe(30);

--- a/research-indicators/src/app/pages/platform/pages/my-projects/my-projects.component.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/my-projects/my-projects.component.spec.ts
@@ -182,7 +182,9 @@ describe('MyProjectsComponent', () => {
         isTableView: false,
         sortField: 'description',
         sortOrder: 1,
-        selectedTab: 'my'
+        selectedTab: 'my',
+        tableScrollTopMy: 0,
+        tableScrollTopAll: 0
       });
     });
   });
@@ -301,6 +303,31 @@ describe('MyProjectsComponent', () => {
       expect(loadPinnedTabPreferenceSpy).toHaveBeenCalled();
       expect(applyPinnedTabDefaultSpy).toHaveBeenCalledWith('my');
       expect(loadCurrentTabStateSpy).not.toHaveBeenCalled();
+    });
+
+    it('should sync service tab from view state when only component state was restored', async () => {
+      mockMyProjectsService.restorePersistedState.mockReturnValue(false);
+      sessionStorage.setItem(
+        'my-projects-component-state',
+        JSON.stringify({
+          selectedTab: 'my',
+          myProjectsFirst: 20,
+          myProjectsRows: 10,
+          allProjectsFirst: 0,
+          allProjectsRows: 10,
+          isTableView: true,
+          sortField: 'agreement_id',
+          sortOrder: -1
+        })
+      );
+      jest.spyOn(component as any, 'loadPinnedTabPreference').mockResolvedValue('all');
+      const loadCurrentTabStateSpy = jest.spyOn(component as any, 'loadCurrentTabState').mockImplementation();
+
+      await (component as any).initializeState();
+
+      expect(mockMyProjectsService.myProjectsFilterItem()?.id).toBe('my');
+      expect(component.myProjectsFilterItem()?.id).toBe('my');
+      expect(loadCurrentTabStateSpy).toHaveBeenCalled();
     });
   });
 
@@ -538,7 +565,7 @@ describe('MyProjectsComponent', () => {
       expect(component.selectedTab()).toBe('my');
       expect(component.myProjectsFirst()).toBe(0);
       expect(component.searchValue).toBe('');
-      expect(mockMyProjectsService.clearFilters).toHaveBeenCalled();
+      expect(mockMyProjectsService.resetFilters).toHaveBeenCalled();
       expect(component.loadMyProjects).toHaveBeenCalled();
     });
 
@@ -552,7 +579,7 @@ describe('MyProjectsComponent', () => {
       expect(component.selectedTab()).toBe('all');
       expect(component.allProjectsFirst()).toBe(0);
       expect(component.searchValue).toBe('');
-      expect(mockMyProjectsService.clearFilters).toHaveBeenCalled();
+      expect(mockMyProjectsService.resetFilters).toHaveBeenCalled();
       expect(component.loadAllProjects).toHaveBeenCalled();
     });
   });
@@ -1150,6 +1177,19 @@ describe('MyProjectsComponent', () => {
       expect(mockMyProjectsService.applyFilters).toHaveBeenCalledWith(
         expect.objectContaining({ page: 2, limit: 10, query: 'find-me' })
       );
+    });
+
+    it('should not refetch when paginator repeats the same first and rows (avoids duplicate GET_FindContracts)', () => {
+      jest.clearAllMocks();
+      mockMyProjectsService.hasFilters.mockReturnValue(false);
+      component.myProjectsFilterItem.set({ id: 'all', label: 'All Projects' });
+      component.allProjectsFirst.set(0);
+      component.allProjectsRows.set(10);
+
+      component.onPageChange({ first: 0, rows: 10 });
+
+      expect(mockMyProjectsService.applyFilters).not.toHaveBeenCalled();
+      expect(mockMyProjectsService.main).not.toHaveBeenCalled();
     });
   });
 

--- a/research-indicators/src/app/pages/platform/pages/my-projects/my-projects.component.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/my-projects/my-projects.component.spec.ts
@@ -889,6 +889,32 @@ describe('MyProjectsComponent', () => {
       expect(component.allProjectsFirst()).toBe(25);
       expect(component.allProjectsRows()).toBe(25);
     });
+
+    it('should clamp first to maxFirst when aligned index exceeds total records', () => {
+      mockMyProjectsService.totalRecords.set(30);
+      component.allProjectsFirst.set(40);
+      component.allProjectsRows.set(10);
+      jest.spyOn(component as any, 'loadAllProjectsWithPagination').mockImplementation();
+
+      component.onAllProjectsPageChange({ first: 0, rows: 25 });
+
+      // floor(40/25)*25 = 25; maxFirst = max(0, 30 - 25) = 5 → clamp to 5
+      expect(component.allProjectsFirst()).toBe(5);
+      expect(component.allProjectsRows()).toBe(25);
+    });
+
+    it('should use safeRows of 10 when event.rows is 0 (alignFirstAfterRowsChange)', () => {
+      mockMyProjectsService.totalRecords.set(100);
+      component.allProjectsFirst.set(25);
+      component.allProjectsRows.set(10);
+      jest.spyOn(component as any, 'loadAllProjectsWithPagination').mockImplementation();
+
+      component.onAllProjectsPageChange({ first: 0, rows: 0 });
+
+      // newRows 0 → safeRows 10; floor(25/10)*10 = 20
+      expect(component.allProjectsFirst()).toBe(20);
+      expect(component.allProjectsRows()).toBe(0);
+    });
   });
 
   describe('orderedFilterItems', () => {

--- a/research-indicators/src/app/pages/platform/pages/my-projects/my-projects.component.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/my-projects/my-projects.component.spec.ts
@@ -899,12 +899,13 @@ describe('MyProjectsComponent', () => {
   });
 
   describe('onAllProjectsPageChange', () => {
-    it('should use event.first when rows are unchanged', () => {
+    it('should use event.first when rows are unchanged (first must align to rows grid)', () => {
+      mockMyProjectsService.totalRecords.set(120);
       component.allProjectsRows.set(40);
-      component.allProjectsFirst.set(10);
-      const event = { first: 30, rows: 40 } as any;
+      component.allProjectsFirst.set(40);
+      const event = { first: 80, rows: 40 } as any;
       component.onAllProjectsPageChange(event);
-      expect(component.allProjectsFirst()).toBe(30);
+      expect(component.allProjectsFirst()).toBe(80);
       expect(component.allProjectsRows()).toBe(40);
     });
 
@@ -917,7 +918,7 @@ describe('MyProjectsComponent', () => {
       expect(component.allProjectsRows()).toBe(25);
     });
 
-    it('should clamp first to maxFirst when aligned index exceeds total records', () => {
+    it('should clamp first to last standard page when aligned index exceeds total (floor((total-1)/rows)*rows)', () => {
       mockMyProjectsService.totalRecords.set(30);
       component.allProjectsFirst.set(40);
       component.allProjectsRows.set(10);
@@ -925,9 +926,19 @@ describe('MyProjectsComponent', () => {
 
       component.onAllProjectsPageChange({ first: 0, rows: 25 });
 
-      // floor(40/25)*25 = 25; maxFirst = max(0, 30 - 25) = 5 → clamp to 5
-      expect(component.allProjectsFirst()).toBe(5);
+      expect(component.allProjectsFirst()).toBe(25);
       expect(component.allProjectsRows()).toBe(25);
+    });
+
+    it('should clamp same-rows navigation to lastPageFirst for total 33 and rows 10', () => {
+      mockMyProjectsService.totalRecords.set(33);
+      component.allProjectsFirst.set(0);
+      component.allProjectsRows.set(10);
+      jest.spyOn(component as any, 'loadAllProjectsWithPagination').mockImplementation();
+
+      component.onAllProjectsPageChange({ first: 50, rows: 10 });
+
+      expect(component.allProjectsFirst()).toBe(30);
     });
 
     it('should use safeRows of 10 when event.rows is 0 (alignFirstAfterRowsChange)', () => {
@@ -1194,11 +1205,12 @@ describe('MyProjectsComponent', () => {
   });
 
   describe('onAllProjectsPageChange (defaults)', () => {
-    it('should use event.first when rows unchanged with explicit rows', () => {
+    it('should use event.first when rows unchanged with explicit rows (aligned to grid)', () => {
+      mockMyProjectsService.totalRecords.set(120);
       component.allProjectsRows.set(40);
-      const event = { first: 30, rows: 40 } as any;
+      const event = { first: 80, rows: 40 } as any;
       component.onAllProjectsPageChange(event);
-      expect(component.allProjectsFirst()).toBe(30);
+      expect(component.allProjectsFirst()).toBe(80);
       expect(component.allProjectsRows()).toBe(40);
     });
 

--- a/research-indicators/src/app/pages/platform/pages/my-projects/my-projects.component.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/my-projects/my-projects.component.spec.ts
@@ -1121,6 +1121,36 @@ describe('MyProjectsComponent', () => {
       expect(component.myProjectsFirst()).toBe(0);
       expect(component.myProjectsRows()).toBe(10);
     });
+
+    it('should call applyFilters on page change when filters are active (preserves status etc.)', () => {
+      mockMyProjectsService.hasFilters.mockReturnValue(true);
+      component.myProjectsFilterItem.set({ id: 'all', label: 'All Projects' });
+      component.allProjectsFirst.set(20);
+      component.allProjectsRows.set(10);
+      component.sortField.set('agreement_id');
+      component.sortOrder.set(-1);
+
+      component.onPageChange({ first: 30, rows: 10 });
+
+      expect(mockMyProjectsService.applyFilters).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 4, limit: 10, sortField: 'contract-code', sortOrder: -1, query: undefined })
+      );
+      expect(mockMyProjectsService.main).not.toHaveBeenCalled();
+    });
+
+    it('should call applyFilters on page change when search query is set on all tab', () => {
+      mockMyProjectsService.hasFilters.mockReturnValue(false);
+      mockMyProjectsService.searchInput.set('find-me');
+      component.myProjectsFilterItem.set({ id: 'all', label: 'All Projects' });
+      component.allProjectsFirst.set(0);
+      component.allProjectsRows.set(10);
+
+      component.onPageChange({ first: 10, rows: 10 });
+
+      expect(mockMyProjectsService.applyFilters).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 2, limit: 10, query: 'find-me' })
+      );
+    });
   });
 
   describe('onAllProjectsPageChange (defaults)', () => {
@@ -1141,7 +1171,8 @@ describe('MyProjectsComponent', () => {
   });
 
   describe('onSort', () => {
-    it('should set sort, reset first and call loadMyProjectsWithPagination when on my tab', () => {
+    it('should set sort, reset first and call applyFilters when on my tab with search query', () => {
+      mockMyProjectsService.hasFilters.mockReturnValue(false);
       component.myProjectsFilterItem.set({ id: 'my', label: 'My Projects' });
       component['_searchValue'].set('my-query');
       component.myProjectsFirst.set(10);
@@ -1152,20 +1183,21 @@ describe('MyProjectsComponent', () => {
       expect(component.sortField()).toBe('description');
       expect(component.sortOrder()).toBe(1);
       expect(component.myProjectsFirst()).toBe(0);
-      expect(mockMyProjectsService.main).toHaveBeenCalledWith(
-        expect.objectContaining({ 'current-user': true, page: 1, query: 'my-query', 'order-field': 'project-name', direction: 'ASC' })
+      expect(mockMyProjectsService.applyFilters).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 1, limit: 10, query: 'my-query', sortField: 'project-name', sortOrder: 1 })
       );
     });
 
-    it('should call loadAllProjectsWithPagination when on all tab', () => {
+    it('should call applyFilters when on all tab with search query', () => {
+      mockMyProjectsService.hasFilters.mockReturnValue(false);
       component.myProjectsFilterItem.set({ id: 'all', label: 'All Projects' });
       mockMyProjectsService.searchInput.set('all-query');
 
       component.onSort({ field: 'agreement_id', order: -1 });
 
       expect(component.allProjectsFirst()).toBe(0);
-      expect(mockMyProjectsService.main).toHaveBeenCalledWith(
-        expect.objectContaining({ 'current-user': false, 'order-field': 'contract-code', direction: 'DESC' })
+      expect(mockMyProjectsService.applyFilters).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 1, limit: 10, query: 'all-query', sortField: 'contract-code', sortOrder: -1 })
       );
     });
 

--- a/research-indicators/src/app/pages/platform/pages/my-projects/my-projects.component.ts
+++ b/research-indicators/src/app/pages/platform/pages/my-projects/my-projects.component.ts
@@ -239,7 +239,10 @@ export default class MyProjectsComponent implements OnInit, AfterViewInit, OnDes
     if (this.myProjectsFilterItem()?.id === 'my') {
       const previousFirst = this.myProjectsFirst();
       const previousRows = this.myProjectsRows();
-      const nextFirst = previousRows === newRows ? (event.first ?? 0) : this.alignFirstAfterRowsChange(previousFirst, newRows);
+      const nextFirst =
+        previousRows === newRows
+          ? this.clampProjectsPaginatorFirst(event.first ?? 0, newRows)
+          : this.alignFirstAfterRowsChange(previousFirst, newRows);
       if (nextFirst === previousFirst && newRows === previousRows) {
         return;
       }
@@ -249,7 +252,10 @@ export default class MyProjectsComponent implements OnInit, AfterViewInit, OnDes
     } else {
       const previousFirst = this.allProjectsFirst();
       const previousRows = this.allProjectsRows();
-      const nextFirst = previousRows === newRows ? (event.first ?? 0) : this.alignFirstAfterRowsChange(previousFirst, newRows);
+      const nextFirst =
+        previousRows === newRows
+          ? this.clampProjectsPaginatorFirst(event.first ?? 0, newRows)
+          : this.alignFirstAfterRowsChange(previousFirst, newRows);
       if (nextFirst === previousFirst && newRows === previousRows) {
         return;
       }
@@ -263,7 +269,10 @@ export default class MyProjectsComponent implements OnInit, AfterViewInit, OnDes
     const newRows = event.rows ?? 10;
     const previousFirst = this.allProjectsFirst();
     const previousRows = this.allProjectsRows();
-    const nextFirst = previousRows === newRows ? (event.first ?? 0) : this.alignFirstAfterRowsChange(previousFirst, newRows);
+    const nextFirst =
+      previousRows === newRows
+        ? this.clampProjectsPaginatorFirst(event.first ?? 0, newRows)
+        : this.alignFirstAfterRowsChange(previousFirst, newRows);
     if (nextFirst === previousFirst && newRows === previousRows) {
       return;
     }
@@ -272,17 +281,23 @@ export default class MyProjectsComponent implements OnInit, AfterViewInit, OnDes
     this.refreshProjectsWithCurrentContext();
   }
 
-  private alignFirstAfterRowsChange(anchorFirst: number, newRows: number): number {
-    const safeRows = newRows > 0 ? newRows : 10;
-    let newFirst = Math.floor(anchorFirst / safeRows) * safeRows;
+  private clampProjectsPaginatorFirst(first: number, rows: number): number {
+    const safeRows = rows > 0 ? rows : 10;
     const total = this.myProjectsService.totalRecords();
+    let f = Math.floor((first ?? 0) / safeRows) * safeRows;
     if (total > 0) {
-      const maxFirst = Math.max(0, total - safeRows);
-      if (newFirst > maxFirst) {
-        newFirst = maxFirst;
+      const lastPageFirst = Math.max(0, Math.floor((total - 1) / safeRows) * safeRows);
+      if (f > lastPageFirst) {
+        f = lastPageFirst;
       }
     }
-    return newFirst;
+    return Math.max(0, f);
+  }
+
+  private alignFirstAfterRowsChange(anchorFirst: number, newRows: number): number {
+    const safeRows = newRows > 0 ? newRows : 10;
+    const candidate = Math.floor(anchorFirst / safeRows) * safeRows;
+    return this.clampProjectsPaginatorFirst(candidate, newRows);
   }
 
   ngOnInit(): void {

--- a/research-indicators/src/app/pages/platform/pages/my-projects/my-projects.component.ts
+++ b/research-indicators/src/app/pages/platform/pages/my-projects/my-projects.component.ts
@@ -200,14 +200,14 @@ export default class MyProjectsComponent implements OnInit, AfterViewInit, OnDes
       const nextFirst = previousRows === newRows ? (event.first ?? 0) : this.alignFirstAfterRowsChange(previousFirst, newRows);
       this.myProjectsFirst.set(nextFirst);
       this.myProjectsRows.set(newRows);
-      this.loadMyProjectsWithPagination();
+      this.refreshProjectsWithCurrentContext();
     } else {
       const previousFirst = this.allProjectsFirst();
       const previousRows = this.allProjectsRows();
       const nextFirst = previousRows === newRows ? (event.first ?? 0) : this.alignFirstAfterRowsChange(previousFirst, newRows);
       this.allProjectsFirst.set(nextFirst);
       this.allProjectsRows.set(newRows);
-      this.loadAllProjectsWithPagination();
+      this.refreshProjectsWithCurrentContext();
     }
   }
 
@@ -218,7 +218,7 @@ export default class MyProjectsComponent implements OnInit, AfterViewInit, OnDes
     const nextFirst = previousRows === newRows ? (event.first ?? 0) : this.alignFirstAfterRowsChange(previousFirst, newRows);
     this.allProjectsFirst.set(nextFirst);
     this.allProjectsRows.set(newRows);
-    this.loadAllProjectsWithPagination();
+    this.refreshProjectsWithCurrentContext();
   }
 
   private alignFirstAfterRowsChange(anchorFirst: number, newRows: number): number {
@@ -549,15 +549,12 @@ export default class MyProjectsComponent implements OnInit, AfterViewInit, OnDes
     this.sortField.set(event.field);
     this.sortOrder.set(event.order);
 
-    const currentQuery = this.myProjectsFilterItem()?.id === 'my' ? this._searchValue() : this.myProjectsService.searchInput();
-
     if (this.myProjectsFilterItem()?.id === 'my') {
       this.myProjectsFirst.set(0);
-      this.loadMyProjectsWithPagination(currentQuery || undefined);
     } else {
       this.allProjectsFirst.set(0);
-      this.loadAllProjectsWithPagination(currentQuery || undefined);
     }
+    this.refreshProjectsWithCurrentContext();
   }
 
   applyFilters(): void {
@@ -591,6 +588,36 @@ export default class MyProjectsComponent implements OnInit, AfterViewInit, OnDes
 
   private getCurrentLimit(): number {
     return this.myProjectsFilterItem()?.id === 'my' ? this.myProjectsRows() : this.allProjectsRows();
+  }
+
+  /**
+   * After page/rows/sort change: reload via applyFilters when sidebar filters or backend search are active,
+   * otherwise use main() with pagination only (load*WithPagination).
+   */
+  private refreshProjectsWithCurrentContext(): void {
+    const currentQuery = this.myProjectsFilterItem()?.id === 'my' ? this._searchValue() : this.myProjectsService.searchInput();
+    const page = this.getCurrentPage();
+    const limit = this.getCurrentLimit();
+    const tableField = this.sortField();
+    const sortOrder = this.sortOrder();
+    const apiField = tableField ? this.mapTableFieldToApiField(tableField) : undefined;
+
+    if (this.myProjectsService.hasFilters() || !!currentQuery) {
+      this.myProjectsService.applyFilters({
+        page,
+        limit,
+        sortField: apiField,
+        sortOrder,
+        query: currentQuery || undefined
+      });
+      return;
+    }
+
+    if (this.myProjectsFilterItem()?.id === 'my') {
+      this.loadMyProjectsWithPagination();
+    } else {
+      this.loadAllProjectsWithPagination();
+    }
   }
 
   private loadMyProjectsWithPagination(query?: string) {

--- a/research-indicators/src/app/pages/platform/pages/my-projects/my-projects.component.ts
+++ b/research-indicators/src/app/pages/platform/pages/my-projects/my-projects.component.ts
@@ -1,4 +1,15 @@
-import { Component, computed, effect, inject, signal, ViewChild, OnInit, AfterViewInit, OnDestroy } from '@angular/core';
+import {
+  Component,
+  computed,
+  effect,
+  ElementRef,
+  inject,
+  signal,
+  ViewChild,
+  OnInit,
+  AfterViewInit,
+  OnDestroy
+} from '@angular/core';
 import { Router, RouterLink } from '@angular/router';
 import { ApiService } from '@shared/services/api.service';
 import { FormsModule } from '@angular/forms';
@@ -61,6 +72,10 @@ export default class MyProjectsComponent implements OnInit, AfterViewInit, OnDes
   private readonly serviceStateKey = 'my-projects';
   private readonly viewStateKey = 'my-projects-component-state';
   private readonly persistViewStateEnabled = signal(false);
+  private readonly pendingScrollRestore = signal<{ top: number } | null>(null);
+  /** Vertical scroll for the contracts table, per tab (session restore / card toggle). */
+  private tableScrollTopMy = 0;
+  private tableScrollTopAll = 0;
   private restoredState = false;
   api = inject(ApiService);
   myProjectsService = inject(MyProjectsService);
@@ -89,6 +104,7 @@ export default class MyProjectsComponent implements OnInit, AfterViewInit, OnDes
 
   @ViewChild('statusSelect') statusSelect?: MultiselectComponent;
   @ViewChild('leverSelect') leverSelect?: MultiselectComponent;
+  @ViewChild('tableRppScope') tableRppScope?: ElementRef<HTMLElement>;
 
   myProjectsFilterItems: MenuItem[] = [
     {
@@ -106,21 +122,47 @@ export default class MyProjectsComponent implements OnInit, AfterViewInit, OnDes
       return;
     }
 
+    const allProjectsFirst = this.allProjectsFirst();
+    const allProjectsRows = this.allProjectsRows();
+    const myProjectsFirst = this.myProjectsFirst();
+    const myProjectsRows = this.myProjectsRows();
+    const searchValue = this._searchValue();
+    const isQuerySentToBackend = this._isQuerySentToBackend();
+    const isTableView = this.isTableView();
+    const sortField = this.sortField();
+    const sortOrder = this.sortOrder();
+    const selectedTab = this.selectedTab();
+
+    const { scrollMy, scrollAll } = this.mergeScrollPositionsForPersist();
+
     globalThis.sessionStorage?.setItem(
       this.viewStateKey,
       JSON.stringify({
-        allProjectsFirst: this.allProjectsFirst(),
-        allProjectsRows: this.allProjectsRows(),
-        myProjectsFirst: this.myProjectsFirst(),
-        myProjectsRows: this.myProjectsRows(),
-        searchValue: this._searchValue(),
-        isQuerySentToBackend: this._isQuerySentToBackend(),
-        isTableView: this.isTableView(),
-        sortField: this.sortField(),
-        sortOrder: this.sortOrder(),
-        selectedTab: this.selectedTab()
+        allProjectsFirst,
+        allProjectsRows,
+        myProjectsFirst,
+        myProjectsRows,
+        searchValue,
+        isQuerySentToBackend,
+        isTableView,
+        sortField,
+        sortOrder,
+        selectedTab,
+        tableScrollTopMy: scrollMy,
+        tableScrollTopAll: scrollAll
       })
     );
+  });
+
+  private readonly scrollRestoreEffect = effect(() => {
+    const loading = this.myProjectsService.loading();
+    const isTable = this.isTableView();
+    const pending = this.pendingScrollRestore();
+    if (loading || !isTable || pending == null) {
+      return;
+    }
+
+    this.scheduleTableScrollRestore(pending.top);
   });
 
   //pinned tab filter items
@@ -198,6 +240,9 @@ export default class MyProjectsComponent implements OnInit, AfterViewInit, OnDes
       const previousFirst = this.myProjectsFirst();
       const previousRows = this.myProjectsRows();
       const nextFirst = previousRows === newRows ? (event.first ?? 0) : this.alignFirstAfterRowsChange(previousFirst, newRows);
+      if (nextFirst === previousFirst && newRows === previousRows) {
+        return;
+      }
       this.myProjectsFirst.set(nextFirst);
       this.myProjectsRows.set(newRows);
       this.refreshProjectsWithCurrentContext();
@@ -205,6 +250,9 @@ export default class MyProjectsComponent implements OnInit, AfterViewInit, OnDes
       const previousFirst = this.allProjectsFirst();
       const previousRows = this.allProjectsRows();
       const nextFirst = previousRows === newRows ? (event.first ?? 0) : this.alignFirstAfterRowsChange(previousFirst, newRows);
+      if (nextFirst === previousFirst && newRows === previousRows) {
+        return;
+      }
       this.allProjectsFirst.set(nextFirst);
       this.allProjectsRows.set(newRows);
       this.refreshProjectsWithCurrentContext();
@@ -216,6 +264,9 @@ export default class MyProjectsComponent implements OnInit, AfterViewInit, OnDes
     const previousFirst = this.allProjectsFirst();
     const previousRows = this.allProjectsRows();
     const nextFirst = previousRows === newRows ? (event.first ?? 0) : this.alignFirstAfterRowsChange(previousFirst, newRows);
+    if (nextFirst === previousFirst && newRows === previousRows) {
+      return;
+    }
     this.allProjectsFirst.set(nextFirst);
     this.allProjectsRows.set(newRows);
     this.refreshProjectsWithCurrentContext();
@@ -254,6 +305,7 @@ export default class MyProjectsComponent implements OnInit, AfterViewInit, OnDes
   }
 
   ngOnDestroy(): void {
+    this.persistViewStateSnapshot();
     this.persistViewStateEnabled.set(false);
     this.myProjectsService.deactivateStatePersistence(this.serviceStateKey);
     this.myProjectsService.showFiltersSidebar.set(false);
@@ -262,6 +314,12 @@ export default class MyProjectsComponent implements OnInit, AfterViewInit, OnDes
   private async initializeState(): Promise<void> {
     const restoredServiceState = this.myProjectsService.restorePersistedState(this.serviceStateKey);
     const restoredViewState = this.restoreViewState();
+
+    if (restoredViewState && !restoredServiceState) {
+      const item =
+        this.selectedTab() === 'my' ? this.myProjectsFilterItems[1] : this.myProjectsFilterItems[0];
+      this.myProjectsService.myProjectsFilterItem.set(item);
+    }
 
     this.restoredState = restoredServiceState || restoredViewState;
     this.myProjectsService.activateStatePersistence(this.serviceStateKey);
@@ -273,6 +331,7 @@ export default class MyProjectsComponent implements OnInit, AfterViewInit, OnDes
       const activeTab = this.myProjectsService.myProjectsFilterItem() ?? this.myProjectsFilterItems[0];
       this.myProjectsFilterItem.set(activeTab);
       this.selectedTab.set(activeTab.id === 'my' ? 'my' : 'all');
+      this.updatePendingScrollFromStoredTabScroll();
       this.loadCurrentTabState();
       return;
     }
@@ -361,17 +420,30 @@ export default class MyProjectsComponent implements OnInit, AfterViewInit, OnDes
   }
 
   onActiveItemChange = (event: MenuItem): void => {
+    if (this.isTableView()) {
+      const top = this.readActiveTabScrollTop();
+      const prevId = this.myProjectsFilterItem()?.id;
+      if (prevId === 'my') {
+        this.tableScrollTopMy = top;
+      } else if (prevId === 'all') {
+        this.tableScrollTopAll = top;
+      }
+    }
+    this.pendingScrollRestore.set(null);
+
     this.myProjectsFilterItem.set(event);
     this.myProjectsService.myProjectsFilterItem.set(event);
 
-    this.myProjectsService.clearFilters();
+    this.myProjectsService.resetFilters();
     this._searchValue.set('');
 
     if (event.id === 'my') {
+      this.tableScrollTopMy = 0;
       this.myProjectsFirst.set(0);
       this.selectedTab.set('my');
       this.loadMyProjects();
     } else {
+      this.tableScrollTopAll = 0;
       this.allProjectsFirst.set(0);
       this.selectedTab.set('all');
       this.loadAllProjects();
@@ -476,10 +548,24 @@ export default class MyProjectsComponent implements OnInit, AfterViewInit, OnDes
   }
 
   toggleTableView() {
+    const tab = this.myProjectsFilterItem()?.id === 'my' ? 'my' : 'all';
+    const top = tab === 'my' ? this.tableScrollTopMy : this.tableScrollTopAll;
     this.isTableView.set(true);
+    if (top > 0) {
+      this.pendingScrollRestore.set({ top });
+    }
   }
 
   toggleCardView() {
+    if (this.isTableView()) {
+      const top = this.readActiveTabScrollTop();
+      const tab = this.myProjectsFilterItem()?.id === 'my' ? 'my' : 'all';
+      if (tab === 'my') {
+        this.tableScrollTopMy = top;
+      } else {
+        this.tableScrollTopAll = top;
+      }
+    }
     this.isTableView.set(false);
   }
 
@@ -704,6 +790,8 @@ export default class MyProjectsComponent implements OnInit, AfterViewInit, OnDes
         sortField: string;
         sortOrder: number;
         selectedTab: string;
+        tableScrollTopMy: number;
+        tableScrollTopAll: number;
       }>;
 
       this.allProjectsFirst.set(state.allProjectsFirst ?? 0);
@@ -716,6 +804,8 @@ export default class MyProjectsComponent implements OnInit, AfterViewInit, OnDes
       this.sortField.set(state.sortField ?? 'agreement_id');
       this.sortOrder.set(state.sortOrder ?? -1);
       this.selectedTab.set(state.selectedTab === 'my' ? 'my' : 'all');
+      this.tableScrollTopMy = Number(state.tableScrollTopMy ?? 0);
+      this.tableScrollTopAll = Number(state.tableScrollTopAll ?? 0);
 
       return true;
     } catch (error) {
@@ -723,6 +813,106 @@ export default class MyProjectsComponent implements OnInit, AfterViewInit, OnDes
       globalThis.sessionStorage?.removeItem(this.viewStateKey);
       return false;
     }
+  }
+
+  private getTableScrollContainer(): HTMLElement | null {
+    const host = this.tableRppScope?.nativeElement;
+    if (!host) {
+      return null;
+    }
+    const el = host.querySelector('.p-datatable-table-container');
+    return el instanceof HTMLElement ? el : null;
+  }
+
+  private readActiveTabScrollTop(): number {
+    return this.getTableScrollContainer()?.scrollTop ?? 0;
+  }
+
+  private readStoredScrollPair(): { my: number; all: number } {
+    try {
+      const raw = globalThis.sessionStorage?.getItem(this.viewStateKey);
+      if (!raw) {
+        return { my: 0, all: 0 };
+      }
+      const p = JSON.parse(raw) as Record<string, unknown>;
+      return {
+        my: Number(p['tableScrollTopMy'] ?? 0),
+        all: Number(p['tableScrollTopAll'] ?? 0)
+      };
+    } catch {
+      return { my: 0, all: 0 };
+    }
+  }
+
+  private mergeScrollPositionsForPersist(): { scrollMy: number; scrollAll: number } {
+    const existing = this.readStoredScrollPair();
+    const tab = this.myProjectsFilterItem()?.id === 'my' ? 'my' : 'all';
+    const container = this.getTableScrollContainer();
+    let scrollMy: number;
+    let scrollAll: number;
+    if (container) {
+      const currentScroll = container.scrollTop;
+      if (tab === 'my') {
+        scrollMy = currentScroll;
+        scrollAll = existing.all;
+      } else {
+        scrollMy = existing.my;
+        scrollAll = currentScroll;
+      }
+    } else {
+      scrollMy = existing.my;
+      scrollAll = existing.all;
+    }
+    this.tableScrollTopMy = scrollMy;
+    this.tableScrollTopAll = scrollAll;
+    return { scrollMy, scrollAll };
+  }
+
+  private persistViewStateSnapshot(): void {
+    const { scrollMy, scrollAll } = this.mergeScrollPositionsForPersist();
+    globalThis.sessionStorage?.setItem(
+      this.viewStateKey,
+      JSON.stringify({
+        allProjectsFirst: this.allProjectsFirst(),
+        allProjectsRows: this.allProjectsRows(),
+        myProjectsFirst: this.myProjectsFirst(),
+        myProjectsRows: this.myProjectsRows(),
+        searchValue: this._searchValue(),
+        isQuerySentToBackend: this._isQuerySentToBackend(),
+        isTableView: this.isTableView(),
+        sortField: this.sortField(),
+        sortOrder: this.sortOrder(),
+        selectedTab: this.selectedTab(),
+        tableScrollTopMy: scrollMy,
+        tableScrollTopAll: scrollAll
+      })
+    );
+  }
+
+  private updatePendingScrollFromStoredTabScroll(): void {
+    if (!this.isTableView()) {
+      this.pendingScrollRestore.set(null);
+      return;
+    }
+    const tab = this.myProjectsFilterItem()?.id === 'my' ? 'my' : 'all';
+    const top = tab === 'my' ? this.tableScrollTopMy : this.tableScrollTopAll;
+    this.pendingScrollRestore.set(top > 0 ? { top } : null);
+  }
+
+  private scheduleTableScrollRestore(top: number): void {
+    this.pendingScrollRestore.set(null);
+    let attempts = 0;
+    const run = (): void => {
+      const el = this.getTableScrollContainer();
+      if (el) {
+        el.scrollTop = top;
+        return;
+      }
+      if (attempts++ < 40) {
+        requestAnimationFrame(run);
+      }
+    };
+    requestAnimationFrame(run);
   }
 
   private loadCurrentTabState(): void {

--- a/research-indicators/src/app/pages/platform/pages/my-projects/my-projects.component.ts
+++ b/research-indicators/src/app/pages/platform/pages/my-projects/my-projects.component.ts
@@ -329,10 +329,16 @@ export default class MyProjectsComponent implements OnInit, AfterViewInit, OnDes
       if (newPinnedTab === 'all') {
         this.myProjectsFilterItem.set(this.myProjectsFilterItems[0]);
         this.myProjectsService.myProjectsFilterItem.set(this.myProjectsFilterItems[0]);
+        this.selectedTab.set('all');
+        this.allProjectsFirst.set(0);
       } else {
         this.myProjectsFilterItem.set(this.myProjectsFilterItems[1]);
         this.myProjectsService.myProjectsFilterItem.set(this.myProjectsFilterItems[1]);
+        this.selectedTab.set('my');
+        this.myProjectsFirst.set(0);
       }
+
+      this.refreshProjectsWithCurrentContext();
 
       setTimeout(() => {
         this.myProjectsService.cleanMultiselects();

--- a/research-indicators/src/app/pages/platform/pages/my-projects/my-projects.component.ts
+++ b/research-indicators/src/app/pages/platform/pages/my-projects/my-projects.component.ts
@@ -165,11 +165,11 @@ export default class MyProjectsComponent implements OnInit, AfterViewInit, OnDes
 
   filteredProjects = computed(() => {
     const projects = this.myProjectsService.list();
-    
+
     if (this.myProjectsService.hasFilters() || this._isQuerySentToBackend()) {
       return projects;
     }
-    
+
     const searchTerm =
       this.myProjectsFilterItem()?.id === 'my' ? this._searchValue().toLowerCase() : this.myProjectsService.searchInput().toLowerCase();
 
@@ -193,21 +193,45 @@ export default class MyProjectsComponent implements OnInit, AfterViewInit, OnDes
   });
 
   onPageChange(event: PaginatorState) {
+    const newRows = event.rows ?? 10;
     if (this.myProjectsFilterItem()?.id === 'my') {
-      this.myProjectsFirst.set(event.first ?? 0);
-      this.myProjectsRows.set(event.rows ?? 10);
+      const previousFirst = this.myProjectsFirst();
+      const previousRows = this.myProjectsRows();
+      const nextFirst = previousRows === newRows ? (event.first ?? 0) : this.alignFirstAfterRowsChange(previousFirst, newRows);
+      this.myProjectsFirst.set(nextFirst);
+      this.myProjectsRows.set(newRows);
       this.loadMyProjectsWithPagination();
     } else {
-      this.allProjectsFirst.set(event.first ?? 0);
-      this.allProjectsRows.set(event.rows ?? 10);
+      const previousFirst = this.allProjectsFirst();
+      const previousRows = this.allProjectsRows();
+      const nextFirst = previousRows === newRows ? (event.first ?? 0) : this.alignFirstAfterRowsChange(previousFirst, newRows);
+      this.allProjectsFirst.set(nextFirst);
+      this.allProjectsRows.set(newRows);
       this.loadAllProjectsWithPagination();
     }
   }
 
   onAllProjectsPageChange(event: PaginatorState) {
-    this.allProjectsFirst.set(event.first ?? 0);
-    this.allProjectsRows.set(event.rows ?? 10);
+    const newRows = event.rows ?? 10;
+    const previousFirst = this.allProjectsFirst();
+    const previousRows = this.allProjectsRows();
+    const nextFirst = previousRows === newRows ? (event.first ?? 0) : this.alignFirstAfterRowsChange(previousFirst, newRows);
+    this.allProjectsFirst.set(nextFirst);
+    this.allProjectsRows.set(newRows);
     this.loadAllProjectsWithPagination();
+  }
+
+  private alignFirstAfterRowsChange(anchorFirst: number, newRows: number): number {
+    const safeRows = newRows > 0 ? newRows : 10;
+    let newFirst = Math.floor(anchorFirst / safeRows) * safeRows;
+    const total = this.myProjectsService.totalRecords();
+    if (total > 0) {
+      const maxFirst = Math.max(0, total - safeRows);
+      if (newFirst > maxFirst) {
+        newFirst = maxFirst;
+      }
+    }
+    return newFirst;
   }
 
   ngOnInit(): void {
@@ -379,7 +403,7 @@ export default class MyProjectsComponent implements OnInit, AfterViewInit, OnDes
 
   setSearchInputFilter(query: string) {
     this._isQuerySentToBackend.set(query.length > 0);
-    
+
     if (this.myProjectsFilterItem()?.id === 'my') {
       this._searchValue.set(query);
       this.myProjectsFirst.set(0);
@@ -387,16 +411,16 @@ export default class MyProjectsComponent implements OnInit, AfterViewInit, OnDes
       this.myProjectsService.searchInput.set(query);
       this.allProjectsFirst.set(0);
     }
-    
+
     const limit = this.getCurrentLimit();
     const tableField = this.sortField();
     const sortOrder = this.sortOrder();
     const apiField = tableField ? this.mapTableFieldToApiField(tableField) : undefined;
-    
-    this.myProjectsService.applyFilters({ 
+
+    this.myProjectsService.applyFilters({
       page: 1, // Reset to first page when searching
-      limit, 
-      sortField: apiField, 
+      limit,
+      sortField: apiField,
       sortOrder,
       query: query || undefined
     });
@@ -408,21 +432,19 @@ export default class MyProjectsComponent implements OnInit, AfterViewInit, OnDes
 
   handleRemoveFilter(label: string, id?: string | number): void {
     this.myProjectsService.removeFilter(label, id);
-    
-    const currentQuery = this.myProjectsFilterItem()?.id === 'my' 
-      ? this._searchValue() 
-      : this.myProjectsService.searchInput();
-    
+
+    const currentQuery = this.myProjectsFilterItem()?.id === 'my' ? this._searchValue() : this.myProjectsService.searchInput();
+
     const page = this.getCurrentPage();
     const limit = this.getCurrentLimit();
     const tableField = this.sortField();
     const sortOrder = this.sortOrder();
     const apiField = tableField ? this.mapTableFieldToApiField(tableField) : undefined;
-    
-    this.myProjectsService.applyFilters({ 
-      page, 
-      limit, 
-      sortField: apiField, 
+
+    this.myProjectsService.applyFilters({
+      page,
+      limit,
+      sortField: apiField,
       sortOrder,
       query: currentQuery || undefined
     });
@@ -511,14 +533,14 @@ export default class MyProjectsComponent implements OnInit, AfterViewInit, OnDes
 
   private mapTableFieldToApiField(tableField: string): string {
     const fieldMapping: Record<string, string> = {
-      'agreement_id': 'contract-code',
-      'description': 'project-name',
-      'contract_status': 'status',
-      'display_principal_investigator': 'principal-investigator',
-      'display_lever_name': 'lever',
-      'lead_center': 'lead-center',
-      'start_date': 'start-date',
-      'end_date': 'end-date'
+      agreement_id: 'contract-code',
+      description: 'project-name',
+      contract_status: 'status',
+      display_principal_investigator: 'principal-investigator',
+      display_lever_name: 'lever',
+      lead_center: 'lead-center',
+      start_date: 'start-date',
+      end_date: 'end-date'
     };
     return fieldMapping[tableField] || tableField;
   }
@@ -526,11 +548,9 @@ export default class MyProjectsComponent implements OnInit, AfterViewInit, OnDes
   onSort(event: { field: string; order: number }): void {
     this.sortField.set(event.field);
     this.sortOrder.set(event.order);
-    
-    const currentQuery = this.myProjectsFilterItem()?.id === 'my' 
-      ? this._searchValue() 
-      : this.myProjectsService.searchInput();
-    
+
+    const currentQuery = this.myProjectsFilterItem()?.id === 'my' ? this._searchValue() : this.myProjectsService.searchInput();
+
     if (this.myProjectsFilterItem()?.id === 'my') {
       this.myProjectsFirst.set(0);
       this.loadMyProjectsWithPagination(currentQuery || undefined);
@@ -546,20 +566,18 @@ export default class MyProjectsComponent implements OnInit, AfterViewInit, OnDes
     const tableField = this.sortField();
     const sortOrder = this.sortOrder();
     const apiField = tableField ? this.mapTableFieldToApiField(tableField) : undefined;
-    
+
     // Get current search query to preserve it when applying filters
-    const currentQuery = this.myProjectsFilterItem()?.id === 'my' 
-      ? this._searchValue() 
-      : this.myProjectsService.searchInput();
-    
+    const currentQuery = this.myProjectsFilterItem()?.id === 'my' ? this._searchValue() : this.myProjectsService.searchInput();
+
     if (currentQuery) {
       this._isQuerySentToBackend.set(true);
     }
-    
-    this.myProjectsService.applyFilters({ 
-      page, 
-      limit, 
-      sortField: apiField, 
+
+    this.myProjectsService.applyFilters({
+      page,
+      limit,
+      sortField: apiField,
       sortOrder,
       query: currentQuery || undefined
     });

--- a/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/alliance-alignment.component.html
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/alliance-alignment.component.html
@@ -135,8 +135,8 @@
               <ng-template #rows let-lever>
                 <app-alliance-lever-card [lever]="lever" [sdgSignal]="getLeverSdgSignal(lever)"
                   [outcomeSignal]="getLeverSignal(lever)"
-                  [showStrategicOutcomes]="cache.currentMetadata()?.indicator_id === 5"
-                  [strategicOutcomesRequired]="cache.currentMetadata()?.indicator_id === 5" [sdgTargetsRequired]="true"
+                  [showStrategicOutcomes]="cache.currentMetadata().indicator_id === 5"
+                  [strategicOutcomesRequired]="cache.currentMetadata().indicator_id === 5" [sdgTargetsRequired]="true"
                   [removeLocked]="isLeverRequiredFromContributingProject(lever)"
                   [disabled]="!submission.isEditableStatus()" (removeLever)="removePrimaryLever(lever)" />
               </ng-template>

--- a/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/alliance-alignment.component.html
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/alliance-alignment.component.html
@@ -126,7 +126,7 @@
                 }
               </ng-template>
               <ng-template #item let-item>
-                <div class="flex items-center gap-2 text-[##4C5158]">
+                <div class="flex items-center gap-2 text-[#4C5158]">
                   <span class="font-[600]">
                     {{ item?.short_name }}: <span class="font-['Barlow'] font-normal">{{ item?.other_names
                       }}</span></span>
@@ -157,7 +157,7 @@
               </ng-template>
               <ng-template #item let-item>
                 <div class="flex items-center gap-2">
-                  <span class="font-[600] text-[##4C5158]">
+                  <span class="font-[600] text-[#4C5158]">
                     {{ item?.short_name }}: <span class="font-['Barlow'] font-normal">{{ item?.other_names
                       }}</span></span>
                 </div>

--- a/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/alliance-alignment.component.html
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/alliance-alignment.component.html
@@ -115,13 +115,13 @@
 
           <div class="flex flex-col pt-2">
             <app-multiselect label="Primary Levers" [disabled]="!submission.isEditableStatus()" [signal]="body"
-              optionValue="lever_id" signalOptionValue="primary_levers" [isRequired]="true" [columnsOnXl]="true"
-              [textSpan]="'Levers selected'" [filterBy]="'short_name,other_names'" scrollHeight="260px"
+              optionValue="lever_id" signalOptionValue="primary_levers" [isRequired]="true" [hideRemoveIcon]="true"
+              [disabledSelectedScroll]="true" [filterBy]="'short_name,other_names'" scrollHeight="260px"
               serviceName="levers" [optionsDisabled]="primaryOptionsDisabled" placeholder="Select the levers">
               <ng-template #selectedItems let-value>
                 @if (value?.length > 0) {
                 <div class="flex items-center gap-2">
-                  <span>{{ value?.length }} Lever{{ value?.length === 1 ? '' : 's' }} selected </span>
+                  <span>{{ value?.length }} lever{{ value?.length === 1 ? '' : 's' }} selected </span>
                 </div>
                 }
               </ng-template>
@@ -133,28 +133,24 @@
                 </div>
               </ng-template>
               <ng-template #rows let-lever>
-                <div class="flex-col flex w-full">
-                  <div
-                    class="flex items-center pt-1 xl:pt-0.5 text-[13px] leading-[18px] text-[#4C5158] gap-x-1 font-['Barlow'] font-[600]">
-                    <img [src]="lever.icon" [alt]="lever.short_name" class="w-[35px] h-[35px] mr-2 rounded-[3px]" />
-                    <span class="text-[15px] text-[#4C5158] font-[600]">
-                      {{ lever?.short_name }}: <span class="font-['Barlow'] font-normal">{{ lever?.other_names
-                        }}</span></span>
-                  </div>
-                </div>
+                <app-alliance-lever-card [lever]="lever" [sdgSignal]="getLeverSdgSignal(lever)"
+                  [outcomeSignal]="getLeverSignal(lever)"
+                  [showStrategicOutcomes]="cache.currentMetadata()?.indicator_id === 5"
+                  [strategicOutcomesRequired]="cache.currentMetadata()?.indicator_id === 5" [sdgTargetsRequired]="true"
+                  [disabled]="!submission.isEditableStatus()" (removeLever)="removePrimaryLever(lever)" />
               </ng-template>
             </app-multiselect>
           </div>
 
           <div class="flex flex-col pt-3">
             <app-multiselect label="Other Contributing Levers" [disabled]="!submission.isEditableStatus()"
-              [signal]="body" optionValue="lever_id" signalOptionValue="contributor_levers" [columnsOnXl]="true"
-              scrollHeight="260px" serviceName="levers" [filterBy]="'short_name,other_names'"
-              [textSpan]="'Levers selected'" [optionsDisabled]="optionsDisabled" placeholder="Select the levers">
+              [signal]="body" optionValue="lever_id" signalOptionValue="contributor_levers" scrollHeight="260px"
+              [hideRemoveIcon]="true" [disabledSelectedScroll]="true" serviceName="levers"
+              [filterBy]="'short_name,other_names'" [optionsDisabled]="optionsDisabled" placeholder="Select the levers">
               <ng-template #selectedItems let-value>
                 @if (value?.length > 0) {
                 <div class="flex items-center gap-2">
-                  <span>{{ value?.length }} Lever{{ value?.length === 1 ? '' : 's' }} selected </span>
+                  <span>{{ value?.length }} lever{{ value?.length === 1 ? '' : 's' }} selected </span>
                 </div>
                 }
               </ng-template>
@@ -166,109 +162,11 @@
                 </div>
               </ng-template>
               <ng-template #rows let-lever>
-                <div class="flex-col flex w-full">
-                  <div
-                    class="flex items-center pt-1 xl:pt-0.5 text-[13px] leading-[18px] text-[#4C5158] gap-x-1 font-['Barlow'] font-[600]">
-                    <img [src]="lever.icon" [alt]="lever.short_name" class="w-[35px] h-[35px] mr-2 rounded-[3px]" />
-                    <span class="text-[15px] text-[#4C5158] font-[600]">
-                      {{ lever?.short_name }}: <span class="font-['Barlow'] font-normal">{{ lever?.other_names
-                        }}</span></span>
-                  </div>
-                </div>
-              </ng-template>
-            </app-multiselect>
-          </div>
-
-          @if (body().primary_levers.length > 0 && cache.currentMetadata().indicator_id === 5) {
-          <div class="flex flex-col pt-3">
-            <span class="text-[#1689CA] text-[16px] leading-[17px] pb-3 font-semibold">Primary lever strategic
-              outcomes</span>
-
-            @for (lever of body().primary_levers; track lever.lever_id) {
-            <div class="flex flex-col p-4 pr-0">
-              <div class="flex items-center">
-                <img [src]="lever.icon" [alt]="lever.short_name" class="w-[35px] h-[35px] mr-3 rounded-[3px]" />
-                <span class="text-[15.5px] text-[#153C71] font-[600]">
-                  {{ lever?.short_name }}{{ lever?.other_names ? ': ' + lever?.other_names : '' }} <span
-                    class="text-red-500">*</span>
-                </span>
-              </div>
-              <app-multiselect [isRequired]="true" [signal]="getLeverSignal(lever)"
-                signalOptionValue="result_lever_strategic_outcomes" optionValue="id" optionLabel="strategic_outcome"
-                serviceName="leverStrategicOutcomes" [enableVirtualScroll]="false" [scrollHeight]="'200px'"
-                [textSpan]="'Strategic outcome selected'" [serviceParams]="lever.lever_id"
-                placeholder="Select the option">
-                <ng-template #selectedItems let-value>
-                  @if (value?.length > 0) {
-                  <div class="flex items-center gap-2">
-                    <span>{{ value?.length }} Strategic outcome{{ value?.length === 1 ? '' : 's' }} selected </span>
-                  </div>
-                  }
-                </ng-template>
-
-                <ng-template #item let-item>
-                  <div
-                    class="flex items-center gap-2 text-[#4C5158] flex items-center block whitespace-normal break-words gap-2 leading-5">
-                    @if (item?.strategic_outcome?.includes(':')) {
-                    <span>
-                      <b>{{ item?.strategic_outcome?.split(':')[0] }}:</b>
-                      {{ item?.strategic_outcome?.split(':')[1]?.trim() }}
-                    </span>
-                    } @else {
-                    <span>{{ item?.strategic_outcome }}</span>
-                    }
-                  </div>
-                </ng-template>
-
-
-                <ng-template #rows let-strategicOutcome>
-                  <div class="flex-col flex w-full">
-                    <div
-                      class="flex items-center gap-2 text-[#4C5158] flex items-center block whitespace-normal break-words gap-2 leading-5">
-                      @if (strategicOutcome?.strategic_outcome?.includes(':')) {
-                      <span>
-                        <b>{{ strategicOutcome?.strategic_outcome?.split(':')[0] }}:</b>
-                        {{ strategicOutcome?.strategic_outcome?.split(':')[1]?.trim() }}
-                      </span>
-                      } @else {
-                      <span>{{ strategicOutcome?.strategic_outcome }}</span>
-                      }
-                    </div>
-                  </div>
-                </ng-template>
-              </app-multiselect>
-            </div>
-            }
-          </div>
-          }
-          <div
-            class="flex flex-col {{ (body().primary_levers.length > 0 && cache.currentMetadata().indicator_id === 5) ? '-mt-2' : 'pt-3' }}">
-            <app-multiselect label="Contribution to SDG targets" [signal]="body"
-              helperText="Indicate the SDGs to which the result is linked." optionLabel="select_label"
-              optionValue="sdg_id" signalOptionValue="result_sdgs" [disabled]="!submission.isEditableStatus()"
-              [removeCondition]="canRemove" [isRequired]="true" [columnsOnXl]="true" serviceName="sdgs"
-              placeholder="Select the SDG targets">
-              <ng-template #selectedItems let-value>
-                @if (value?.length > 0) {
-                <div class="flex items-center gap-2">
-                  <span>{{ value?.length }} SDG{{ value?.length === 1 ? '' : 's' }} selected </span>
-                </div>
-                }
-              </ng-template>
-              <ng-template #rows let-sdg>
-                <div class="flex-col flex w-full">
-                  <div
-                    class="flex items-center pt-1 xl:pt-0.5 text-[13px] leading-[18px] text-[#4C5158] gap-x-1 font-['Barlow'] font-[600]">
-                    @if (sdg.icon) {
-                    <img [src]="sdg.icon" [alt]="sdg.short_name" class="w-[35px] h-[35px] mr-2 rounded-[3px]" />
-                    }
-                    @if (sdg.description) {
-                    <span class="text-[15px] text-[#4C5158] font-[600]">
-                      SDG {{ sdg.short_name?.split(':')[0] }} - <span class="font-normal">{{
-                        sdg.short_name?.split(':')[1]?.trim() }} </span></span>
-                    }
-                  </div>
-                </div>
+                <app-alliance-lever-card [lever]="lever" [sdgSignal]="getLeverSdgSignal(lever)"
+                  [outcomeSignal]="getLeverSignal(lever)"
+                  [showStrategicOutcomes]="cache.currentMetadata()?.indicator_id === 5"
+                  [strategicOutcomesRequired]="cache.currentMetadata()?.indicator_id === 5" [sdgTargetsRequired]="false"
+                  [disabled]="!submission.isEditableStatus()" (removeLever)="removeContributorLever(lever)" />
               </ng-template>
             </app-multiselect>
           </div>

--- a/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/alliance-alignment.component.html
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/alliance-alignment.component.html
@@ -137,6 +137,7 @@
                   [outcomeSignal]="getLeverSignal(lever)"
                   [showStrategicOutcomes]="cache.currentMetadata()?.indicator_id === 5"
                   [strategicOutcomesRequired]="cache.currentMetadata()?.indicator_id === 5" [sdgTargetsRequired]="true"
+                  [removeLocked]="isLeverRequiredFromContributingProject(lever)"
                   [disabled]="!submission.isEditableStatus()" (removeLever)="removePrimaryLever(lever)" />
               </ng-template>
             </app-multiselect>
@@ -164,8 +165,9 @@
               <ng-template #rows let-lever>
                 <app-alliance-lever-card [lever]="lever" [sdgSignal]="getLeverSdgSignal(lever)"
                   [outcomeSignal]="getLeverSignal(lever)"
-                  [showStrategicOutcomes]="cache.currentMetadata()?.indicator_id === 5"
-                  [strategicOutcomesRequired]="cache.currentMetadata()?.indicator_id === 5" [sdgTargetsRequired]="false"
+                  [showStrategicOutcomes]="false"
+                  [strategicOutcomesRequired]="false"
+                  [sdgTargetsRequired]="false"
                   [disabled]="!submission.isEditableStatus()" (removeLever)="removeContributorLever(lever)" />
               </ng-template>
             </app-multiselect>

--- a/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/alliance-alignment.component.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/alliance-alignment.component.spec.ts
@@ -1050,6 +1050,20 @@ describe('AllianceAlignmentComponent', () => {
       expect(component.body().primary_levers.some(l => String(l.lever_id) === '88')).toBe(true);
     });
 
+    it('sync effect drops the same lever from contributor_levers when it becomes primary', () => {
+      component.body.set({
+        contracts: [{ is_primary: true, lever_id: 6 }],
+        result_sdgs: [],
+        primary_levers: [],
+        contributor_levers: [{ lever_id: 6, short_name: 'L6' } as any]
+      });
+      fixture.detectChanges();
+      TestBed.flushEffects();
+      fixture.detectChanges();
+      expect(component.body().primary_levers.some(l => String(l.lever_id) === '6')).toBe(true);
+      expect(component.body().contributor_levers.some(l => String(l.lever_id) === '6')).toBe(false);
+    });
+
     it('findCatalogLever returns matching catalog row', () => {
       getLeversServiceMock.list.set([{ lever_id: 77, id: 77, short_name: 'Cat', other_names: 'o' } as any]);
       expect((component as any).findCatalogLever(77)?.short_name).toBe('Cat');

--- a/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/alliance-alignment.component.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/alliance-alignment.component.spec.ts
@@ -890,13 +890,14 @@ describe('AllianceAlignmentComponent', () => {
   });
 
   describe('getRequiredLeverIdsFromContracts', () => {
-    it('should collect unique lever ids from nested levers and top-level lever_id', () => {
+    it('should collect unique lever ids only from primary contributing contracts', () => {
       const ids = component.getRequiredLeverIdsFromContracts([
         null,
-        { levers: [{ id: 1, full_name: 'Not available' }] },
-        { levers: [{ lever_id: 2, full_name: 'OK', short_name: 's' }] },
-        { lever_id: 3 },
-        { lever_id: 3 }
+        { is_primary: false, lever_id: 999 },
+        { is_primary: true, levers: [{ id: 1, full_name: 'Not available' }] },
+        { is_primary: true, levers: [{ lever_id: 2, full_name: 'OK', short_name: 's' }] },
+        { is_primary: true, lever_id: 3 },
+        { is_primary: true, lever_id: 3 }
       ]);
       expect(ids).toEqual([2, 3]);
     });
@@ -906,14 +907,23 @@ describe('AllianceAlignmentComponent', () => {
     });
 
     it('should skip contracts where nested lever has no resolvable id', () => {
-      expect(component.getRequiredLeverIdsFromContracts([{ levers: [{}] }])).toEqual([]);
+      expect(component.getRequiredLeverIdsFromContracts([{ is_primary: true, levers: [{}] }])).toEqual([]);
+    });
+
+    it('should ignore levers on non-primary contracts', () => {
+      expect(
+        component.getRequiredLeverIdsFromContracts([
+          { is_primary: false, lever_id: 50 },
+          { is_primary: true, lever_id: 7 }
+        ])
+      ).toEqual([7]);
     });
   });
 
   describe('isLeverRequiredFromContributingProject', () => {
-    it('should return true when lever id matches a required contract lever', () => {
+    it('should return true when lever id matches the primary contributing contract lever', () => {
       component.body.set({
-        contracts: [{ lever_id: 7 }],
+        contracts: [{ is_primary: true, lever_id: 7 }],
         result_sdgs: [],
         primary_levers: [],
         contributor_levers: []
@@ -923,12 +933,25 @@ describe('AllianceAlignmentComponent', () => {
 
     it('should return false when no match', () => {
       component.body.set({
-        contracts: [{ lever_id: 7 }],
+        contracts: [{ is_primary: true, lever_id: 7 }],
         result_sdgs: [],
         primary_levers: [],
         contributor_levers: []
       });
       expect(component.isLeverRequiredFromContributingProject({ lever_id: 99 } as any)).toBe(false);
+    });
+
+    it('should return false when lever is only on a non-primary contract', () => {
+      component.body.set({
+        contracts: [
+          { is_primary: true, lever_id: 1 },
+          { is_primary: false, lever_id: 50 }
+        ],
+        result_sdgs: [],
+        primary_levers: [],
+        contributor_levers: []
+      });
+      expect(component.isLeverRequiredFromContributingProject({ lever_id: 50 } as any)).toBe(false);
     });
   });
 
@@ -975,10 +998,10 @@ describe('AllianceAlignmentComponent', () => {
       expect(component.body().primary_levers).toHaveLength(1);
     });
 
-    it('should not remove primary when lever is required by contract', () => {
+    it('should not remove primary when lever is required by primary contract', () => {
       submission.isEditableStatus.mockReturnValue(true);
       component.body.set({
-        contracts: [{ lever_id: 42 }],
+        contracts: [{ is_primary: true, lever_id: 42 }],
         result_sdgs: [],
         primary_levers: [lever],
         contributor_levers: []
@@ -1016,7 +1039,7 @@ describe('AllianceAlignmentComponent', () => {
   describe('syncContractLeversToPrimaryEffect and lever resolution', () => {
     it('sync effect merges required levers into primary_levers', () => {
       component.body.set({
-        contracts: [{ lever_id: 88 }],
+        contracts: [{ is_primary: true, lever_id: 88 }],
         result_sdgs: [],
         primary_levers: [],
         contributor_levers: []
@@ -1079,7 +1102,7 @@ describe('AllianceAlignmentComponent', () => {
 
     it('resolveLeverForPrimary prefers catalog over nested contract', () => {
       getLeversServiceMock.list.set([{ lever_id: 77, id: 77, short_name: 'Cat', other_names: 'o' } as any]);
-      const contracts = [{ lever_id: 77 }];
+      const contracts = [{ is_primary: true, lever_id: 77 }];
       const lever = (component as any).resolveLeverForPrimary(77, [], contracts);
       expect(lever.short_name).toBe('Cat');
     });
@@ -1087,7 +1110,10 @@ describe('AllianceAlignmentComponent', () => {
     it('resolveLeverForPrimary uses nested contract when catalog misses', () => {
       getLeversServiceMock.list.set([]);
       const contracts = [
-        { levers: [{ id: 66, full_name: 'N', short_name: 'Sn', other_names: 'on', lever_url: 'http://x' }] }
+        {
+          is_primary: true,
+          levers: [{ id: 66, full_name: 'N', short_name: 'Sn', other_names: 'on', lever_url: 'http://x' }]
+        }
       ];
       const lever = (component as any).resolveLeverForPrimary(66, [], contracts);
       expect(lever.short_name).toBe('Sn');
@@ -1101,7 +1127,7 @@ describe('AllianceAlignmentComponent', () => {
 
     it('computeMergedPrimaryLevers combines required and optional primaries', () => {
       component.body.set({
-        contracts: [{ lever_id: 10 }],
+        contracts: [{ is_primary: true, lever_id: 10 }],
         result_sdgs: [],
         primary_levers: [{ lever_id: 20, short_name: 'Opt' } as any],
         contributor_levers: []
@@ -1271,7 +1297,7 @@ describe('AllianceAlignmentComponent', () => {
     it('sync effect skips body.update when merged sequence matches current', () => {
       const updateSpy = jest.spyOn(component.body, 'update');
       component.body.set({
-        contracts: [{ lever_id: 1 }],
+        contracts: [{ is_primary: true, lever_id: 1 }],
         result_sdgs: [],
         primary_levers: [{ lever_id: 1, result_lever_strategic_outcomes: [] } as any],
         contributor_levers: []
@@ -1336,7 +1362,7 @@ describe('AllianceAlignmentComponent', () => {
 
     it('sync effect handles undefined primary_levers on body', () => {
       component.body.set({
-        contracts: [{ lever_id: 3 }],
+        contracts: [{ is_primary: true, lever_id: 3 }],
         result_sdgs: [],
         primary_levers: undefined as any,
         contributor_levers: []

--- a/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/alliance-alignment.component.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/alliance-alignment.component.spec.ts
@@ -1418,4 +1418,55 @@ describe('AllianceAlignmentComponent', () => {
       expect((component as any).findNestedLeverShape(contracts, 3)?.short_name).toBe('First');
     });
   });
+
+  describe('getPrimaryContracts and contributorLeversExcludingPrimary', () => {
+    it('getPrimaryContracts returns empty array when contracts is undefined or null', () => {
+      expect((component as any).getPrimaryContracts(undefined)).toEqual([]);
+      expect((component as any).getPrimaryContracts(null)).toEqual([]);
+    });
+
+    it('getPrimaryContracts filters out non-objects and non-primary contracts', () => {
+      expect(
+        (component as any).getPrimaryContracts([
+          null,
+          { is_primary: false, lever_id: 1 },
+          { is_primary: true, lever_id: 2 }
+        ])
+      ).toEqual([{ is_primary: true, lever_id: 2 }]);
+    });
+
+    it('isPrimaryContributingContract returns false for null and non-objects', () => {
+      expect((component as any).isPrimaryContributingContract(null)).toBe(false);
+      expect((component as any).isPrimaryContributingContract('x')).toBe(false);
+    });
+
+    it('getLeverIdFromContract returns null when contract is null, undefined, or not an object', () => {
+      expect((component as any).getLeverIdFromContract(null)).toBeNull();
+      expect((component as any).getLeverIdFromContract(undefined)).toBeNull();
+      expect((component as any).getLeverIdFromContract(42)).toBeNull();
+    });
+
+    it('contributorLeversExcludingPrimary treats undefined primary as empty id set', () => {
+      const c = [{ lever_id: 1 } as any];
+      expect((component as any).contributorLeversExcludingPrimary(undefined, c)).toEqual(c);
+    });
+
+    it('contributorLeversExcludingPrimary treats undefined contributors as empty', () => {
+      expect((component as any).contributorLeversExcludingPrimary([{ lever_id: 1 } as any], undefined)).toEqual([]);
+    });
+
+    it('sync effect uses prev.contributor_levers ?? [] when contributor_levers was undefined', () => {
+      component.body.set({
+        contracts: [{ is_primary: true, lever_id: 9 }],
+        result_sdgs: [],
+        primary_levers: [],
+        contributor_levers: undefined as any
+      });
+      fixture.detectChanges();
+      TestBed.flushEffects();
+      fixture.detectChanges();
+      expect(component.body().primary_levers.some(l => String(l.lever_id) === '9')).toBe(true);
+      expect(component.body().contributor_levers).toEqual([]);
+    });
+  });
 });

--- a/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/alliance-alignment.component.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/alliance-alignment.component.spec.ts
@@ -119,11 +119,19 @@ describe('AllianceAlignmentComponent', () => {
     api.GET_Alignments.mockResolvedValue({ data: { contracts: [{ id: 1 }] } });
     jest.spyOn(component, 'getData');
 
-    // Set result_sdgs to ensure line 145 is covered
     component.body.set({
       contracts: [],
-      result_sdgs: [{ id: 1, created_at: '2024-01-01', is_active: true, updated_at: '2024-01-01' }],
-      primary_levers: [],
+      result_sdgs: [],
+      primary_levers: [
+        {
+          lever_id: 1,
+          result_lever_id: 1,
+          result_id: 1,
+          lever_role_id: 1,
+          is_primary: true,
+          result_lever_sdgs: [{ id: 1, created_at: '2024-01-01', is_active: true, updated_at: '2024-01-01', clarisa_sdg_id: 1 } as any]
+        }
+      ],
       contributor_levers: []
     });
 
@@ -454,14 +462,23 @@ describe('AllianceAlignmentComponent', () => {
       expect(callArgs[1].primary_levers[0]).toEqual(lever);
     });
 
-    it('should map result_sdgs correctly', async () => {
+    it('should map result_sdgs correctly from lever selections', async () => {
       api.PATCH_Alignments.mockResolvedValue({ successfulRequest: true });
       api.GET_Alignments.mockResolvedValue({ data: { contracts: [], result_sdgs: [] } });
 
       component.body.set({
         contracts: [],
-        result_sdgs: [{ id: 1, created_at: '2024-01-01', is_active: true, updated_at: '2024-01-01' }],
-        primary_levers: [],
+        result_sdgs: [],
+        primary_levers: [
+          {
+            lever_id: 1,
+            result_lever_id: 1,
+            result_id: 1,
+            lever_role_id: 1,
+            is_primary: true,
+            result_lever_sdgs: [{ id: 1, created_at: '2024-01-01', is_active: true, updated_at: '2024-01-01', clarisa_sdg_id: 1 } as any]
+          }
+        ],
         contributor_levers: []
       });
 
@@ -539,6 +556,21 @@ describe('AllianceAlignmentComponent', () => {
     });
   });
 
+  describe('getLeverSdgSignal', () => {
+    it('should return existing signal if already created', () => {
+      const lever = { lever_id: 1, result_lever_sdgs: [{ id: 1 } as any] };
+      const signal1 = component.getLeverSdgSignal(lever as any);
+      const signal2 = component.getLeverSdgSignal(lever as any);
+      expect(signal1).toBe(signal2);
+    });
+
+    it('should create new signal with sdgs from lever', () => {
+      const lever = { lever_id: 2, result_lever_sdgs: [{ id: 2, clarisa_sdg_id: 2 } as any] };
+      const s = component.getLeverSdgSignal(lever as any);
+      expect(s().result_lever_sdgs).toEqual([{ id: 2, clarisa_sdg_id: 2 }]);
+    });
+  });
+
   describe('getLeverSignal', () => {
     it('should return existing signal if already created', () => {
       const lever = { lever_id: 1, result_lever_strategic_outcomes: [{ lever_strategic_outcome_id: 1 }] };
@@ -561,24 +593,32 @@ describe('AllianceAlignmentComponent', () => {
   });
 
   describe('getData', () => {
-    it('should map result_sdgs with clarisa_sdg_id', async () => {
+    it('should migrate legacy flat result_sdgs onto a single primary lever', async () => {
       api.GET_Alignments.mockResolvedValue({
         data: {
           contracts: [],
           result_sdgs: [
-            { clarisa_sdg_id: 1, name: 'SDG 1' },
-            { clarisa_sdg_id: 2, name: 'SDG 2' }
+            { clarisa_sdg_id: 1, id: 1, created_at: '', updated_at: '', is_active: true },
+            { clarisa_sdg_id: 2, id: 2, created_at: '', updated_at: '', is_active: true }
           ],
-          primary_levers: [],
+          primary_levers: [
+            {
+              lever_id: 10,
+              result_lever_id: 1,
+              result_id: 1,
+              lever_role_id: 1,
+              is_primary: true
+            }
+          ],
           contributor_levers: []
         }
       });
 
       await component.getData();
 
-      expect(component.body().result_sdgs[0].sdg_id).toBe(1);
-      expect(component.body().result_sdgs[0].is_primary).toBe(false);
-      expect(component.body().result_sdgs[1].sdg_id).toBe(2);
+      expect(component.body().result_sdgs).toEqual([]);
+      expect(component.body().primary_levers[0].result_lever_sdgs?.[0].sdg_id).toBe(1);
+      expect(component.body().primary_levers[0].result_lever_sdgs?.[1].sdg_id).toBe(2);
     });
 
     it('should handle missing result_sdgs', async () => {
@@ -730,17 +770,25 @@ describe('AllianceAlignmentComponent', () => {
 
       component.body.set({
         contracts: [],
-        result_sdgs: [
+        result_sdgs: [],
+        primary_levers: [
           {
-            id: 5,
-            created_at: '2024-01-01',
-            is_active: true,
-            updated_at: '2024-01-02',
-            sdg_id: 5,
-            is_primary: false
+            lever_id: 1,
+            result_lever_id: 1,
+            result_id: 1,
+            lever_role_id: 1,
+            is_primary: true,
+            result_lever_sdgs: [
+              {
+                id: 5,
+                clarisa_sdg_id: 5,
+                created_at: '2024-01-01',
+                is_active: true,
+                updated_at: '2024-01-02'
+              } as any
+            ]
           }
         ],
-        primary_levers: [],
         contributor_levers: []
       });
 
@@ -763,11 +811,20 @@ describe('AllianceAlignmentComponent', () => {
 
       component.body.set({
         contracts: [],
-        result_sdgs: [
-          { id: 1, created_at: '2024-01-01', is_active: true, updated_at: '2024-01-01' },
-          { id: 2, created_at: '2024-01-02', is_active: true, updated_at: '2024-01-02' }
+        result_sdgs: [],
+        primary_levers: [
+          {
+            lever_id: 1,
+            result_lever_id: 1,
+            result_id: 1,
+            lever_role_id: 1,
+            is_primary: true,
+            result_lever_sdgs: [
+              { id: 1, created_at: '2024-01-01', is_active: true, updated_at: '2024-01-01', clarisa_sdg_id: 1 } as any,
+              { id: 2, created_at: '2024-01-02', is_active: true, updated_at: '2024-01-02', clarisa_sdg_id: 2 } as any
+            ]
+          }
         ],
-        primary_levers: [],
         contributor_levers: []
       });
 

--- a/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/alliance-alignment.component.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/alliance-alignment.component.spec.ts
@@ -1094,18 +1094,13 @@ describe('AllianceAlignmentComponent', () => {
     });
 
     it('leverFromContractNested maps nested contract fields', () => {
-      const lever = (component as any).leverFromContractNested(
-        { short_name: 'Sn', other_names: 'on', lever_url: 'http://x' },
-        66
-      );
+      const lever = (component as any).leverFromContractNested({ short_name: 'Sn', other_names: 'on', lever_url: 'http://x' }, 66);
       expect(lever.lever_id).toBe(66);
       expect(lever.short_name).toBe('Sn');
     });
 
     it('findNestedLeverShape returns nested lever object', () => {
-      const contracts = [
-        { levers: [{ id: 66, full_name: 'N', short_name: 'Sn', other_names: 'on', lever_url: 'http://x' }] }
-      ];
+      const contracts = [{ levers: [{ id: 66, full_name: 'N', short_name: 'Sn', other_names: 'on', lever_url: 'http://x' }] }];
       expect((component as any).findNestedLeverShape(contracts, 66)?.short_name).toBe('Sn');
     });
 
@@ -1322,9 +1317,9 @@ describe('AllianceAlignmentComponent', () => {
     });
 
     it('samePrimaryLeverSequence is false when lever ids differ at same index', () => {
-      expect(
-        (component as any).samePrimaryLeverSequence([{ lever_id: 1 }, { lever_id: 2 }] as any, [{ lever_id: 1 }, { lever_id: 9 }] as any)
-      ).toBe(false);
+      expect((component as any).samePrimaryLeverSequence([{ lever_id: 1 }, { lever_id: 2 }] as any, [{ lever_id: 1 }, { lever_id: 9 }] as any)).toBe(
+        false
+      );
     });
 
     it('normalizeSdgs picks clarisa_sdg_id when sdg_id missing in getData', async () => {
@@ -1426,13 +1421,9 @@ describe('AllianceAlignmentComponent', () => {
     });
 
     it('getPrimaryContracts filters out non-objects and non-primary contracts', () => {
-      expect(
-        (component as any).getPrimaryContracts([
-          null,
-          { is_primary: false, lever_id: 1 },
-          { is_primary: true, lever_id: 2 }
-        ])
-      ).toEqual([{ is_primary: true, lever_id: 2 }]);
+      expect((component as any).getPrimaryContracts([null, { is_primary: false, lever_id: 1 }, { is_primary: true, lever_id: 2 }])).toEqual([
+        { is_primary: true, lever_id: 2 }
+      ]);
     });
 
     it('isPrimaryContributingContract returns false for null and non-objects', () => {

--- a/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/alliance-alignment.component.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/alliance-alignment.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed, fakeAsync, tick, flush } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { signal } from '@angular/core';
 
 import AllianceAlignmentComponent from './alliance-alignment.component';
 import { ActivatedRoute } from '@angular/router';
@@ -11,16 +12,20 @@ import { Router } from '@angular/router';
 import { SubmissionService } from '@shared/services/submission.service';
 import { VersionWatcherService } from '@shared/services/version-watcher.service';
 import { GetContractsService } from '@services/control-list/get-contracts.service';
+import { GetLeversService } from '@services/control-list/get-levers.service';
 
 class ApiServiceMock {
   GET_Alignments = jest.fn();
   PATCH_Alignments = jest.fn();
 }
 class CacheServiceMock {
+  metadata = signal<Record<string, unknown>>({});
   currentResultId = jest.fn().mockReturnValue(1);
   getCurrentNumericResultId = jest.fn().mockReturnValue(1);
   currentResultIndicatorSectionPath = jest.fn().mockReturnValue('next-section');
-  currentMetadata = jest.fn().mockReturnValue({});
+  currentMetadata() {
+    return this.metadata();
+  }
   currentResultIsLoading = jest.fn().mockReturnValue(false);
   showSectionHeaderActions = jest.fn().mockReturnValue(false);
   hasSmallScreen = jest.fn().mockReturnValue(false);
@@ -45,6 +50,14 @@ class GetContractsServiceMock {
   isOpenSearch = jest.fn().mockReturnValue(false);
 }
 
+let getLeversServiceMock: {
+  list: ReturnType<typeof signal<any[]>>;
+  loading: ReturnType<typeof signal<boolean>>;
+  isOpenSearch: ReturnType<typeof signal<boolean>>;
+  main: jest.Mock;
+  update: jest.Mock;
+};
+
 describe('AllianceAlignmentComponent', () => {
   let component: AllianceAlignmentComponent;
   let fixture: ComponentFixture<AllianceAlignmentComponent>;
@@ -56,6 +69,13 @@ describe('AllianceAlignmentComponent', () => {
   let route: any;
 
   beforeEach(async () => {
+    getLeversServiceMock = {
+      list: signal<any[]>([]),
+      loading: signal(false),
+      isOpenSearch: signal(false),
+      main: jest.fn().mockResolvedValue(undefined),
+      update: jest.fn()
+    };
     api = new ApiServiceMock();
     cache = new CacheServiceMock();
     actions = new ActionsServiceMock();
@@ -81,7 +101,8 @@ describe('AllianceAlignmentComponent', () => {
         { provide: SubmissionService, useValue: submission },
         { provide: VersionWatcherService, useClass: VersionWatcherServiceMock },
         { provide: ActivatedRoute, useValue: route },
-        { provide: GetContractsService, useClass: GetContractsServiceMock }
+        { provide: GetContractsService, useClass: GetContractsServiceMock },
+        { provide: GetLeversService, useValue: getLeversServiceMock }
       ]
     }).compileComponents();
 
@@ -853,6 +874,508 @@ describe('AllianceAlignmentComponent', () => {
       expect(api.PATCH_Alignments).toHaveBeenCalled();
       const callArgs = api.PATCH_Alignments.mock.calls[0];
       expect(callArgs[1].result_sdgs).toEqual([]);
+    });
+  });
+
+  describe('contractServiceParams', () => {
+    it('should set exclude-pooled-funding to false when indicator_id is 5', () => {
+      cache.metadata.set({ indicator_id: 5 });
+      expect(component.contractServiceParams()['exclude-pooled-funding']).toBe(false);
+    });
+
+    it('should set exclude-pooled-funding to true when indicator_id is not 5', () => {
+      cache.metadata.set({ indicator_id: 4 });
+      expect(component.contractServiceParams()['exclude-pooled-funding']).toBe(true);
+    });
+  });
+
+  describe('getRequiredLeverIdsFromContracts', () => {
+    it('should collect unique lever ids from nested levers and top-level lever_id', () => {
+      const ids = component.getRequiredLeverIdsFromContracts([
+        null,
+        { levers: [{ id: 1, full_name: 'Not available' }] },
+        { levers: [{ lever_id: 2, full_name: 'OK', short_name: 's' }] },
+        { lever_id: 3 },
+        { lever_id: 3 }
+      ]);
+      expect(ids).toEqual([2, 3]);
+    });
+
+    it('should return empty array for undefined contracts', () => {
+      expect(component.getRequiredLeverIdsFromContracts(undefined)).toEqual([]);
+    });
+
+    it('should skip contracts where nested lever has no resolvable id', () => {
+      expect(component.getRequiredLeverIdsFromContracts([{ levers: [{}] }])).toEqual([]);
+    });
+  });
+
+  describe('isLeverRequiredFromContributingProject', () => {
+    it('should return true when lever id matches a required contract lever', () => {
+      component.body.set({
+        contracts: [{ lever_id: 7 }],
+        result_sdgs: [],
+        primary_levers: [],
+        contributor_levers: []
+      });
+      expect(component.isLeverRequiredFromContributingProject({ lever_id: 7 } as any)).toBe(true);
+    });
+
+    it('should return false when no match', () => {
+      component.body.set({
+        contracts: [{ lever_id: 7 }],
+        result_sdgs: [],
+        primary_levers: [],
+        contributor_levers: []
+      });
+      expect(component.isLeverRequiredFromContributingProject({ lever_id: 99 } as any)).toBe(false);
+    });
+  });
+
+  describe('removePrimaryLever / removeContributorLever', () => {
+    const lever = {
+      lever_id: 42,
+      result_lever_id: 1,
+      result_id: 1,
+      lever_role_id: 1,
+      is_primary: true,
+      short_name: 'X',
+      other_names: '',
+      result_lever_sdgs: [],
+      result_lever_sdg_targets: [],
+      result_lever_strategic_outcomes: []
+    } as any;
+
+    it('should remove primary lever when editable and not required', () => {
+      submission.isEditableStatus.mockReturnValue(true);
+      component.body.set({
+        contracts: [],
+        result_sdgs: [],
+        primary_levers: [lever],
+        contributor_levers: []
+      });
+      component.getLeverSignal(lever);
+      component.getLeverSdgSignal(lever);
+
+      component.removePrimaryLever(lever);
+
+      expect(component.body().primary_levers).toEqual([]);
+      expect(actions.saveCurrentSection).toHaveBeenCalled();
+    });
+
+    it('should not remove primary when not editable', () => {
+      submission.isEditableStatus.mockReturnValue(false);
+      component.body.set({
+        contracts: [],
+        result_sdgs: [],
+        primary_levers: [lever],
+        contributor_levers: []
+      });
+      component.removePrimaryLever(lever);
+      expect(component.body().primary_levers).toHaveLength(1);
+    });
+
+    it('should not remove primary when lever is required by contract', () => {
+      submission.isEditableStatus.mockReturnValue(true);
+      component.body.set({
+        contracts: [{ lever_id: 42 }],
+        result_sdgs: [],
+        primary_levers: [lever],
+        contributor_levers: []
+      });
+      component.removePrimaryLever(lever);
+      expect(component.body().primary_levers).toHaveLength(1);
+    });
+
+    it('should remove contributor lever when editable', () => {
+      submission.isEditableStatus.mockReturnValue(true);
+      component.body.set({
+        contracts: [],
+        result_sdgs: [],
+        primary_levers: [],
+        contributor_levers: [lever]
+      });
+      component.removeContributorLever(lever);
+      expect(component.body().contributor_levers).toEqual([]);
+      expect(actions.saveCurrentSection).toHaveBeenCalled();
+    });
+
+    it('should not remove contributor when not editable', () => {
+      submission.isEditableStatus.mockReturnValue(false);
+      component.body.set({
+        contracts: [],
+        result_sdgs: [],
+        primary_levers: [],
+        contributor_levers: [lever]
+      });
+      component.removeContributorLever(lever);
+      expect(component.body().contributor_levers).toHaveLength(1);
+    });
+  });
+
+  describe('syncContractLeversToPrimaryEffect and lever resolution', () => {
+    it('sync effect merges required levers into primary_levers', () => {
+      component.body.set({
+        contracts: [{ lever_id: 88 }],
+        result_sdgs: [],
+        primary_levers: [],
+        contributor_levers: []
+      });
+      fixture.detectChanges();
+      TestBed.flushEffects();
+      fixture.detectChanges();
+      expect(component.body().primary_levers.some(l => String(l.lever_id) === '88')).toBe(true);
+    });
+
+    it('findCatalogLever returns matching catalog row', () => {
+      getLeversServiceMock.list.set([{ lever_id: 77, id: 77, short_name: 'Cat', other_names: 'o' } as any]);
+      expect((component as any).findCatalogLever(77)?.short_name).toBe('Cat');
+    });
+
+    it('findCatalogLever matches catalog row by id when lever_id is absent', () => {
+      getLeversServiceMock.list.set([{ id: 82, short_name: 'ById', other_names: '' } as any]);
+      expect((component as any).findCatalogLever(82)?.short_name).toBe('ById');
+    });
+
+    it('findCatalogLever uses empty array when list() is undefined', () => {
+      const svc = (component as any).getLeversService;
+      const prev = svc.list;
+      svc.list = () => undefined as any;
+      expect((component as any).findCatalogLever(1)).toBeUndefined();
+      svc.list = prev;
+    });
+
+    it('leverFromCatalog maps catalog entry to Lever', () => {
+      const lever = (component as any).leverFromCatalog({
+        lever_id: 9,
+        id: 9,
+        short_name: 'S',
+        other_names: 'o'
+      });
+      expect(lever.lever_id).toBe(9);
+      expect(lever.short_name).toBe('S');
+    });
+
+    it('leverFromContractNested maps nested contract fields', () => {
+      const lever = (component as any).leverFromContractNested(
+        { short_name: 'Sn', other_names: 'on', lever_url: 'http://x' },
+        66
+      );
+      expect(lever.lever_id).toBe(66);
+      expect(lever.short_name).toBe('Sn');
+    });
+
+    it('findNestedLeverShape returns nested lever object', () => {
+      const contracts = [
+        { levers: [{ id: 66, full_name: 'N', short_name: 'Sn', other_names: 'on', lever_url: 'http://x' }] }
+      ];
+      expect((component as any).findNestedLeverShape(contracts, 66)?.short_name).toBe('Sn');
+    });
+
+    it('resolveLeverForPrimary returns existing primary when present', () => {
+      const existing = { lever_id: 5, short_name: 'Keep' } as any;
+      expect((component as any).resolveLeverForPrimary(5, [existing], [])).toBe(existing);
+    });
+
+    it('resolveLeverForPrimary prefers catalog over nested contract', () => {
+      getLeversServiceMock.list.set([{ lever_id: 77, id: 77, short_name: 'Cat', other_names: 'o' } as any]);
+      const contracts = [{ lever_id: 77 }];
+      const lever = (component as any).resolveLeverForPrimary(77, [], contracts);
+      expect(lever.short_name).toBe('Cat');
+    });
+
+    it('resolveLeverForPrimary uses nested contract when catalog misses', () => {
+      getLeversServiceMock.list.set([]);
+      const contracts = [
+        { levers: [{ id: 66, full_name: 'N', short_name: 'Sn', other_names: 'on', lever_url: 'http://x' }] }
+      ];
+      const lever = (component as any).resolveLeverForPrimary(66, [], contracts);
+      expect(lever.short_name).toBe('Sn');
+    });
+
+    it('resolveLeverForPrimary falls back to minimal stub', () => {
+      const lever = (component as any).resolveLeverForPrimary(999, [], []);
+      expect(lever.lever_id).toBe(999);
+      expect(lever.result_lever_sdgs).toEqual([]);
+    });
+
+    it('computeMergedPrimaryLevers combines required and optional primaries', () => {
+      component.body.set({
+        contracts: [{ lever_id: 10 }],
+        result_sdgs: [],
+        primary_levers: [{ lever_id: 20, short_name: 'Opt' } as any],
+        contributor_levers: []
+      });
+      const merged = (component as any).computeMergedPrimaryLevers();
+      expect(merged.map((l: any) => l.lever_id)).toEqual([10, 20]);
+    });
+
+    it('samePrimaryLeverSequence returns true for identical id order', () => {
+      const a = [{ lever_id: 1 }, { lever_id: 2 }] as any[];
+      expect((component as any).samePrimaryLeverSequence(a, [{ lever_id: 1 }, { lever_id: 2 }])).toBe(true);
+      expect((component as any).samePrimaryLeverSequence(a, [{ lever_id: 2 }, { lever_id: 1 }])).toBe(false);
+    });
+  });
+
+  describe('getData normalization', () => {
+    it('should normalize SDG targets from numbers and mixed object shapes', async () => {
+      api.GET_Alignments.mockResolvedValue({
+        data: {
+          contracts: [],
+          result_sdgs: [],
+          primary_levers: [
+            {
+              lever_id: 1,
+              result_lever_sdg_targets: [3, { sdg_target_id: 4 }, { id: '5' }, { id: 'bad' }, null] as any
+            }
+          ],
+          contributor_levers: []
+        }
+      });
+      await component.getData();
+      const targets = component.body().primary_levers[0].result_lever_sdg_targets ?? [];
+      expect(targets.map(t => t.sdg_target_id)).toEqual([3, 4, 5]);
+    });
+
+    it('should migrate legacy result_sdgs onto a single contributor lever', async () => {
+      api.GET_Alignments.mockResolvedValue({
+        data: {
+          contracts: [],
+          result_sdgs: [{ clarisa_sdg_id: 9, id: 9, created_at: '', updated_at: '', is_active: true }],
+          primary_levers: [],
+          contributor_levers: [{ lever_id: 20, result_lever_id: 1, result_id: 1, lever_role_id: 1, is_primary: false }]
+        }
+      });
+      await component.getData();
+      expect(component.body().contributor_levers[0].result_lever_sdgs?.[0].sdg_id).toBe(9);
+    });
+  });
+
+  describe('saveData with SDG signal merge', () => {
+    it('should merge leverSdgSignals targets into payload', async () => {
+      api.PATCH_Alignments.mockResolvedValue({ successfulRequest: true });
+      api.GET_Alignments.mockResolvedValue({ data: { contracts: [], result_sdgs: [], primary_levers: [], contributor_levers: [] } });
+
+      const lever = {
+        lever_id: 11,
+        result_lever_id: 1,
+        result_id: 1,
+        lever_role_id: 1,
+        is_primary: true,
+        result_lever_sdgs: [{ id: 1, clarisa_sdg_id: 1 } as any],
+        result_lever_sdg_targets: []
+      } as any;
+
+      component.body.set({
+        contracts: [],
+        result_sdgs: [],
+        primary_levers: [lever],
+        contributor_levers: []
+      });
+
+      const sdgSig = component.getLeverSdgSignal(lever);
+      sdgSig.set({
+        result_lever_sdgs: [],
+        result_lever_sdg_targets: [{ sdg_target_id: 21 }, { sdg_target_id: 0 }, { sdg_target_id: NaN } as any]
+      });
+
+      await component.saveData();
+
+      const payload = api.PATCH_Alignments.mock.calls[0][1];
+      expect(payload.primary_levers[0].result_lever_sdg_targets).toEqual([{ sdg_target_id: 21 }]);
+      expect(payload.primary_levers[0].result_lever_sdgs).toEqual([]);
+    });
+
+    it('treats undefined result_lever_sdg_targets as empty when merging', async () => {
+      api.PATCH_Alignments.mockResolvedValue({ successfulRequest: true });
+      api.GET_Alignments.mockResolvedValue({ data: { contracts: [], result_sdgs: [], primary_levers: [], contributor_levers: [] } });
+
+      const lever = {
+        lever_id: 12,
+        result_lever_id: 1,
+        result_id: 1,
+        lever_role_id: 1,
+        is_primary: true,
+        result_lever_sdgs: [],
+        result_lever_sdg_targets: []
+      } as any;
+
+      component.body.set({
+        contracts: [],
+        result_sdgs: [],
+        primary_levers: [lever],
+        contributor_levers: []
+      });
+
+      const sdgSig = component.getLeverSdgSignal(lever);
+      sdgSig.set({ result_lever_sdgs: [], result_lever_sdg_targets: undefined as any });
+
+      await component.saveData();
+
+      expect(api.PATCH_Alignments.mock.calls[0][1].primary_levers[0].result_lever_sdg_targets).toEqual([]);
+    });
+  });
+
+  describe('additional branch coverage', () => {
+    it('skips legacy root SDG migration when any lever already has SDGs', async () => {
+      api.GET_Alignments.mockResolvedValue({
+        data: {
+          contracts: [],
+          result_sdgs: [{ clarisa_sdg_id: 1, id: 1, created_at: '', updated_at: '', is_active: true }],
+          primary_levers: [
+            {
+              lever_id: 10,
+              result_lever_sdgs: [{ id: 2, clarisa_sdg_id: 2, created_at: '', updated_at: '', is_active: true } as any]
+            }
+          ],
+          contributor_levers: []
+        }
+      });
+      await component.getData();
+      expect(component.body().primary_levers[0].result_lever_sdgs?.[0].sdg_id).toBe(2);
+    });
+
+    it('maps result_sdgs payload using clarisa_sdg_id when id is absent', async () => {
+      api.PATCH_Alignments.mockResolvedValue({ successfulRequest: true });
+      api.GET_Alignments.mockResolvedValue({ data: { contracts: [], result_sdgs: [], primary_levers: [], contributor_levers: [] } });
+
+      component.body.set({
+        contracts: [],
+        result_sdgs: [],
+        primary_levers: [
+          {
+            lever_id: 1,
+            result_lever_id: 1,
+            result_id: 1,
+            lever_role_id: 1,
+            is_primary: true,
+            result_lever_sdgs: [{ clarisa_sdg_id: 42, created_at: 'a', is_active: true, updated_at: 'b' } as any]
+          }
+        ],
+        contributor_levers: []
+      });
+
+      await component.saveData();
+
+      const sent = api.PATCH_Alignments.mock.calls[0][1].result_sdgs[0];
+      expect(sent.clarisa_sdg_id).toBe(42);
+    });
+
+    it('getLeverSdgSignal uses empty arrays when lever omits sdg fields', () => {
+      const lever = { lever_id: 55 } as any;
+      const s = component.getLeverSdgSignal(lever);
+      expect(s().result_lever_sdgs).toEqual([]);
+      expect(s().result_lever_sdg_targets).toEqual([]);
+    });
+
+    it('sync effect skips body.update when merged sequence matches current', () => {
+      const updateSpy = jest.spyOn(component.body, 'update');
+      component.body.set({
+        contracts: [{ lever_id: 1 }],
+        result_sdgs: [],
+        primary_levers: [{ lever_id: 1, result_lever_strategic_outcomes: [] } as any],
+        contributor_levers: []
+      });
+      fixture.detectChanges();
+      TestBed.flushEffects();
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+
+    it('samePrimaryLeverSequence is false when lever ids differ at same index', () => {
+      expect(
+        (component as any).samePrimaryLeverSequence([{ lever_id: 1 }, { lever_id: 2 }] as any, [{ lever_id: 1 }, { lever_id: 9 }] as any)
+      ).toBe(false);
+    });
+
+    it('normalizeSdgs picks clarisa_sdg_id when sdg_id missing in getData', async () => {
+      api.GET_Alignments.mockResolvedValue({
+        data: {
+          contracts: [],
+          result_sdgs: [],
+          primary_levers: [
+            {
+              lever_id: 1,
+              result_lever_sdgs: [{ clarisa_sdg_id: 8, id: 8, created_at: '', updated_at: '', is_active: true } as any]
+            }
+          ],
+          contributor_levers: []
+        }
+      });
+      await component.getData();
+      expect(component.body().primary_levers[0].result_lever_sdgs?.[0].sdg_id).toBe(8);
+    });
+
+    it('normalizeSdgs uses id when sdg_id and clarisa are absent', async () => {
+      api.GET_Alignments.mockResolvedValue({
+        data: {
+          contracts: [],
+          result_sdgs: [],
+          primary_levers: [
+            {
+              lever_id: 1,
+              result_lever_sdgs: [{ id: 99, created_at: '', updated_at: '', is_active: true } as any]
+            }
+          ],
+          contributor_levers: []
+        }
+      });
+      await component.getData();
+      expect(component.body().primary_levers[0].result_lever_sdgs?.[0].sdg_id).toBe(99);
+    });
+
+    it('computeMergedPrimaryLevers treats missing contracts and primary arrays as empty', () => {
+      component.body.set({
+        contracts: undefined as any,
+        result_sdgs: [],
+        primary_levers: undefined as any,
+        contributor_levers: []
+      });
+      const merged = (component as any).computeMergedPrimaryLevers();
+      expect(Array.isArray(merged)).toBe(true);
+    });
+
+    it('sync effect handles undefined primary_levers on body', () => {
+      component.body.set({
+        contracts: [{ lever_id: 3 }],
+        result_sdgs: [],
+        primary_levers: undefined as any,
+        contributor_levers: []
+      });
+      fixture.detectChanges();
+      TestBed.flushEffects();
+      expect(component.body().primary_levers?.length).toBeGreaterThan(0);
+    });
+
+    it('leverFromCatalog uses id when lever_id is missing', () => {
+      const lever = (component as any).leverFromCatalog({ id: 4, short_name: 'Z', other_names: 'oz' } as any);
+      expect(lever.lever_id).toBe(4);
+    });
+
+    it('anyLeverHasSdgs handles null result_lever_sdgs on a lever', async () => {
+      api.GET_Alignments.mockResolvedValue({
+        data: {
+          contracts: [],
+          result_sdgs: [],
+          primary_levers: [{ lever_id: 1, result_lever_sdgs: null as any }],
+          contributor_levers: []
+        }
+      });
+      await component.getData();
+      expect(component.body().primary_levers[0].result_lever_sdgs).toEqual([]);
+    });
+
+    it('findNestedLeverShape skips contracts until leverId matches', () => {
+      const contracts = [{ lever_id: 1 }, { levers: [{ id: 2, full_name: 'N', short_name: 'Second' }] }];
+      expect((component as any).findNestedLeverShape(contracts, 2)?.short_name).toBe('Second');
+    });
+
+    it('findNestedLeverShape returns undefined when no nested lever matches', () => {
+      expect((component as any).findNestedLeverShape([{ lever_id: 9 }], 2)).toBeUndefined();
+    });
+
+    it('findNestedLeverShape returns on first contract when it matches', () => {
+      const contracts = [{ levers: [{ id: 3, full_name: 'Y', short_name: 'First' }] }];
+      expect((component as any).findNestedLeverShape(contracts, 3)?.short_name).toBe('First');
     });
   });
 });

--- a/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/alliance-alignment.component.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/alliance-alignment.component.ts
@@ -298,16 +298,30 @@ export default class AllianceAlignmentComponent {
     return a.every((x, i) => String(x.lever_id) === String(b[i]?.lever_id));
   }
 
+  private contributorLeversExcludingPrimary(primary: Lever[], contributors: Lever[] | undefined): Lever[] {
+    const primaryIds = new Set((primary ?? []).map(l => String(l.lever_id)));
+    return (contributors ?? []).filter(c => !primaryIds.has(String(c.lever_id)));
+  }
+
   private readonly syncContractLeversToPrimaryEffect = effect(
     () => {
       this.body();
       this.getLeversService.list();
       const merged = this.computeMergedPrimaryLevers();
-      const current = this.body().primary_levers ?? [];
-      if (this.samePrimaryLeverSequence(current, merged)) {
+      const currentPrimary = this.body().primary_levers ?? [];
+      const currentContributors = this.body().contributor_levers ?? [];
+      const primaryIds = new Set(merged.map(l => String(l.lever_id)));
+      const contributorsOverlapPrimary = currentContributors.some(c => primaryIds.has(String(c.lever_id)));
+
+      if (this.samePrimaryLeverSequence(currentPrimary, merged) && !contributorsOverlapPrimary) {
         return;
       }
-      this.body.update(prev => ({ ...prev, primary_levers: merged }));
+
+      this.body.update(prev => ({
+        ...prev,
+        primary_levers: merged,
+        contributor_levers: this.contributorLeversExcludingPrimary(merged, prev.contributor_levers ?? [])
+      }));
     },
     { allowSignalWrites: true }
   );

--- a/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/alliance-alignment.component.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/alliance-alignment.component.ts
@@ -127,7 +127,9 @@ export default class AllianceAlignmentComponent {
     let contributor_levers = mapLevers(response.data.contributor_levers);
 
     const legacyRootSdgs = normalizeSdgs(response.data.result_sdgs);
-    const anyLeverHasSdgs = [...primary_levers, ...contributor_levers].some(l => (l.result_lever_sdgs?.length ?? 0) > 0);
+    const anyLeverHasSdgs = [...primary_levers, ...contributor_levers].some(
+      l => l.result_lever_sdgs != null && l.result_lever_sdgs.length > 0
+    );
 
     if (legacyRootSdgs.length && !anyLeverHasSdgs) {
       const total = primary_levers.length + contributor_levers.length;

--- a/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/alliance-alignment.component.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/alliance-alignment.component.ts
@@ -20,6 +20,7 @@ import { TooltipModule } from 'primeng/tooltip';
 import { getContractStatusClasses } from '@shared/constants/status-classes.constants';
 import { Lever, LeverStrategicOutcome } from '@shared/interfaces/oicr-creation.interface';
 import { GetSdgs } from '@shared/interfaces/get-sdgs.interface';
+import { ResultLeverSdgTargetPayload } from '@shared/interfaces/lever-sdg-target.interface';
 import { AllianceLeverCardComponent } from './components/alliance-lever-card/alliance-lever-card.component';
 
 @Component({
@@ -60,7 +61,13 @@ export default class AllianceAlignmentComponent {
   containerWidth = 0;
 
   private readonly leverOutcomeSignals = new Map<string | number, WritableSignal<{ result_lever_strategic_outcomes: LeverStrategicOutcome[] }>>();
-  private readonly leverSdgSignals = new Map<string | number, WritableSignal<{ result_lever_sdgs: GetSdgs[] }>>();
+  private readonly leverSdgSignals = new Map<
+    string | number,
+    WritableSignal<{
+      result_lever_sdgs: GetSdgs[];
+      result_lever_sdg_targets: ResultLeverSdgTargetPayload[];
+    }>
+  >();
 
   contractServiceParams = computed(() => {
     const indicatorId = this.cache.currentMetadata()?.indicator_id;
@@ -87,10 +94,33 @@ export default class AllianceAlignmentComponent {
         sdg_id: (sdg as GetSdgs & { sdg_id?: number }).sdg_id ?? sdg.clarisa_sdg_id ?? sdg.id
       }));
 
+    const normalizeSdgTargets = (raw: unknown): ResultLeverSdgTargetPayload[] => {
+      if (!Array.isArray(raw)) return [];
+      const out: ResultLeverSdgTargetPayload[] = [];
+      for (const x of raw) {
+        if (typeof x === 'number' && Number.isFinite(x)) {
+          out.push({ sdg_target_id: x });
+          continue;
+        }
+        if (x && typeof x === 'object') {
+          const o = x as Record<string, unknown>;
+          const id = o['sdg_target_id'] ?? o['id'];
+          let n = Number.NaN;
+          if (typeof id === 'number') n = id;
+          else if (typeof id === 'string' && id !== '') n = Number(id);
+          if (Number.isFinite(n) && n > 0) out.push({ sdg_target_id: n });
+        }
+      }
+      return out;
+    };
+
     const mapLevers = (levers: Lever[] | undefined): Lever[] =>
       (levers ?? []).map(l => ({
         ...l,
-        result_lever_sdgs: normalizeSdgs(l.result_lever_sdgs)
+        result_lever_sdgs: normalizeSdgs(l.result_lever_sdgs),
+        result_lever_sdg_targets: normalizeSdgTargets(
+          (l as Lever & { result_lever_sdg_targets?: unknown }).result_lever_sdg_targets
+        )
       }));
 
     let primary_levers = mapLevers(response.data.primary_levers);
@@ -178,6 +208,7 @@ export default class AllianceAlignmentComponent {
       other_names: entry.other_names,
       icon: undefined,
       result_lever_sdgs: [],
+      result_lever_sdg_targets: [],
       result_lever_strategic_outcomes: []
     };
   }
@@ -196,6 +227,7 @@ export default class AllianceAlignmentComponent {
       other_names: nested.other_names,
       icon: nested.lever_url,
       result_lever_sdgs: [],
+      result_lever_sdg_targets: [],
       result_lever_strategic_outcomes: []
     };
   }
@@ -233,6 +265,7 @@ export default class AllianceAlignmentComponent {
       lever_role_id: 1,
       is_primary: true,
       result_lever_sdgs: [],
+      result_lever_sdg_targets: [],
       result_lever_strategic_outcomes: []
     };
   }
@@ -335,7 +368,11 @@ export default class AllianceAlignmentComponent {
         }
         const sdgSig = this.leverSdgSignals.get(l.lever_id);
         if (sdgSig) {
-          next = { ...next, result_lever_sdgs: sdgSig().result_lever_sdgs };
+          const sig = sdgSig();
+          const targets = (sig.result_lever_sdg_targets ?? [])
+            .map(t => ({ sdg_target_id: t.sdg_target_id }))
+            .filter(t => Number.isFinite(t.sdg_target_id) && t.sdg_target_id > 0);
+          next = { ...next, result_lever_sdg_targets: targets, result_lever_sdgs: [] };
         }
         return next;
       };
@@ -476,8 +513,9 @@ export default class AllianceAlignmentComponent {
   getLeverSdgSignal(lever: Lever) {
     let s = this.leverSdgSignals.get(lever.lever_id);
     if (!s) {
-      s = signal<{ result_lever_sdgs: GetSdgs[] }>({
-        result_lever_sdgs: lever.result_lever_sdgs || []
+      s = signal({
+        result_lever_sdgs: lever.result_lever_sdgs || [],
+        result_lever_sdg_targets: lever.result_lever_sdg_targets || []
       });
       this.leverSdgSignals.set(lever.lever_id, s);
     }

--- a/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/alliance-alignment.component.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/alliance-alignment.component.ts
@@ -14,21 +14,29 @@ import { SubmissionService } from '@shared/services/submission.service';
 import { FormHeaderComponent } from '@shared/components/form-header/form-header.component';
 import { VersionWatcherService } from '@shared/services/version-watcher.service';
 import { NavigationButtonsComponent } from '@shared/components/navigation-buttons/navigation-buttons.component';
-import { GetSdgsService } from '@shared/services/control-list/get-sdgs.service';
 import { TooltipModule } from 'primeng/tooltip';
 import { getContractStatusClasses } from '@shared/constants/status-classes.constants';
 import { Lever, LeverStrategicOutcome } from '@shared/interfaces/oicr-creation.interface';
 import { GetSdgs } from '@shared/interfaces/get-sdgs.interface';
+import { AllianceLeverCardComponent } from './components/alliance-lever-card/alliance-lever-card.component';
 
 @Component({
   selector: 'app-alliance-alignment',
-  imports: [MultiSelectModule, FormHeaderComponent, FormsModule, MultiselectComponent, NavigationButtonsComponent, DatePipe, TooltipModule],
+  imports: [
+    MultiSelectModule,
+    FormHeaderComponent,
+    FormsModule,
+    MultiselectComponent,
+    NavigationButtonsComponent,
+    DatePipe,
+    TooltipModule,
+    AllianceLeverCardComponent
+  ],
   templateUrl: './alliance-alignment.component.html'
 })
 export default class AllianceAlignmentComponent {
   environment = environment;
   getContractsService = inject(GetContractsService);
-  getSdgsService = inject(GetSdgsService);
   body: WritableSignal<GetAllianceAlignment> = signal({
     contracts: [],
     result_sdgs: [],
@@ -49,6 +57,7 @@ export default class AllianceAlignmentComponent {
   containerWidth = 0;
 
   private readonly leverOutcomeSignals = new Map<string | number, WritableSignal<{ result_lever_strategic_outcomes: LeverStrategicOutcome[] }>>();
+  private readonly leverSdgSignals = new Map<string | number, WritableSignal<{ result_lever_sdgs: GetSdgs[] }>>();
 
   contractServiceParams = computed(() => {
     const indicatorId = this.cache.currentMetadata()?.indicator_id;
@@ -64,21 +73,46 @@ export default class AllianceAlignmentComponent {
   }
 
   async getData() {
+    this.leverOutcomeSignals.clear();
+    this.leverSdgSignals.clear();
+
     const response = await this.apiService.GET_Alignments(this.cache.getCurrentNumericResultId());
 
-    const mappedData = {
-      contracts: response.data.contracts || [],
-      result_sdgs:
-        response.data.result_sdgs?.map(sdg => ({
-          ...sdg,
-          sdg_id: sdg.clarisa_sdg_id,
-          is_primary: false
-        })) || [],
-      primary_levers: response.data.primary_levers || [],
-      contributor_levers: response.data.contributor_levers || []
-    };
+    const normalizeSdgs = (sdgs: GetSdgs[] | undefined): GetSdgs[] =>
+      (sdgs ?? []).map(sdg => ({
+        ...sdg,
+        sdg_id: (sdg as GetSdgs & { sdg_id?: number }).sdg_id ?? sdg.clarisa_sdg_id ?? sdg.id
+      }));
 
-    this.body.set(mappedData);
+    const mapLevers = (levers: Lever[] | undefined): Lever[] =>
+      (levers ?? []).map(l => ({
+        ...l,
+        result_lever_sdgs: normalizeSdgs(l.result_lever_sdgs)
+      }));
+
+    let primary_levers = mapLevers(response.data.primary_levers);
+    let contributor_levers = mapLevers(response.data.contributor_levers);
+
+    const legacyRootSdgs = normalizeSdgs(response.data.result_sdgs);
+    const anyLeverHasSdgs = [...primary_levers, ...contributor_levers].some(l => (l.result_lever_sdgs?.length ?? 0) > 0);
+
+    if (legacyRootSdgs.length && !anyLeverHasSdgs) {
+      const total = primary_levers.length + contributor_levers.length;
+      if (total === 1) {
+        if (primary_levers.length === 1) {
+          primary_levers = [{ ...primary_levers[0], result_lever_sdgs: legacyRootSdgs }];
+        } else if (contributor_levers.length === 1) {
+          contributor_levers = [{ ...contributor_levers[0], result_lever_sdgs: legacyRootSdgs }];
+        }
+      }
+    }
+
+    this.body.set({
+      contracts: response.data.contracts || [],
+      result_sdgs: [],
+      primary_levers,
+      contributor_levers
+    });
   }
 
   optionsDisabled: WritableSignal<Lever[]> = signal([]);
@@ -139,30 +173,50 @@ export default class AllianceAlignmentComponent {
         return { lever_strategic_outcome_id: 0 } as LeverStrategicOutcome;
       };
 
-      const withOutcomes = this.body().primary_levers.map(l => {
-        const s = this.leverOutcomeSignals.get(l.lever_id);
-        if (!s) return l;
-        const raw: unknown = s().result_lever_strategic_outcomes as unknown;
-        let normalized: LeverStrategicOutcome[] = [];
-        if (Array.isArray(raw)) {
-          normalized = (raw as unknown[]).map(normalizeOutcome);
-        } else if (typeof raw === 'number' || (raw && typeof raw === 'object')) {
-          normalized = [normalizeOutcome(raw)];
+      const mergeLever = (l: Lever): Lever => {
+        let next: Lever = { ...l };
+        const outSig = this.leverOutcomeSignals.get(l.lever_id);
+        if (outSig) {
+          const raw: unknown = outSig().result_lever_strategic_outcomes as unknown;
+          let normalized: LeverStrategicOutcome[] = [];
+          if (Array.isArray(raw)) {
+            normalized = (raw as unknown[]).map(normalizeOutcome);
+          } else if (typeof raw === 'number' || (raw && typeof raw === 'object')) {
+            normalized = [normalizeOutcome(raw)];
+          }
+          next = { ...next, result_lever_strategic_outcomes: normalized };
         }
-        return { ...l, result_lever_strategic_outcomes: normalized };
-      });
+        const sdgSig = this.leverSdgSignals.get(l.lever_id);
+        if (sdgSig) {
+          next = { ...next, result_lever_sdgs: sdgSig().result_lever_sdgs };
+        }
+        return next;
+      };
+
+      const primary_levers = this.body().primary_levers.map(mergeLever);
+      const contributor_levers = this.body().contributor_levers.map(mergeLever);
+
+      const sdgByKey = new Map<number, GetSdgs>();
+      for (const lever of [...primary_levers, ...contributor_levers]) {
+        for (const sdg of lever.result_lever_sdgs ?? []) {
+          const id = sdg.id ?? (sdg as GetSdgs & { sdg_id?: number }).sdg_id ?? sdg.clarisa_sdg_id;
+          if (id != null) sdgByKey.set(Number(id), sdg);
+        }
+      }
+
+      const result_sdgs = [...sdgByKey.values()].map(sdg => ({
+        created_at: sdg.created_at,
+        is_active: sdg.is_active,
+        updated_at: sdg.updated_at,
+        clarisa_sdg_id: sdg.id ?? sdg.clarisa_sdg_id,
+        result_id: numericResultId
+      }));
 
       const dataToSend = {
         ...this.body(),
-        primary_levers: withOutcomes,
-        result_sdgs:
-          this.body().result_sdgs?.map(sdg => ({
-            created_at: sdg.created_at,
-            is_active: sdg.is_active,
-            updated_at: sdg.updated_at,
-            clarisa_sdg_id: sdg.id,
-            result_id: numericResultId
-          })) || []
+        primary_levers,
+        contributor_levers,
+        result_sdgs
       };
 
       const response = await this.apiService.PATCH_Alignments(numericResultId, dataToSend);
@@ -220,6 +274,28 @@ export default class AllianceAlignmentComponent {
     this.actions.saveCurrentSection();
   }
 
+  removePrimaryLever(lever: Lever) {
+    if (!this.submission.isEditableStatus()) return;
+    this.leverOutcomeSignals.delete(lever.lever_id);
+    this.leverSdgSignals.delete(lever.lever_id);
+    this.body.update(current => ({
+      ...current,
+      primary_levers: current.primary_levers.filter(l => l.lever_id !== lever.lever_id)
+    }));
+    this.actions.saveCurrentSection();
+  }
+
+  removeContributorLever(lever: Lever) {
+    if (!this.submission.isEditableStatus()) return;
+    this.leverOutcomeSignals.delete(lever.lever_id);
+    this.leverSdgSignals.delete(lever.lever_id);
+    this.body.update(current => ({
+      ...current,
+      contributor_levers: current.contributor_levers.filter(l => l.lever_id !== lever.lever_id)
+    }));
+    this.actions.saveCurrentSection();
+  }
+
   getShortDescription(description: string): string {
     let max: number;
     if (this.containerWidth < 900) {
@@ -245,6 +321,17 @@ export default class AllianceAlignmentComponent {
         result_lever_strategic_outcomes: lever.result_lever_strategic_outcomes || []
       });
       this.leverOutcomeSignals.set(lever.lever_id, s);
+    }
+    return s;
+  }
+
+  getLeverSdgSignal(lever: Lever) {
+    let s = this.leverSdgSignals.get(lever.lever_id);
+    if (!s) {
+      s = signal<{ result_lever_sdgs: GetSdgs[] }>({
+        result_lever_sdgs: lever.result_lever_sdgs || []
+      });
+      this.leverSdgSignals.set(lever.lever_id, s);
     }
     return s;
   }

--- a/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/alliance-alignment.component.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/alliance-alignment.component.ts
@@ -94,31 +94,11 @@ export default class AllianceAlignmentComponent {
         sdg_id: (sdg as GetSdgs & { sdg_id?: number }).sdg_id ?? sdg.clarisa_sdg_id ?? sdg.id
       }));
 
-    const normalizeSdgTargets = (raw: unknown): ResultLeverSdgTargetPayload[] => {
-      if (!Array.isArray(raw)) return [];
-      const out: ResultLeverSdgTargetPayload[] = [];
-      for (const x of raw) {
-        if (typeof x === 'number' && Number.isFinite(x)) {
-          out.push({ sdg_target_id: x });
-          continue;
-        }
-        if (x && typeof x === 'object') {
-          const o = x as Record<string, unknown>;
-          const id = o['sdg_target_id'] ?? o['id'];
-          let n = Number.NaN;
-          if (typeof id === 'number') n = id;
-          else if (typeof id === 'string' && id !== '') n = Number(id);
-          if (Number.isFinite(n) && n > 0) out.push({ sdg_target_id: n });
-        }
-      }
-      return out;
-    };
-
     const mapLevers = (levers: Lever[] | undefined): Lever[] =>
       (levers ?? []).map(l => ({
         ...l,
         result_lever_sdgs: normalizeSdgs(l.result_lever_sdgs),
-        result_lever_sdg_targets: normalizeSdgTargets((l as Lever & { result_lever_sdg_targets?: unknown }).result_lever_sdg_targets)
+        result_lever_sdg_targets: this.normalizeResultLeverSdgTargets((l as Lever & { result_lever_sdg_targets?: unknown }).result_lever_sdg_targets)
       }));
 
     let primary_levers = mapLevers(response.data.primary_levers);
@@ -185,6 +165,30 @@ export default class AllianceAlignmentComponent {
 
   isLeverRequiredFromContributingProject(lever: Lever): boolean {
     return this.getRequiredLeverIdsFromContracts(this.body().contracts).some(id => String(id) === String(lever.lever_id));
+  }
+
+  parseResultLeverSdgTargetEntry(x: unknown): ResultLeverSdgTargetPayload | null {
+    if (typeof x === 'number' && Number.isFinite(x)) {
+      return { sdg_target_id: x };
+    }
+    if (!x || typeof x !== 'object') return null;
+    const o = x as Record<string, unknown>;
+    const id = o['sdg_target_id'] ?? o['id'];
+    let n = Number.NaN;
+    if (typeof id === 'number') n = id;
+    else if (typeof id === 'string' && id !== '') n = Number(id);
+    if (!Number.isFinite(n) || n <= 0) return null;
+    return { sdg_target_id: n };
+  }
+
+  normalizeResultLeverSdgTargets(raw: unknown): ResultLeverSdgTargetPayload[] {
+    if (!Array.isArray(raw)) return [];
+    const out: ResultLeverSdgTargetPayload[] = [];
+    for (const x of raw) {
+      const parsed = this.parseResultLeverSdgTargetEntry(x);
+      if (parsed) out.push(parsed);
+    }
+    return out;
   }
 
   private getLeverIdFromContract(contract: unknown): string | number | null {

--- a/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/alliance-alignment.component.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/alliance-alignment.component.ts
@@ -1,5 +1,7 @@
 import { Component, computed, effect, ElementRef, inject, signal, ViewChild, WritableSignal } from '@angular/core';
 import { GetContractsService } from '@services/control-list/get-contracts.service';
+import { GetLeversService } from '@services/control-list/get-levers.service';
+import { GetLevers } from '@shared/interfaces/get-levers.interface';
 import { FormsModule } from '@angular/forms';
 import { ApiService } from '../../../../../../shared/services/api.service';
 import { MultiSelectModule } from 'primeng/multiselect';
@@ -37,6 +39,7 @@ import { AllianceLeverCardComponent } from './components/alliance-lever-card/all
 export default class AllianceAlignmentComponent {
   environment = environment;
   getContractsService = inject(GetContractsService);
+  private readonly getLeversService = inject(GetLeversService);
   body: WritableSignal<GetAllianceAlignment> = signal({
     contracts: [],
     result_sdgs: [],
@@ -126,6 +129,147 @@ export default class AllianceAlignmentComponent {
     return this.body().contributor_levers || [];
   }
 
+  getRequiredLeverIdsFromContracts(contracts: unknown[] | undefined): (string | number)[] {
+    const list = contracts ?? [];
+    const ordered: (string | number)[] = [];
+    const seen = new Set<string>();
+    for (const c of list) {
+      const id = this.getLeverIdFromContract(c);
+      if (id == null) continue;
+      const key = String(id);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      ordered.push(id);
+    }
+    return ordered;
+  }
+
+  isLeverRequiredFromContributingProject(lever: Lever): boolean {
+    return this.getRequiredLeverIdsFromContracts(this.body().contracts).some(id => String(id) === String(lever.lever_id));
+  }
+
+  private getLeverIdFromContract(contract: unknown): string | number | null {
+    if (contract == null || typeof contract !== 'object') return null;
+    const c = contract as Record<string, unknown>;
+    const raw = c['levers'];
+    let lv: unknown = raw;
+    if (Array.isArray(lv)) lv = lv[0];
+    if (lv && typeof lv === 'object') {
+      const levers = lv as Record<string, unknown>;
+      const name = levers['full_name'];
+      if (name === 'Not available') return null;
+      const id = levers['id'] ?? levers['lever_id'];
+      if (id != null && id !== '') return id as string | number;
+    }
+    const top = c['lever_id'];
+    if (top != null && top !== '') return top as string | number;
+    return null;
+  }
+
+  private leverFromCatalog(entry: GetLevers): Lever {
+    const lid = entry.lever_id ?? entry.id;
+    return {
+      result_lever_id: 0,
+      result_id: 0,
+      lever_id: lid,
+      lever_role_id: 1,
+      is_primary: true,
+      short_name: entry.short_name,
+      other_names: entry.other_names,
+      icon: undefined,
+      result_lever_sdgs: [],
+      result_lever_strategic_outcomes: []
+    };
+  }
+
+  private leverFromContractNested(
+    nested: { id?: number; short_name?: string; other_names?: string; lever_url?: string },
+    leverId: string | number
+  ): Lever {
+    return {
+      result_lever_id: 0,
+      result_id: 0,
+      lever_id: leverId,
+      lever_role_id: 1,
+      is_primary: true,
+      short_name: nested.short_name,
+      other_names: nested.other_names,
+      icon: nested.lever_url,
+      result_lever_sdgs: [],
+      result_lever_strategic_outcomes: []
+    };
+  }
+
+  private findCatalogLever(leverId: string | number): GetLevers | undefined {
+    const list = this.getLeversService.list() ?? [];
+    return list.find(l => String(l.lever_id ?? l.id) === String(leverId));
+  }
+
+  private findNestedLeverShape(
+    contracts: unknown[],
+    leverId: string | number
+  ): { short_name?: string; other_names?: string; lever_url?: string } | undefined {
+    for (const c of contracts) {
+      if (String(this.getLeverIdFromContract(c)) !== String(leverId)) continue;
+      const raw = (c as Record<string, unknown>)['levers'];
+      let lv: unknown = raw;
+      if (Array.isArray(lv)) lv = lv[0];
+      if (lv && typeof lv === 'object') return lv as { short_name?: string; other_names?: string; lever_url?: string };
+    }
+    return undefined;
+  }
+
+  private resolveLeverForPrimary(leverId: string | number, currentPrimaries: Lever[], contracts: unknown[]): Lever {
+    const existing = currentPrimaries.find(l => String(l.lever_id) === String(leverId));
+    if (existing) return existing;
+    const cat = this.findCatalogLever(leverId);
+    if (cat) return this.leverFromCatalog(cat);
+    const nested = this.findNestedLeverShape(contracts, leverId);
+    if (nested) return this.leverFromContractNested(nested, leverId);
+    return {
+      result_lever_id: 0,
+      result_id: 0,
+      lever_id: leverId,
+      lever_role_id: 1,
+      is_primary: true,
+      result_lever_sdgs: [],
+      result_lever_strategic_outcomes: []
+    };
+  }
+
+  private computeMergedPrimaryLevers(): Lever[] {
+    const b = this.body();
+    const contracts = b.contracts ?? [];
+    const current = b.primary_levers ?? [];
+    const requiredIds = this.getRequiredLeverIdsFromContracts(contracts);
+    const requiredSet = new Set(requiredIds.map(String));
+
+    const requiredLevers = requiredIds.map(id => this.resolveLeverForPrimary(id, current, contracts));
+
+    const optional = current.filter(l => !requiredSet.has(String(l.lever_id)));
+
+    return [...requiredLevers, ...optional];
+  }
+
+  private samePrimaryLeverSequence(a: Lever[], b: Lever[]): boolean {
+    if (a.length !== b.length) return false;
+    return a.every((x, i) => String(x.lever_id) === String(b[i]?.lever_id));
+  }
+
+  private readonly syncContractLeversToPrimaryEffect = effect(
+    () => {
+      this.body();
+      this.getLeversService.list();
+      const merged = this.computeMergedPrimaryLevers();
+      const current = this.body().primary_levers ?? [];
+      if (this.samePrimaryLeverSequence(current, merged)) {
+        return;
+      }
+      this.body.update(prev => ({ ...prev, primary_levers: merged }));
+    },
+    { allowSignalWrites: true }
+  );
+
   updateOptionsDisabledEffect = effect(
     () => {
       this.optionsDisabled.set(this.getPrimaryLeversForOptions());
@@ -135,7 +279,10 @@ export default class AllianceAlignmentComponent {
 
   updatePrimaryOptionsDisabledEffect = effect(
     () => {
-      this.primaryOptionsDisabled.set(this.getContributorLeversForOptions());
+      const contracts = this.body().contracts;
+      const contributor = this.getContributorLeversForOptions();
+      const lockedStubs = this.getRequiredLeverIdsFromContracts(contracts).map(id => ({ lever_id: id }) as Lever);
+      this.primaryOptionsDisabled.set([...contributor, ...lockedStubs]);
     },
     { allowSignalWrites: true }
   );
@@ -276,6 +423,7 @@ export default class AllianceAlignmentComponent {
 
   removePrimaryLever(lever: Lever) {
     if (!this.submission.isEditableStatus()) return;
+    if (this.isLeverRequiredFromContributingProject(lever)) return;
     this.leverOutcomeSignals.delete(lever.lever_id);
     this.leverSdgSignals.delete(lever.lever_id);
     this.body.update(current => ({

--- a/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/alliance-alignment.component.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/alliance-alignment.component.ts
@@ -118,18 +118,14 @@ export default class AllianceAlignmentComponent {
       (levers ?? []).map(l => ({
         ...l,
         result_lever_sdgs: normalizeSdgs(l.result_lever_sdgs),
-        result_lever_sdg_targets: normalizeSdgTargets(
-          (l as Lever & { result_lever_sdg_targets?: unknown }).result_lever_sdg_targets
-        )
+        result_lever_sdg_targets: normalizeSdgTargets((l as Lever & { result_lever_sdg_targets?: unknown }).result_lever_sdg_targets)
       }));
 
     let primary_levers = mapLevers(response.data.primary_levers);
     let contributor_levers = mapLevers(response.data.contributor_levers);
 
     const legacyRootSdgs = normalizeSdgs(response.data.result_sdgs);
-    const anyLeverHasSdgs = [...primary_levers, ...contributor_levers].some(
-      l => l.result_lever_sdgs != null && l.result_lever_sdgs.length > 0
-    );
+    const anyLeverHasSdgs = [...primary_levers, ...contributor_levers].some(l => l.result_lever_sdgs != null && l.result_lever_sdgs.length > 0);
 
     if (legacyRootSdgs.length && !anyLeverHasSdgs) {
       const total = primary_levers.length + contributor_levers.length;
@@ -166,6 +162,7 @@ export default class AllianceAlignmentComponent {
     const ordered: (string | number)[] = [];
     const seen = new Set<string>();
     for (const c of list) {
+      if (!this.isPrimaryContributingContract(c)) continue;
       const id = this.getLeverIdFromContract(c);
       if (id == null) continue;
       const key = String(id);
@@ -174,6 +171,16 @@ export default class AllianceAlignmentComponent {
       ordered.push(id);
     }
     return ordered;
+  }
+
+  private isPrimaryContributingContract(contract: unknown): boolean {
+    if (contract == null || typeof contract !== 'object') return false;
+    const v = (contract as Record<string, unknown>)['is_primary'];
+    return Number(v) === 1;
+  }
+
+  private getPrimaryContracts(contracts: unknown[] | undefined): unknown[] {
+    return (contracts ?? []).filter(c => this.isPrimaryContributingContract(c));
   }
 
   isLeverRequiredFromContributingProject(lever: Lever): boolean {
@@ -258,7 +265,7 @@ export default class AllianceAlignmentComponent {
     if (existing) return existing;
     const cat = this.findCatalogLever(leverId);
     if (cat) return this.leverFromCatalog(cat);
-    const nested = this.findNestedLeverShape(contracts, leverId);
+    const nested = this.findNestedLeverShape(this.getPrimaryContracts(contracts), leverId);
     if (nested) return this.leverFromContractNested(nested, leverId);
     return {
       result_lever_id: 0,

--- a/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/components/alliance-lever-card/alliance-lever-card.component.html
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/components/alliance-lever-card/alliance-lever-card.component.html
@@ -1,0 +1,91 @@
+<div class="flex flex-col gap-4 flex-1 min-w-0 w-full py-3">
+  <div class="flex w-full min-w-0 items-start justify-between gap-3 pb-1.5">
+    <div class="flex min-w-0 flex-1 items-center gap-3.5">
+      @if (lever.icon) {
+      <img [src]="lever.icon" [alt]="lever.short_name || ''" class="h-[28px] w-[28px] shrink-0 rounded-[3px]" />
+      }
+      <span class="font-['Space_Grotesk'] text-[13px] font-[550] uppercase tracking-[2.8px] text-[#8D9299]">
+        {{ lever?.short_name }}{{ lever?.other_names ? ' - ' + lever.other_names : '' }}
+      </span>
+    </div>
+    @if (!disabled) {
+    <button type="button"
+      class="shrink-0 cursor-pointer border-0 bg-transparent p-0 leading-none text-[#CF0808] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#CF0808]/30 rounded"
+      (click)="removeLever.emit()" (keydown.enter)="removeLever.emit()" aria-label="Remove lever">
+      <i class="pi pi-times-circle !text-[20px]"></i>
+    </button>
+    }
+  </div>
+
+  <div class="lever-card-fields w-full min-w-0">
+    @if (showStrategicOutcomes) {
+    <app-multiselect class="block w-full min-w-0" label="Strategic Outcome(s)" [signal]="outcomeSignal"
+      signalOptionValue="result_lever_strategic_outcomes" optionValue="id" optionLabel="strategic_outcome"
+      serviceName="leverStrategicOutcomes" [enableVirtualScroll]="false" [scrollHeight]="'200px'" [columnsOnXl]="true"
+      [textSpan]="'Outcomes selected'" [serviceParams]="lever.lever_id" [disabled]="disabled"
+      [isRequired]="strategicOutcomesRequired" placeholder="Select the outcomes">
+      <ng-template #selectedItems let-value>
+        @if (value?.length > 0) {
+        <div class="flex items-center gap-2">
+          <span>{{ value?.length }} outcome{{ value?.length === 1 ? '' : 's' }} selected</span>
+        </div>
+        }
+      </ng-template>
+      <ng-template #item let-item>
+        <div class="flex items-center gap-2 text-[#4C5158] whitespace-normal break-words leading-5">
+          @if (item?.strategic_outcome?.includes(':')) {
+          <span>
+            <b>{{ item?.strategic_outcome?.split(':')[0] }}:</b>
+            {{ item?.strategic_outcome?.split(':')[1]?.trim() }}
+          </span>
+          } @else {
+          <span>{{ item?.strategic_outcome }}</span>
+          }
+        </div>
+      </ng-template>
+      <ng-template #rows let-strategicOutcome>
+        <div class="flex flex-col w-full">
+          <div class="flex items-center gap-2 text-[#4C5158] whitespace-normal break-words leading-5">
+            @if (strategicOutcome?.strategic_outcome?.includes(':')) {
+            <span>
+              <b>{{ strategicOutcome?.strategic_outcome?.split(':')[0] }}:</b>
+              {{ strategicOutcome?.strategic_outcome?.split(':')[1]?.trim() }}
+            </span>
+            } @else {
+            <span>{{ strategicOutcome?.strategic_outcome }}</span>
+            }
+          </div>
+        </div>
+      </ng-template>
+    </app-multiselect>
+    }
+
+    <app-multiselect class="block w-full min-w-0" label="SDG target(s)" [signal]="sdgSignal" optionLabel="select_label"
+      optionValue="sdg_id" signalOptionValue="result_lever_sdgs" [disabled]="disabled" [removeCondition]="allowRemove"
+      [columnsOnXl]="true" [isRequired]="sdgTargetsRequired" serviceName="sdgs" placeholder="Select the SDG targets">
+      <ng-template #selectedItems let-value>
+        @if (value?.length > 0) {
+        <div class="flex items-center gap-2">
+          <span>{{ value?.length }} SDG{{ value?.length === 1 ? '' : 's' }} selected</span>
+        </div>
+        }
+      </ng-template>
+      <ng-template #rows let-sdg>
+        <div class="flex flex-col w-full">
+          <div
+            class="flex items-center pt-1 xl:pt-0.5 text-[13px] leading-[18px] text-[#4C5158] gap-x-1 font-['Barlow'] font-[600]">
+            @if (sdg.icon) {
+            <img [src]="sdg.icon" [alt]="sdg.short_name" class="w-[35px] h-[35px] mr-2 rounded-[3px]" />
+            }
+            @if (sdg.description) {
+            <span class="text-[15px] text-[#4C5158] font-[600]">
+              SDG {{ sdg.short_name?.split(':')[0] }} -
+              <span class="font-normal">{{ sdg.short_name?.split(':')[1]?.trim() }}</span>
+            </span>
+            }
+          </div>
+        </div>
+      </ng-template>
+    </app-multiselect>
+  </div>
+</div>

--- a/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/components/alliance-lever-card/alliance-lever-card.component.html
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/components/alliance-lever-card/alliance-lever-card.component.html
@@ -47,7 +47,7 @@
         <div class="flex flex-col gap-2">
           @if (item?.strategic_outcome?.includes(':')) {
           <span>
-            <b>{{ item?.strategic_outcome?.split(':')[0] }}:</b>
+            <b>{{ item?.strategic_outcome?.split(':')[0] }} - </b>
             {{ item?.strategic_outcome?.split(':')[1]?.trim() }}
           </span>
           } @else {
@@ -60,7 +60,7 @@
           <div class="flex items-center gap-2 text-[#4C5158] whitespace-normal break-words leading-5">
             @if (strategicOutcome?.strategic_outcome?.includes(':')) {
             <span>
-              <b>{{ strategicOutcome?.strategic_outcome?.split(':')[0] }}:</b>
+              <b>{{ strategicOutcome?.strategic_outcome?.split(':')[0] }} - </b>
               {{ strategicOutcome?.strategic_outcome?.split(':')[1]?.trim() }}
             </span>
             } @else {

--- a/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/components/alliance-lever-card/alliance-lever-card.component.html
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/components/alliance-lever-card/alliance-lever-card.component.html
@@ -10,9 +10,7 @@
     </div>
     @if (!disabled) {
     @if (removeLocked) {
-    <span
-      class="inline-flex shrink-0 cursor-not-allowed"
-      pTooltip="The primary project lever cannot be removed."
+    <span class="inline-flex shrink-0 cursor-not-allowed" pTooltip="The primary project lever cannot be removed."
       tooltipPosition="top">
       <button type="button" disabled
         class="shrink-0 cursor-not-allowed border-0 bg-transparent p-0 leading-none text-[#A2A9AF] focus:outline-none rounded pointer-events-none"
@@ -34,10 +32,10 @@
     @if (showStrategicOutcomes) {
     <app-multiselect class="block w-full min-w-0" label="Strategic Outcome(s)" [signal]="outcomeSignal"
       signalOptionValue="result_lever_strategic_outcomes" optionValue="id" optionLabel="strategic_outcome"
-      serviceName="leverStrategicOutcomes" [enableVirtualScroll]="false" [scrollHeight]="'200px'" [columnsOnXl]="true"
-      [selectedItemsSurfaceColor]="selectedItemsSurfaceColor" [textSpan]="'Outcomes selected'"
-      [serviceParams]="lever.lever_id" [disabled]="disabled"
-      [isRequired]="strategicOutcomesRequired" placeholder="Select the outcomes">
+      serviceName="leverStrategicOutcomes" filterBy="strategic_outcome" [enableVirtualScroll]="false"
+      [scrollHeight]="'200px'" [columnsOnXl]="true" [selectedItemsSurfaceColor]="selectedItemsSurfaceColor"
+      [textSpan]="'Outcomes selected'" [serviceParams]="lever.lever_id" [disabled]="disabled"
+      [optionLabel2]="'strategic_outcome'" [isRequired]="strategicOutcomesRequired" placeholder="Select the outcomes">
       <ng-template #selectedItems let-value>
         @if (value?.length > 0) {
         <div class="flex items-center gap-2">
@@ -46,7 +44,7 @@
         }
       </ng-template>
       <ng-template #item let-item>
-        <div class="flex items-center gap-2 text-[#4C5158] whitespace-normal break-words leading-5">
+        <div class="flex flex-col gap-2">
           @if (item?.strategic_outcome?.includes(':')) {
           <span>
             <b>{{ item?.strategic_outcome?.split(':')[0] }}:</b>
@@ -75,30 +73,29 @@
     }
 
     <app-multiselect class="block w-full min-w-0" label="SDG target(s)" [signal]="sdgSignal" optionLabel="select_label"
-      optionValue="sdg_id" signalOptionValue="result_lever_sdgs" [disabled]="disabled" [removeCondition]="allowRemove"
-      [columnsOnXl]="true" [selectedItemsSurfaceColor]="selectedItemsSurfaceColor" [isRequired]="sdgTargetsRequired"
-      serviceName="sdgs" placeholder="Select the SDG targets">
+      optionLabel2="sdg_target" optionValue="sdg_target_id" signalOptionValue="result_lever_sdg_targets"
+      [disabled]="disabled" [removeCondition]="allowRemove" [columnsOnXl]="true"
+      [selectedItemsSurfaceColor]="selectedItemsSurfaceColor" [isRequired]="sdgTargetsRequired"
+      serviceName="leverSdgTargets" [serviceParams]="lever.lever_id" filterBy="sdg_target_code,sdg_target,select_label"
+      [enableVirtualScroll]="false" [scrollHeight]="'200px'" placeholder="Select the SDG targets">
       <ng-template #selectedItems let-value>
         @if (value?.length > 0) {
         <div class="flex items-center gap-2">
-          <span>{{ value?.length }} SDG{{ value?.length === 1 ? '' : 's' }} selected</span>
+          <span>{{ value?.length }} target{{ value?.length === 1 ? '' : 's' }} selected</span>
         </div>
         }
       </ng-template>
-      <ng-template #rows let-sdg>
-        <div class="flex flex-col w-full">
-          <div
-            class="flex items-center pt-1 xl:pt-0.5 text-[13px] leading-[18px] text-[#4C5158] gap-x-1 font-['Barlow'] font-[600]">
-            @if (sdg.icon) {
-            <img [src]="sdg.icon" [alt]="sdg.short_name" class="w-[35px] h-[35px] mr-2 rounded-[3px]" />
-            }
-            @if (sdg.description) {
-            <span class="text-[15px] text-[#4C5158] font-[600]">
-              SDG {{ sdg.short_name?.split(':')[0] }} -
-              <span class="font-normal">{{ sdg.short_name?.split(':')[1]?.trim() }}</span>
-            </span>
-            }
-          </div>
+      <ng-template #item let-item>
+        <div class="flex flex-col gap-2">
+          <p class="font-[600]">{{ item?.sdg_target_code }}
+            <span class="font-normal">{{ item?.sdg_target }}</span>
+          </p>
+        </div>
+      </ng-template>
+      <ng-template #rows let-tgt>
+        <div class="flex flex-col w-full gap-1">
+          <span class="text-[15px] text-[#4C5158] font-[600]">{{ tgt?.sdg_target_code }}</span>
+          <span class="text-[13px] leading-[18px] text-[#4C5158] font-normal">{{ tgt?.sdg_target }}</span>
         </div>
       </ng-template>
     </app-multiselect>

--- a/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/components/alliance-lever-card/alliance-lever-card.component.html
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/components/alliance-lever-card/alliance-lever-card.component.html
@@ -9,11 +9,24 @@
       </span>
     </div>
     @if (!disabled) {
+    @if (removeLocked) {
+    <span
+      class="inline-flex shrink-0 cursor-not-allowed"
+      pTooltip="The primary project lever cannot be removed."
+      tooltipPosition="top">
+      <button type="button" disabled
+        class="shrink-0 cursor-not-allowed border-0 bg-transparent p-0 leading-none text-[#A2A9AF] focus:outline-none rounded pointer-events-none"
+        aria-label="The primary project lever cannot be removed.">
+        <i class="pi pi-times-circle !text-[20px]" aria-hidden="true"></i>
+      </button>
+    </span>
+    } @else {
     <button type="button"
       class="shrink-0 cursor-pointer border-0 bg-transparent p-0 leading-none text-[#CF0808] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#CF0808]/30 rounded"
       (click)="removeLever.emit()" (keydown.enter)="removeLever.emit()" aria-label="Remove lever">
       <i class="pi pi-times-circle !text-[20px]"></i>
     </button>
+    }
     }
   </div>
 

--- a/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/components/alliance-lever-card/alliance-lever-card.component.html
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/components/alliance-lever-card/alliance-lever-card.component.html
@@ -22,7 +22,8 @@
     <app-multiselect class="block w-full min-w-0" label="Strategic Outcome(s)" [signal]="outcomeSignal"
       signalOptionValue="result_lever_strategic_outcomes" optionValue="id" optionLabel="strategic_outcome"
       serviceName="leverStrategicOutcomes" [enableVirtualScroll]="false" [scrollHeight]="'200px'" [columnsOnXl]="true"
-      [textSpan]="'Outcomes selected'" [serviceParams]="lever.lever_id" [disabled]="disabled"
+      [selectedItemsSurfaceColor]="selectedItemsSurfaceColor" [textSpan]="'Outcomes selected'"
+      [serviceParams]="lever.lever_id" [disabled]="disabled"
       [isRequired]="strategicOutcomesRequired" placeholder="Select the outcomes">
       <ng-template #selectedItems let-value>
         @if (value?.length > 0) {
@@ -62,7 +63,8 @@
 
     <app-multiselect class="block w-full min-w-0" label="SDG target(s)" [signal]="sdgSignal" optionLabel="select_label"
       optionValue="sdg_id" signalOptionValue="result_lever_sdgs" [disabled]="disabled" [removeCondition]="allowRemove"
-      [columnsOnXl]="true" [isRequired]="sdgTargetsRequired" serviceName="sdgs" placeholder="Select the SDG targets">
+      [columnsOnXl]="true" [selectedItemsSurfaceColor]="selectedItemsSurfaceColor" [isRequired]="sdgTargetsRequired"
+      serviceName="sdgs" placeholder="Select the SDG targets">
       <ng-template #selectedItems let-value>
         @if (value?.length > 0) {
         <div class="flex items-center gap-2">

--- a/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/components/alliance-lever-card/alliance-lever-card.component.html
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/components/alliance-lever-card/alliance-lever-card.component.html
@@ -5,7 +5,7 @@
       <img [src]="lever.icon" [alt]="lever.short_name || ''" class="h-[28px] w-[28px] shrink-0 rounded-[3px]" />
       }
       <span class="font-['Space_Grotesk'] text-[13px] font-[550] uppercase tracking-[2.8px] text-[#8D9299]">
-        {{ lever?.short_name }}{{ lever?.other_names ? ' - ' + lever.other_names : '' }}
+        {{ lever.short_name }}{{ lever.other_names ? ' - ' + lever.other_names : '' }}
       </span>
     </div>
     @if (!disabled) {

--- a/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/components/alliance-lever-card/alliance-lever-card.component.html
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/components/alliance-lever-card/alliance-lever-card.component.html
@@ -86,16 +86,27 @@
         }
       </ng-template>
       <ng-template #item let-item>
-        <div class="flex flex-col gap-2">
-          <p class="font-[600]">{{ item?.sdg_target_code }}
-            <span class="font-normal">{{ item?.sdg_target }}</span>
+        <div class="flex w-full min-w-0 items-center gap-3">
+          @if (item?.clarisa_sdg?.icon) {
+          <img [src]="item.clarisa_sdg.icon" [alt]="item.clarisa_sdg.short_name || 'SDG'" loading="lazy"
+            class="h-[35px] w-[35px] shrink-0 rounded-[3px] object-contain" />
+          }
+          <p class="m-0 min-w-0 flex-1 text-left text-[14px] leading-[18px] text-[#4C5158]">
+            <span class="font-[600]">{{ item?.sdg_target_code }}</span><span class="font-normal"> -
+              {{ item?.sdg_target }}</span>
           </p>
         </div>
       </ng-template>
       <ng-template #rows let-tgt>
-        <div class="flex flex-col w-full gap-1">
-          <span class="text-[15px] text-[#4C5158] font-[600]">{{ tgt?.sdg_target_code }}</span>
-          <span class="text-[13px] leading-[18px] text-[#4C5158] font-normal">{{ tgt?.sdg_target }}</span>
+        <div class="flex w-full min-w-0 items-center gap-3">
+          @if (tgt?.clarisa_sdg?.icon) {
+          <img [src]="tgt.clarisa_sdg.icon" [alt]="tgt.clarisa_sdg.short_name || 'SDG'" loading="lazy"
+            class="h-[35px] w-[35px] shrink-0 rounded-[3px] object-contain" />
+          }
+          <p class="m-0 min-w-0 flex-1 text-left text-[14px] leading-[18px] text-[#4C5158]">
+            <span class="font-[600]">{{ tgt?.sdg_target_code }}</span><span class="font-normal"> -
+              {{ tgt?.sdg_target }}</span>
+          </p>
         </div>
       </ng-template>
     </app-multiselect>

--- a/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/components/alliance-lever-card/alliance-lever-card.component.scss
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/components/alliance-lever-card/alliance-lever-card.component.scss
@@ -1,0 +1,25 @@
+:host {
+  display: block;
+  width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+}
+
+.lever-card-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 100%;
+  min-width: 0;
+}
+
+.lever-card-fields app-multiselect {
+  display: block;
+  width: 100%;
+  min-width: 0;
+}
+
+.lever-card-fields ::ng-deep .items {
+  width: 100%;
+  max-width: 100%;
+}

--- a/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/components/alliance-lever-card/alliance-lever-card.component.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/components/alliance-lever-card/alliance-lever-card.component.spec.ts
@@ -49,7 +49,7 @@ describe('AllianceLeverCardComponent', () => {
 
   it('should expose allowRemove and selectedItemsSurfaceColor', () => {
     expect(component.allowRemove()).toBe(true);
-    expect(component.selectedItemsSurfaceColor).toBe('#f6f6f6');
+    expect(component.selectedItemsSurfaceColor).toBe('#E8EBED');
   });
 
   it('should emit removeLever when remove is clicked', () => {

--- a/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/components/alliance-lever-card/alliance-lever-card.component.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/components/alliance-lever-card/alliance-lever-card.component.spec.ts
@@ -1,0 +1,61 @@
+import { signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { AllianceLeverCardComponent } from './alliance-lever-card.component';
+
+describe('AllianceLeverCardComponent', () => {
+  let fixture: ComponentFixture<AllianceLeverCardComponent>;
+  let component: AllianceLeverCardComponent;
+
+  const baseLever = {
+    lever_id: 1,
+    result_lever_id: 0,
+    result_id: 0,
+    lever_role_id: 1,
+    is_primary: true,
+    short_name: 'L',
+    other_names: '',
+    result_lever_sdgs: [],
+    result_lever_sdg_targets: [],
+    result_lever_strategic_outcomes: []
+  } as const;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AllianceLeverCardComponent]
+    })
+      .overrideComponent(AllianceLeverCardComponent, {
+        set: {
+          template:
+            '<button type="button" data-testid="remove" (click)="removeLever.emit()">remove</button>',
+          imports: []
+        }
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(AllianceLeverCardComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('lever', { ...baseLever });
+    fixture.componentRef.setInput(
+      'sdgSignal',
+      signal({ result_lever_sdgs: [], result_lever_sdg_targets: [] })
+    );
+    fixture.componentRef.setInput('outcomeSignal', signal({ result_lever_strategic_outcomes: [] }));
+  });
+
+  it('should create', () => {
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('should expose allowRemove and selectedItemsSurfaceColor', () => {
+    expect(component.allowRemove()).toBe(true);
+    expect(component.selectedItemsSurfaceColor).toBe('#f6f6f6');
+  });
+
+  it('should emit removeLever when remove is clicked', () => {
+    jest.spyOn(component.removeLever, 'emit');
+    fixture.detectChanges();
+    (fixture.nativeElement as HTMLElement).querySelector('[data-testid="remove"]')?.dispatchEvent(new Event('click'));
+    expect(component.removeLever.emit).toHaveBeenCalled();
+  });
+});

--- a/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/components/alliance-lever-card/alliance-lever-card.component.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/components/alliance-lever-card/alliance-lever-card.component.ts
@@ -14,7 +14,7 @@ import { TooltipModule } from 'primeng/tooltip';
 })
 export class AllianceLeverCardComponent {
   readonly allowRemove = (): boolean => true;
-  readonly selectedItemsSurfaceColor = '#f6f6f6';
+  readonly selectedItemsSurfaceColor = '#E8EBED';
 
   removeLever = output<void>();
 

--- a/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/components/alliance-lever-card/alliance-lever-card.component.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/components/alliance-lever-card/alliance-lever-card.component.ts
@@ -1,0 +1,27 @@
+import { Component, Input, output, WritableSignal } from '@angular/core';
+import { Lever, LeverStrategicOutcome } from '@shared/interfaces/oicr-creation.interface';
+import { GetSdgs } from '@shared/interfaces/get-sdgs.interface';
+import { MultiselectComponent } from '@shared/components/custom-fields/multiselect/multiselect.component';
+
+@Component({
+  selector: 'app-alliance-lever-card',
+  standalone: true,
+  imports: [MultiselectComponent],
+  templateUrl: './alliance-lever-card.component.html',
+  styleUrl: './alliance-lever-card.component.scss'
+})
+export class AllianceLeverCardComponent {
+  readonly allowRemove = (): boolean => true;
+
+  removeLever = output<void>();
+
+  @Input({ required: true }) lever!: Lever;
+  @Input({ required: true }) sdgSignal!: WritableSignal<{ result_lever_sdgs: GetSdgs[] }>;
+  @Input({ required: true }) outcomeSignal!: WritableSignal<{ result_lever_strategic_outcomes: LeverStrategicOutcome[] }>;
+
+  @Input() showStrategicOutcomes = false;
+  @Input() strategicOutcomesRequired = false;
+  @Input() sdgTargetsRequired = true;
+
+  @Input() disabled = false;
+}

--- a/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/components/alliance-lever-card/alliance-lever-card.component.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/components/alliance-lever-card/alliance-lever-card.component.ts
@@ -12,6 +12,7 @@ import { MultiselectComponent } from '@shared/components/custom-fields/multisele
 })
 export class AllianceLeverCardComponent {
   readonly allowRemove = (): boolean => true;
+  readonly selectedItemsSurfaceColor = '#f6f6f6';
 
   removeLever = output<void>();
 

--- a/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/components/alliance-lever-card/alliance-lever-card.component.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/components/alliance-lever-card/alliance-lever-card.component.ts
@@ -2,11 +2,12 @@ import { Component, Input, output, WritableSignal } from '@angular/core';
 import { Lever, LeverStrategicOutcome } from '@shared/interfaces/oicr-creation.interface';
 import { GetSdgs } from '@shared/interfaces/get-sdgs.interface';
 import { MultiselectComponent } from '@shared/components/custom-fields/multiselect/multiselect.component';
+import { TooltipModule } from 'primeng/tooltip';
 
 @Component({
   selector: 'app-alliance-lever-card',
   standalone: true,
-  imports: [MultiselectComponent],
+  imports: [MultiselectComponent, TooltipModule],
   templateUrl: './alliance-lever-card.component.html',
   styleUrl: './alliance-lever-card.component.scss'
 })
@@ -16,13 +17,12 @@ export class AllianceLeverCardComponent {
 
   removeLever = output<void>();
 
+  @Input() removeLocked = false;
   @Input({ required: true }) lever!: Lever;
   @Input({ required: true }) sdgSignal!: WritableSignal<{ result_lever_sdgs: GetSdgs[] }>;
   @Input({ required: true }) outcomeSignal!: WritableSignal<{ result_lever_strategic_outcomes: LeverStrategicOutcome[] }>;
-
   @Input() showStrategicOutcomes = false;
   @Input() strategicOutcomesRequired = false;
   @Input() sdgTargetsRequired = true;
-
   @Input() disabled = false;
 }

--- a/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/components/alliance-lever-card/alliance-lever-card.component.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/alliance-alignment/components/alliance-lever-card/alliance-lever-card.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, output, WritableSignal } from '@angular/core';
 import { Lever, LeverStrategicOutcome } from '@shared/interfaces/oicr-creation.interface';
 import { GetSdgs } from '@shared/interfaces/get-sdgs.interface';
+import { ResultLeverSdgTargetPayload } from '@shared/interfaces/lever-sdg-target.interface';
 import { MultiselectComponent } from '@shared/components/custom-fields/multiselect/multiselect.component';
 import { TooltipModule } from 'primeng/tooltip';
 
@@ -19,7 +20,10 @@ export class AllianceLeverCardComponent {
 
   @Input() removeLocked = false;
   @Input({ required: true }) lever!: Lever;
-  @Input({ required: true }) sdgSignal!: WritableSignal<{ result_lever_sdgs: GetSdgs[] }>;
+  @Input({ required: true }) sdgSignal!: WritableSignal<{
+    result_lever_sdgs: GetSdgs[];
+    result_lever_sdg_targets: ResultLeverSdgTargetPayload[];
+  }>;
   @Input({ required: true }) outcomeSignal!: WritableSignal<{ result_lever_strategic_outcomes: LeverStrategicOutcome[] }>;
   @Input() showStrategicOutcomes = false;
   @Input() strategicOutcomesRequired = false;

--- a/research-indicators/src/app/pages/platform/pages/result/pages/links-to-result/links-to-result.component.html
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/links-to-result/links-to-result.component.html
@@ -59,19 +59,18 @@
               </p>
               <div
                 class="flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-[#777C83] !font-['Space_Grotesk']">
-
+                @if (result.result_status?.result_status_id && result.result_status?.name) {
+                <app-custom-tag [statusId]="result.result_status!.result_status_id ?? ''"
+                  [statusName]="result.result_status!.name ?? ''"
+                  [statusColor]="result.result_status?.config?.color?.text ?? ''"
+                  [statusBackground]="result.result_status?.config?.color?.background ?? ''"
+                  [statusBorder]="result.result_status?.config?.color?.border ?? ''" [icon]="true"
+                  [iconName]="result.result_status?.config?.icon?.name ?? ''"
+                  [iconColor]="result.result_status?.config?.icon?.color ?? ''"
+                  [tooltip]="result.result_status?.description ?? ''" class="pr-1.5"></app-custom-tag>
+                }
                 @if (result.result_contracts?.contract_id) {
                 <span class="text-[#8D9299] font-normal text-[12px] !font-['Space_Grotesk']">
-                  @if (result.result_status?.result_status_id && result.result_status?.name) {
-                  <app-custom-tag [statusId]="result.result_status!.result_status_id ?? ''"
-                    [statusName]="result.result_status!.name ?? ''"
-                    [statusColor]="result.result_status?.config?.color?.text ?? ''"
-                    [statusBackground]="result.result_status?.config?.color?.background ?? ''"
-                    [statusBorder]="result.result_status?.config?.color?.border ?? ''" [icon]="true"
-                    [iconName]="result.result_status?.config?.icon?.name ?? ''"
-                    [iconColor]="result.result_status?.config?.icon?.color ?? ''"
-                    [tooltip]="result.result_status?.description ?? ''" class="pr-1.5"></app-custom-tag>
-                  }
                   Reporting Project <i class="pi pi-arrow-right !text-[8px] text-[#777C83] pr-1.5 pl-1"></i>
                   <span class="text-[#345B8F] uppercase font-semibold text-[11px]">{{
                     result.result_contracts?.contract_id }}

--- a/research-indicators/src/app/pages/platform/pages/result/pages/links-to-result/links-to-result.component.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/links-to-result/links-to-result.component.spec.ts
@@ -10,6 +10,7 @@ import { ApiService } from '@shared/services/api.service';
 import { ActionsService } from '@shared/services/actions.service';
 import { ResultsCenterService } from '@pages/platform/pages/results-center/results-center.service';
 import { Result } from '@shared/interfaces/result/result.interface';
+import { mapOtherResultLinkPayloadToResult } from '@shared/utils/map-link-other-result-to-result';
 
 jest.mock('@shared/constants/indicator-icon.constants', () => ({
   getIndicatorIcon: jest.fn().mockReturnValue({ icon: 'pi pi-star', color: '#000' })
@@ -44,7 +45,7 @@ describe('LinksToResultComponent', () => {
 
     apiService = {
       GET_LinkedResults: jest.fn().mockResolvedValue({ data: { link_results: [] } }),
-      GET_Results: jest.fn().mockResolvedValue({ data: [] }),
+      GET_Results: jest.fn(),
       PATCH_LinkedResults: jest.fn().mockResolvedValue({ data: { link_results: [] } })
     } as unknown as jest.Mocked<ApiService>;
 
@@ -183,6 +184,7 @@ describe('LinksToResultComponent', () => {
     submissionService.isEditableStatus.mockReturnValue(false);
     const current = [{ result_id: 1 } as unknown as Result];
     component.linkedResults.set(current);
+    allModalsService.syncSelectedResults.set.mockClear();
 
     component.removeLinkedResult(1);
 
@@ -257,36 +259,52 @@ describe('LinksToResultComponent', () => {
     expect(component.linkedResults()).toEqual([]);
   });
 
-  it('should use empty array when GET_Results returns non-array data (line 91 fallback)', async () => {
+  it('should map nothing when link rows have no embedded other_result', async () => {
     apiService.GET_LinkedResults.mockResolvedValueOnce({
       data: { link_results: [{ other_result_id: 1 }] }
     } as any);
-    apiService.GET_Results.mockResolvedValueOnce({ data: null } as any);
+    apiService.GET_Results.mockClear();
 
     await component.loadLinkedResults();
 
-    expect(apiService.GET_Results).toHaveBeenCalled();
+    expect(apiService.GET_Results).not.toHaveBeenCalled();
     expect(component.linkedResults()).toEqual([]);
   });
 
-  it('should load and map linked results when ids exist', async () => {
-    const linkedIds = [{ other_result_id: 1 }, { other_result_id: 2 }];
-    const allResults: Result[] = [
-      { result_id: 1, result_official_code: '001', title: 'R1' } as any,
-      { result_id: 2, result_official_code: '002', title: 'R2' } as any,
-      { result_id: 3, result_official_code: '003', title: 'R3' } as any
-    ];
+  it('should load and map linked results from embedded other_result (no GET_Results)', async () => {
+    const o1 = {
+      result_id: 1,
+      result_official_code: 1,
+      title: 'R1',
+      platform_code: 'STAR',
+      indicator_id: 1
+    };
+    const o2 = {
+      result_id: 2,
+      result_official_code: 2,
+      title: 'R2',
+      platform_code: 'STAR',
+      indicator_id: 2
+    };
+    const expected: Result[] = [mapOtherResultLinkPayloadToResult(o1), mapOtherResultLinkPayloadToResult(o2)];
 
-    apiService.GET_LinkedResults.mockResolvedValueOnce({ data: { link_results: linkedIds } } as any);
-    apiService.GET_Results.mockResolvedValueOnce({ data: allResults } as any);
+    apiService.GET_LinkedResults.mockResolvedValueOnce({
+      data: {
+        link_results: [
+          { other_result_id: 1, other_result: o1 },
+          { other_result_id: 2, other_result: o2 }
+        ]
+      }
+    } as any);
+    apiService.GET_Results.mockClear();
 
     await component.loadLinkedResults();
 
     expect(apiService.GET_LinkedResults).toHaveBeenCalledWith(123);
-    expect(apiService.GET_Results).toHaveBeenCalled();
-    expect(component.linkedResults()).toEqual(allResults.slice(0, 2));
-    expect(component.originalLinkedResults()).toEqual(allResults.slice(0, 2));
-    expect(allModalsService.syncSelectedResults.set).toHaveBeenCalledWith(allResults.slice(0, 2));
+    expect(apiService.GET_Results).not.toHaveBeenCalled();
+    expect(component.linkedResults()).toEqual(expected);
+    expect(component.originalLinkedResults()).toEqual(expected);
+    expect(allModalsService.syncSelectedResults.set).toHaveBeenCalledWith(expected);
     expect(component.loading()).toBe(false);
   });
 

--- a/research-indicators/src/app/pages/platform/pages/result/pages/links-to-result/links-to-result.component.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/links-to-result/links-to-result.component.ts
@@ -7,13 +7,14 @@ import { CacheService } from '@shared/services/cache/cache.service';
 import { SubmissionService } from '@shared/services/submission.service';
 import { AllModalsService } from '@shared/services/cache/all-modals.service';
 import { ApiService } from '@shared/services/api.service';
-import { Result, ResultConfig } from '@shared/interfaces/result/result.interface';
+import { Result } from '@shared/interfaces/result/result.interface';
 import { TooltipModule } from 'primeng/tooltip';
 import { ActionsService } from '@shared/services/actions.service';
 import { LinkResultsResponse } from '@shared/interfaces/link-results.interface';
 import { CustomTagComponent } from '@shared/components/custom-tag/custom-tag.component';
 import { getIndicatorIcon } from '@shared/constants/indicator-icon.constants';
 import { ResultsCenterService } from '@pages/platform/pages/results-center/results-center.service';
+import { mapOtherResultLinkPayloadToResult } from '@shared/utils/map-link-other-result-to-result';
 
 const MODAL_INDICATOR_CODES = [1, 2, 3, 4, 6] as const;
 
@@ -64,36 +65,20 @@ export default class LinksToResultComponent implements OnInit, OnDestroy {
     try {
       const resultId = this.cache.getCurrentNumericResultId();
       const response = await this.api.GET_LinkedResults(resultId);
-      const linkedResultIds = response.data?.link_results?.map(item => item.other_result_id) ?? [];
-      
-      if (linkedResultIds.length === 0) {
+      const items = response.data?.link_results ?? [];
+
+      if (items.length === 0) {
         this.linkedResults.set([]);
+        this.originalLinkedResults.set([]);
+        this.allModalsService.syncSelectedResults.set([]);
         return;
       }
 
-      const resultFilter = {
-        'indicator-codes-tabs': [...MODAL_INDICATOR_CODES],
-        'indicator-codes-filter': []
-      };
-      
-      const resultConfig: ResultConfig = {
-        indicators: true,
-        'result-status': true,
-        contracts: true,
-        'primary-contract': true,
-        'primary-lever': true,
-        levers: true,
-        'audit-data': true,
-        'audit-data-object': true
-      };
+      const matched = items
+        .map(item => item.other_result)
+        .filter((o): o is NonNullable<typeof o> => o != null)
+        .map(mapOtherResultLinkPayloadToResult);
 
-      const resultsResponse = await this.api.GET_Results(resultFilter, resultConfig);
-      const allResults = Array.isArray(resultsResponse?.data) ? resultsResponse.data : [];
-      
-      const matched = allResults.filter(result => 
-        linkedResultIds.includes(result.result_id)
-      );
-      
       this.linkedResults.set(matched);
       this.originalLinkedResults.set([...matched]);
       this.allModalsService.syncSelectedResults.set(matched);
@@ -185,4 +170,3 @@ export default class LinksToResultComponent implements OnInit, OnDestroy {
     this.allModalsService.openModal('selectLinkedResults');
   }
 }
-

--- a/research-indicators/src/app/pages/platform/pages/result/pages/oicr-details/components/impact-areas/impact-areas.component.html
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/oicr-details/components/impact-areas/impact-areas.component.html
@@ -20,19 +20,20 @@
 
       <div class="relative w-full min-w-0 flex-1 flex-col">
         <div class="input-container">
-          <label class="label inline-block" [attr.for]="'impact-area-global-target-' + area.id"><span>Global Target</span>@if (isGlobalTargetRequired(area.id)) {<span class="text-red-500">*</span>}</label>
+          <label class="label inline-block" [attr.for]="'impact-area-global-target-' + area.id"><span>Global
+              Target</span>@if (isGlobalTargetRequired(area.id)) {<span class="text-red-500">*</span>}</label>
         </div>
         <div class="items">
-          <div>
-            <p-multiSelect [inputId]="'impact-area-global-target-' + area.id"
+          <div class="w-full min-w-0" #globalTargetTrigger>
+            <p-multiSelect #globalTargetMs [inputId]="'impact-area-global-target-' + area.id"
               [style]="isGlobalTargetInvalid(area.id) ? { width: '100%', border: '2px solid #E69F00' } : { width: '100%' }"
-              [options]="globalTargetOptions(area.id) ?? []"
-              [loading]="globalTargetLoading(area.id)" [display]="'comma'" optionLabel="target" optionValue="targetId"
-              [showToggleAll]="false" [filter]="true" filterBy="smo_code,target"
-              [ngModel]="getGlobalTargetIdsSignal(area.id)()" (ngModelChange)="onGlobalTargetIdsChange(area.id, $event)"
-              [disabled]="disabled" [virtualScroll]="false" [scrollHeight]="'145px'"
-              placeholder="Select the Global Target" appendTo="self"
-              [panelStyle]="{ width: '100%', minWidth: '100%', maxWidth: '100%', boxSizing: 'border-box' }">
+              [options]="globalTargetOptions(area.id) ?? []" [loading]="globalTargetLoading(area.id)"
+              [display]="'comma'" optionLabel="target" optionValue="targetId" [showToggleAll]="false" [filter]="true"
+              filterBy="smo_code,target" [ngModel]="getGlobalTargetIdsSignal(area.id)()"
+              (ngModelChange)="onGlobalTargetIdsChange(area.id, $event)" [disabled]="disabled" [virtualScroll]="false"
+              [scrollHeight]="'145px'" placeholder="Select the Global Target" appendTo="body" [baseZIndex]="11000"
+              [panelStyle]="globalTargetPanelStyle(area.id)"
+              (onPanelShow)="onGlobalTargetPanelOpen(area.id, globalTargetMs, globalTargetTrigger)">
               <ng-template pTemplate="selectedItems" let-value>
                 @if (value?.length > 0) {
                 <span class="text-[#777C83]">{{ value.length }} selected</span>

--- a/research-indicators/src/app/pages/platform/pages/result/pages/oicr-details/components/impact-areas/impact-areas.component.html
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/oicr-details/components/impact-areas/impact-areas.component.html
@@ -1,18 +1,7 @@
 <div class="flex flex-col gap-6">
 
-  <!-- Global Target Item Template -->
-  <ng-template #globalTargetItemTemplate let-item>
-    <div class="flex items-center block whitespace-normal break-words gap-2 text-[#4C5158]">
-      <span class="font-[600]">
-        {{ item?.smo_code }} <span class="font-['Barlow'] font-normal">{{ item?.target }}</span>
-      </span>
-    </div>
-  </ng-template>
-
-  <!-- Impact Areas List -->
   @for (area of impactAreasService.list() || []; track area.id) {
   <div class="flex flex-col gap-4 p-7 bg-[#F4F7F9] border border-[#E8EBED] rounded-lg">
-    <!-- Impact Area Header -->
     <div class="flex items-center gap-3">
       <div class="w-8 h-8 rounded flex items-center justify-center overflow-hidden">
         <img [src]="area.icon" [alt]="area.name" class="w-full h-full object-cover">
@@ -22,35 +11,78 @@
       </span>
     </div>
 
-    <div class="flex flex-col xl:flex-row gap-5 justify-between pt-2.5">
-      <!-- Impact Area Score -->
+    <div class="flex flex-col xl:flex-row xl:items-start gap-5 justify-between pt-2.5">
       <app-radio-button [label]="'Impact Area Score'" [isRequired]="true" [signal]="getImpactAreaScore(area.id)"
         [disabled]="disabled" [serviceName]="'impactAreaScores'" [optionLabel]="'name'"
         [optionValue]="{ body: 'score', option: 'id' }" [direction]="'horizontal'" [spaceX]="'gap-4'"
         [centerOptions]="true" (selectEvent)="onScoreChange(area.id, $event)">
       </app-radio-button>
 
-      <div class="flex-1">
-        <app-select [signal]="getImpactAreaGlobalTarget(area.id)" [disabled]="disabled"
-          [isRequired]="isGlobalTargetRequired(area.id)" label="Global Target" serviceName="globalTargets"
-          optionLabel="target" [serviceParams]="area.id"
-          [optionValue]="{ body: 'global_target_id', option: 'targetId' }" placeholder="Select the Global Target"
-          [scrollHeight]="'145px'" (selectEvent)="onGlobalTargetChange(area.id, $event)">
-
-          <!-- Selected item template -->
-          <ng-template #selectedItemTemplate let-value>
-            <ng-container [ngTemplateOutlet]="globalTargetItemTemplate"
-              [ngTemplateOutletContext]="{ $implicit: value }"></ng-container>
-          </ng-template>
-
-          <!-- Item template -->
-          <ng-template #item let-item>
-            <ng-container [ngTemplateOutlet]="globalTargetItemTemplate"
-              [ngTemplateOutletContext]="{ $implicit: item }"></ng-container>
-          </ng-template>
-        </app-select>
+      <div class="relative w-full min-w-0 flex-1 flex-col">
+        <div class="input-container">
+          <label class="label inline-block flex items-center" [attr.for]="'impact-area-global-target-' + area.id">
+            Global Target
+            @if (isGlobalTargetRequired(area.id)) {
+            <span class="text-red-500">*</span>
+            }
+          </label>
+        </div>
+        <div class="items">
+          <div>
+            <p-multiSelect [inputId]="'impact-area-global-target-' + area.id"
+              [style]="isGlobalTargetInvalid(area.id) ? { width: '100%', border: '2px solid #E69F00' } : { width: '100%' }"
+              [options]="globalTargetOptions(area.id) ?? []"
+              [loading]="globalTargetLoading(area.id)" [display]="'comma'" optionLabel="target" optionValue="targetId"
+              [showToggleAll]="false" [filter]="true" filterBy="smo_code,target"
+              [ngModel]="getGlobalTargetIdsSignal(area.id)()" (ngModelChange)="onGlobalTargetIdsChange(area.id, $event)"
+              [disabled]="disabled" [virtualScroll]="false" [scrollHeight]="'145px'"
+              placeholder="Select the Global Target" appendTo="self"
+              [panelStyle]="{ width: '100%', minWidth: '100%', maxWidth: '100%', boxSizing: 'border-box' }">
+              <ng-template pTemplate="selectedItems" let-value>
+                @if (value?.length > 0) {
+                <span class="text-[#777C83]">{{ value.length }} selected</span>
+                }
+              </ng-template>
+              <ng-template pTemplate="item" let-item>
+                <span
+                  class="block w-full min-w-0 text-left text-[14px] leading-[18px] text-[#4C5158] font-['Barlow'] whitespace-normal break-words">
+                  <span class="font-[600]">{{ item?.smo_code }}</span><span class="font-normal"> {{ item?.target
+                    }}</span>
+                </span>
+              </ng-template>
+            </p-multiSelect>
+            @if (isGlobalTargetInvalid(area.id)) {
+            <div class="flex items-center gap-1 mt-1 text-[#E69F00] text-sm">
+              <i class="material-symbols-rounded !text-base">warning</i>
+              <span>This field is required</span>
+            </div>
+            }
+          </div>
+        </div>
       </div>
     </div>
+
+    @if (selectedGlobalTargetRows(area.id).length > 0) {
+    <div class="flex w-full min-w-0 flex-col gap-3 xl:flex-row xl:flex-wrap xl:gap-4">
+      @for (row of selectedGlobalTargetRows(area.id); track row.targetId) {
+      <div
+        class="flex w-full min-w-0 items-center justify-between gap-3 rounded-[6px] border !border-[#c6cdd1]/40 bg-[#E8EBED] px-5 py-2.5 xl:w-[calc(50%-0.5rem)] xl:max-w-none xl:flex-none">
+        <p
+          class="m-0 min-w-0 flex-1 text-left text-[14px] leading-[18px] text-[#4C5158] font-['Barlow'] line-clamp-4 [overflow-wrap:anywhere]">
+          <span class="font-[600]">{{ row.smo_code }}</span><span class="font-normal"> {{ row.target }}</span>
+        </p>
+        @if (!disabled) {
+        <button type="button"
+          class="multiselect-row-remove shrink-0 cursor-pointer border-0 bg-transparent p-0 leading-none text-[#CF0808] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#CF0808]/30 rounded"
+          (click)="removeGlobalTargetRow(area.id, row.targetId)"
+          (keydown.enter)="removeGlobalTargetRow(area.id, row.targetId)" aria-label="Remove">
+          <i class="pi pi-times-circle !text-[20px]"></i>
+        </button>
+        }
+      </div>
+      }
+    </div>
+    }
   </div>
   }
 </div>

--- a/research-indicators/src/app/pages/platform/pages/result/pages/oicr-details/components/impact-areas/impact-areas.component.html
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/oicr-details/components/impact-areas/impact-areas.component.html
@@ -20,12 +20,7 @@
 
       <div class="relative w-full min-w-0 flex-1 flex-col">
         <div class="input-container">
-          <label class="label inline-block flex items-center" [attr.for]="'impact-area-global-target-' + area.id">
-            Global Target
-            @if (isGlobalTargetRequired(area.id)) {
-            <span class="text-red-500">*</span>
-            }
-          </label>
+          <label class="label inline-block" [attr.for]="'impact-area-global-target-' + area.id"><span>Global Target</span>@if (isGlobalTargetRequired(area.id)) {<span class="text-red-500">*</span>}</label>
         </div>
         <div class="items">
           <div>

--- a/research-indicators/src/app/pages/platform/pages/result/pages/oicr-details/components/impact-areas/impact-areas.component.html
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/oicr-details/components/impact-areas/impact-areas.component.html
@@ -27,7 +27,7 @@
           <div class="w-full min-w-0" #globalTargetTrigger>
             <p-multiSelect #globalTargetMs [inputId]="'impact-area-global-target-' + area.id"
               [style]="isGlobalTargetInvalid(area.id) ? { width: '100%', border: '2px solid #E69F00' } : { width: '100%' }"
-              [options]="globalTargetOptions(area.id) ?? []" [loading]="globalTargetLoading(area.id)"
+              [options]="globalTargetOptions(area.id)" [loading]="globalTargetLoading(area.id)"
               [display]="'comma'" optionLabel="target" optionValue="targetId" [showToggleAll]="false" [filter]="true"
               filterBy="smo_code,target" [ngModel]="getGlobalTargetIdsSignal(area.id)()"
               (ngModelChange)="onGlobalTargetIdsChange(area.id, $event)" [disabled]="disabled" [virtualScroll]="false"

--- a/research-indicators/src/app/pages/platform/pages/result/pages/oicr-details/components/impact-areas/impact-areas.component.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/oicr-details/components/impact-areas/impact-areas.component.spec.ts
@@ -3,15 +3,44 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ImpactAreasComponent } from './impact-areas.component';
 import { ServiceLocatorService } from '@shared/services/service-locator.service';
 import { signal } from '@angular/core';
-import { ResultImpactArea, ImpactAreasBody, BaseService } from '@shared/interfaces/impact-area.interface';
+import { ImpactAreasBody, BaseService } from '@shared/interfaces/impact-area.interface';
+import { GlobalTargetsService } from '@shared/services/short-control-list/global-targets.service';
+import { ImpactAreasService } from '@shared/services/short-control-list/impact-areas.service';
+import { GlobalTarget } from '@shared/interfaces/global-target.interface';
 
 describe('ImpactAreasComponent', () => {
   let component: ImpactAreasComponent;
   let fixture: ComponentFixture<ImpactAreasComponent>;
   let serviceLocatorMock: jest.Mocked<ServiceLocatorService>;
   let mockImpactAreasService: jest.Mocked<BaseService>;
+  let listSignalForArea1: ReturnType<typeof signal<GlobalTarget[]>>;
+  let loadingSignalForArea1: ReturnType<typeof signal<boolean>>;
+  let mockGlobalTargetsService: {
+    main: jest.Mock;
+    getList: jest.Mock;
+    getLoading: jest.Mock;
+  };
 
   beforeEach(async () => {
+    listSignalForArea1 = signal<GlobalTarget[]>([]);
+    loadingSignalForArea1 = signal(false);
+
+    mockGlobalTargetsService = {
+      main: jest.fn().mockResolvedValue(undefined),
+      getList: jest.fn((areaId?: number) => {
+        if (areaId === 1) {
+          return listSignalForArea1;
+        }
+        return signal<GlobalTarget[]>([]);
+      }),
+      getLoading: jest.fn((areaId?: number) => {
+        if (areaId === 1) {
+          return loadingSignalForArea1;
+        }
+        return signal(false);
+      })
+    };
+
     mockImpactAreasService = {
       list: signal([
         { id: 1, name: 'Impact Area 1', icon: 'icon1.png' },
@@ -28,7 +57,14 @@ describe('ImpactAreasComponent', () => {
     await TestBed.configureTestingModule({
       imports: [ImpactAreasComponent, HttpClientTestingModule],
       providers: [
-        { provide: ServiceLocatorService, useValue: serviceLocatorMock }
+        { provide: ServiceLocatorService, useValue: serviceLocatorMock },
+        { provide: GlobalTargetsService, useValue: mockGlobalTargetsService },
+        {
+          provide: ImpactAreasService,
+          useValue: {
+            list: mockImpactAreasService.list
+          }
+        }
       ]
     }).compileComponents();
 
@@ -39,6 +75,11 @@ describe('ImpactAreasComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should trigger globalTargetsService.main for each impact area in list', () => {
+    expect(mockGlobalTargetsService.main).toHaveBeenCalledWith(1);
+    expect(mockGlobalTargetsService.main).toHaveBeenCalledWith(2);
   });
 
   describe('Input properties', () => {
@@ -53,7 +94,7 @@ describe('ImpactAreasComponent', () => {
           {
             impact_area_id: 1,
             impact_area_score_id: 2,
-            global_target_id: 3
+            result_impact_area_global_targets: [{ global_target_id: 3 }]
           }
         ]
       };
@@ -80,7 +121,7 @@ describe('ImpactAreasComponent', () => {
           {
             impact_area_id: 1,
             impact_area_score_id: 3,
-            global_target_id: null
+            result_impact_area_global_targets: []
           }
         ]
       };
@@ -94,7 +135,7 @@ describe('ImpactAreasComponent', () => {
           {
             impact_area_id: 1,
             impact_area_score_id: 2,
-            global_target_id: null
+            result_impact_area_global_targets: []
           }
         ]
       };
@@ -113,7 +154,7 @@ describe('ImpactAreasComponent', () => {
           {
             impact_area_id: 1,
             impact_area_score_id: undefined as any,
-            global_target_id: null
+            result_impact_area_global_targets: []
           }
         ]
       };
@@ -141,7 +182,7 @@ describe('ImpactAreasComponent', () => {
           {
             impact_area_id: 1,
             impact_area_score_id: 5,
-            global_target_id: null
+            result_impact_area_global_targets: []
           }
         ]
       };
@@ -149,22 +190,22 @@ describe('ImpactAreasComponent', () => {
       tick();
       flush();
       fixture.detectChanges();
-      
+
       const scoreSignal = component.getImpactAreaScore(1);
       expect(scoreSignal().score).toBe(5);
     }));
   });
 
-  describe('getImpactAreaGlobalTarget', () => {
-    it('should return signal for global target', () => {
-      const targetSignal = component.getImpactAreaGlobalTarget(1);
-      expect(targetSignal).toBeDefined();
-      expect(targetSignal().global_target_id).toBeNull();
+  describe('getGlobalTargetIdsSignal', () => {
+    it('should return signal for global target ids', () => {
+      const idsSignal = component.getGlobalTargetIdsSignal(1);
+      expect(idsSignal).toBeDefined();
+      expect(idsSignal()).toEqual([]);
     });
 
     it('should return existing signal if already created', () => {
-      const signal1 = component.getImpactAreaGlobalTarget(1);
-      const signal2 = component.getImpactAreaGlobalTarget(1);
+      const signal1 = component.getGlobalTargetIdsSignal(1);
+      const signal2 = component.getGlobalTargetIdsSignal(1);
       expect(signal1).toBe(signal2);
     });
 
@@ -174,7 +215,7 @@ describe('ImpactAreasComponent', () => {
           {
             impact_area_id: 1,
             impact_area_score_id: null,
-            global_target_id: 10
+            result_impact_area_global_targets: [{ global_target_id: 10 }]
           }
         ]
       };
@@ -182,17 +223,81 @@ describe('ImpactAreasComponent', () => {
       tick();
       flush();
       fixture.detectChanges();
-      
-      const targetSignal = component.getImpactAreaGlobalTarget(1);
-      expect(targetSignal().global_target_id).toBe(10);
+
+      const idsSignal = component.getGlobalTargetIdsSignal(1);
+      expect(idsSignal()).toEqual([10]);
     }));
+  });
+
+  describe('globalTargetOptions and globalTargetLoading', () => {
+    it('should delegate to GlobalTargetsService', () => {
+      listSignalForArea1.set([
+        {
+          targetId: 1,
+          smo_code: 'S',
+          target: 'T',
+          impactAreaId: 1,
+          impactAreaName: 'A'
+        }
+      ]);
+      expect(component.globalTargetOptions(1)).toEqual(listSignalForArea1());
+      loadingSignalForArea1.set(true);
+      expect(component.globalTargetLoading(1)).toBe(true);
+    });
+  });
+
+  describe('selectedGlobalTargetRows', () => {
+    it('should map ids to options when present', () => {
+      const row: GlobalTarget = {
+        targetId: 7,
+        smo_code: 'x',
+        target: 'y',
+        impactAreaId: 1,
+        impactAreaName: 'n'
+      };
+      listSignalForArea1.set([row]);
+      component.getGlobalTargetIdsSignal(1).set([7]);
+      expect(component.selectedGlobalTargetRows(1)).toEqual([row]);
+    });
+
+    it('should use placeholder when option is missing', () => {
+      listSignalForArea1.set([]);
+      component.getGlobalTargetIdsSignal(1).set([99]);
+      const rows = component.selectedGlobalTargetRows(1);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        targetId: 99,
+        smo_code: '',
+        target: '',
+        impactAreaId: 1,
+        impactAreaName: ''
+      });
+    });
+
+    it('should treat undefined options from service as empty array', () => {
+      mockGlobalTargetsService.getList.mockImplementationOnce(() => signal(undefined as unknown as GlobalTarget[]));
+      component.getGlobalTargetIdsSignal(1).set([3]);
+      const rows = component.selectedGlobalTargetRows(1);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].targetId).toBe(3);
+    });
+  });
+
+  describe('removeGlobalTargetRow', () => {
+    it('should remove id and persist to body', () => {
+      component.body.set({});
+      component.onGlobalTargetIdsChange(1, [5, 9]);
+      component.removeGlobalTargetRow(1, 5);
+      expect(component.getGlobalTargetIdsSignal(1)()).toEqual([9]);
+      expect(component.body().result_impact_areas?.[0].result_impact_area_global_targets).toEqual([{ global_target_id: 9 }]);
+    });
   });
 
   describe('onScoreChange', () => {
     it('should create new impact area if not exists', () => {
       component.body.set({});
       component.onScoreChange(1, 2);
-      
+
       const body = component.body();
       expect(body.result_impact_areas).toBeDefined();
       expect(body.result_impact_areas?.length).toBe(1);
@@ -206,13 +311,13 @@ describe('ImpactAreasComponent', () => {
           {
             impact_area_id: 1,
             impact_area_score_id: 2,
-            global_target_id: null
+            result_impact_area_global_targets: []
           }
         ]
       };
       component.body.set(body);
       component.onScoreChange(1, 5);
-      
+
       const updatedBody = component.body();
       expect(updatedBody.result_impact_areas?.[0].impact_area_score_id).toBe(5);
     });
@@ -220,7 +325,7 @@ describe('ImpactAreasComponent', () => {
     it('should update score signal', () => {
       component.body.set({});
       component.onScoreChange(1, 3);
-      
+
       const scoreSignal = component.getImpactAreaScore(1);
       expect(scoreSignal().score).toBe(3);
     });
@@ -228,57 +333,74 @@ describe('ImpactAreasComponent', () => {
     it('should initialize result_impact_areas if undefined', () => {
       component.body.set({ result_impact_areas: undefined as any });
       component.onScoreChange(1, 2);
-      
+
       const body = component.body();
       expect(body.result_impact_areas).toBeDefined();
       expect(body.result_impact_areas?.length).toBe(1);
     });
   });
 
-  describe('onGlobalTargetChange', () => {
+  describe('onGlobalTargetIdsChange', () => {
     it('should create new impact area if not exists', () => {
       component.body.set({});
-      component.onGlobalTargetChange(1, 10);
-      
+      component.onGlobalTargetIdsChange(1, [10]);
+
       const body = component.body();
       expect(body.result_impact_areas).toBeDefined();
       expect(body.result_impact_areas?.length).toBe(1);
       expect(body.result_impact_areas?.[0].impact_area_id).toBe(1);
-      expect(body.result_impact_areas?.[0].global_target_id).toBe(10);
+      expect(body.result_impact_areas?.[0].result_impact_area_global_targets).toEqual([{ global_target_id: 10 }]);
     });
 
-    it('should update existing impact area global target', () => {
+    it('should update existing impact area global targets', () => {
       const body: ImpactAreasBody = {
         result_impact_areas: [
           {
             impact_area_id: 1,
             impact_area_score_id: null,
-            global_target_id: 5
+            result_impact_area_global_targets: [{ global_target_id: 5 }]
           }
         ]
       };
       component.body.set(body);
-      component.onGlobalTargetChange(1, 15);
-      
+      component.onGlobalTargetIdsChange(1, [15]);
+
       const updatedBody = component.body();
-      expect(updatedBody.result_impact_areas?.[0].global_target_id).toBe(15);
+      expect(updatedBody.result_impact_areas?.[0].result_impact_area_global_targets).toEqual([{ global_target_id: 15 }]);
     });
 
-    it('should update global target signal', () => {
+    it('should update global target ids signal', () => {
       component.body.set({});
-      component.onGlobalTargetChange(1, 20);
-      
-      const targetSignal = component.getImpactAreaGlobalTarget(1);
-      expect(targetSignal().global_target_id).toBe(20);
+      component.onGlobalTargetIdsChange(1, [20]);
+
+      const idsSignal = component.getGlobalTargetIdsSignal(1);
+      expect(idsSignal()).toEqual([20]);
     });
 
     it('should initialize result_impact_areas if undefined', () => {
       component.body.set({ result_impact_areas: undefined as any });
-      component.onGlobalTargetChange(1, 10);
-      
+      component.onGlobalTargetIdsChange(1, [10]);
+
       const body = component.body();
       expect(body.result_impact_areas).toBeDefined();
       expect(body.result_impact_areas?.length).toBe(1);
+    });
+
+    it('should treat null as empty selection', () => {
+      component.body.set({});
+      component.onGlobalTargetIdsChange(1, [7]);
+      component.onGlobalTargetIdsChange(1, null);
+
+      expect(component.getGlobalTargetIdsSignal(1)()).toEqual([]);
+      expect(component.body().result_impact_areas?.[0].result_impact_area_global_targets).toBeUndefined();
+    });
+
+    it('should clear result_impact_area_global_targets when ids empty', () => {
+      component.body.set({});
+      component.onGlobalTargetIdsChange(1, [1]);
+      component.onGlobalTargetIdsChange(1, []);
+
+      expect(component.body().result_impact_areas?.[0].result_impact_area_global_targets).toBeUndefined();
     });
   });
 
@@ -289,12 +411,12 @@ describe('ImpactAreasComponent', () => {
           {
             impact_area_id: 1,
             impact_area_score_id: 5,
-            global_target_id: 10
+            result_impact_area_global_targets: [{ global_target_id: 10 }]
           },
           {
             impact_area_id: 2,
             impact_area_score_id: 3,
-            global_target_id: null
+            result_impact_area_global_targets: []
           }
         ]
       };
@@ -305,14 +427,14 @@ describe('ImpactAreasComponent', () => {
       fixture.detectChanges();
 
       const scoreSignal1 = component.getImpactAreaScore(1);
-      const targetSignal1 = component.getImpactAreaGlobalTarget(1);
+      const idsSignal1 = component.getGlobalTargetIdsSignal(1);
       const scoreSignal2 = component.getImpactAreaScore(2);
-      const targetSignal2 = component.getImpactAreaGlobalTarget(2);
+      const idsSignal2 = component.getGlobalTargetIdsSignal(2);
 
       expect(scoreSignal1().score).toBe(5);
-      expect(targetSignal1().global_target_id).toBe(10);
+      expect(idsSignal1()).toEqual([10]);
       expect(scoreSignal2().score).toBe(3);
-      expect(targetSignal2().global_target_id).toBeNull();
+      expect(idsSignal2()).toEqual([]);
     }));
 
     it('should handle null values in body', fakeAsync(() => {
@@ -321,7 +443,7 @@ describe('ImpactAreasComponent', () => {
           {
             impact_area_id: 1,
             impact_area_score_id: null,
-            global_target_id: null
+            result_impact_area_global_targets: []
           }
         ]
       };
@@ -332,10 +454,10 @@ describe('ImpactAreasComponent', () => {
       fixture.detectChanges();
 
       const scoreSignal = component.getImpactAreaScore(1);
-      const targetSignal = component.getImpactAreaGlobalTarget(1);
+      const idsSignal = component.getGlobalTargetIdsSignal(1);
 
       expect(scoreSignal().score).toBeNull();
-      expect(targetSignal().global_target_id).toBeNull();
+      expect(idsSignal()).toEqual([]);
     }));
 
     it('should handle undefined values in body', fakeAsync(() => {
@@ -344,7 +466,7 @@ describe('ImpactAreasComponent', () => {
           {
             impact_area_id: 1,
             impact_area_score_id: undefined as any,
-            global_target_id: undefined as any
+            result_impact_area_global_targets: undefined
           }
         ]
       };
@@ -355,10 +477,10 @@ describe('ImpactAreasComponent', () => {
       fixture.detectChanges();
 
       const scoreSignal = component.getImpactAreaScore(1);
-      const targetSignal = component.getImpactAreaGlobalTarget(1);
+      const idsSignal = component.getGlobalTargetIdsSignal(1);
 
       expect(scoreSignal().score).toBeNull();
-      expect(targetSignal().global_target_id).toBeNull();
+      expect(idsSignal()).toEqual([]);
     }));
 
     it('should handle body without result_impact_areas', fakeAsync(() => {
@@ -367,7 +489,6 @@ describe('ImpactAreasComponent', () => {
       flush();
       fixture.detectChanges();
 
-      // Should not throw error
       expect(component.body()).toEqual({});
     }));
 
@@ -377,7 +498,7 @@ describe('ImpactAreasComponent', () => {
           {
             impact_area_id: undefined as any,
             impact_area_score_id: 5,
-            global_target_id: 10
+            result_impact_area_global_targets: [{ global_target_id: 10 }]
           }
         ]
       };
@@ -387,7 +508,6 @@ describe('ImpactAreasComponent', () => {
       flush();
       fixture.detectChanges();
 
-      // Should not create signals for undefined areaId
       expect(component.body().result_impact_areas?.length).toBe(1);
     }));
 
@@ -397,17 +517,17 @@ describe('ImpactAreasComponent', () => {
           {
             impact_area_id: 1,
             impact_area_score_id: 2,
-            global_target_id: 5
+            result_impact_area_global_targets: [{ global_target_id: 5 }]
           },
           {
             impact_area_id: 2,
             impact_area_score_id: 3,
-            global_target_id: 10
+            result_impact_area_global_targets: [{ global_target_id: 10 }]
           },
           {
             impact_area_id: 3,
             impact_area_score_id: 4,
-            global_target_id: 15
+            result_impact_area_global_targets: [{ global_target_id: 15 }]
           }
         ]
       };
@@ -418,63 +538,73 @@ describe('ImpactAreasComponent', () => {
       fixture.detectChanges();
 
       const scoreSignal1 = component.getImpactAreaScore(1);
-      const targetSignal1 = component.getImpactAreaGlobalTarget(1);
+      const idsSignal1 = component.getGlobalTargetIdsSignal(1);
       const scoreSignal2 = component.getImpactAreaScore(2);
-      const targetSignal2 = component.getImpactAreaGlobalTarget(2);
+      const idsSignal2 = component.getGlobalTargetIdsSignal(2);
       const scoreSignal3 = component.getImpactAreaScore(3);
-      const targetSignal3 = component.getImpactAreaGlobalTarget(3);
+      const idsSignal3 = component.getGlobalTargetIdsSignal(3);
 
       expect(scoreSignal1().score).toBe(2);
-      expect(targetSignal1().global_target_id).toBe(5);
+      expect(idsSignal1()).toEqual([5]);
       expect(scoreSignal2().score).toBe(3);
-      expect(targetSignal2().global_target_id).toBe(10);
+      expect(idsSignal2()).toEqual([10]);
       expect(scoreSignal3().score).toBe(4);
-      expect(targetSignal3().global_target_id).toBe(15);
+      expect(idsSignal3()).toEqual([15]);
+    }));
+
+    it('should sync empty result_impact_area_global_targets to empty ids', fakeAsync(() => {
+      const body: ImpactAreasBody = {
+        result_impact_areas: [
+          {
+            impact_area_id: 1,
+            impact_area_score_id: 1,
+            result_impact_area_global_targets: []
+          }
+        ]
+      };
+      component.body.set(body);
+      tick();
+      flush();
+      fixture.detectChanges();
+      expect(component.getGlobalTargetIdsSignal(1)()).toEqual([]);
     }));
   });
 
   describe('private methods', () => {
-    it('should ensure global target signal creates new signal if not exists', () => {
-      const signal = component.getImpactAreaGlobalTarget(999);
-      expect(signal).toBeDefined();
-      expect(signal().global_target_id).toBeNull();
+    it('should ensure global target ids signal creates new signal if not exists', () => {
+      const sig = component.getGlobalTargetIdsSignal(999);
+      expect(sig).toBeDefined();
+      expect(sig()).toEqual([]);
     });
 
     it('should ensure impact area score signal creates new signal if not exists', () => {
-      const signal = component.getImpactAreaScore(999);
-      expect(signal).toBeDefined();
-      expect(signal().score).toBeNull();
+      const sig = component.getImpactAreaScore(999);
+      expect(sig).toBeDefined();
+      expect(sig().score).toBeNull();
     });
 
-    it('should update global target signal correctly', () => {
-      component.onGlobalTargetChange(1, 25);
-      const signal = component.getImpactAreaGlobalTarget(1);
-      expect(signal().global_target_id).toBe(25);
+    it('should update global target ids signal correctly', () => {
+      component.onGlobalTargetIdsChange(1, [25]);
+      const sig = component.getGlobalTargetIdsSignal(1);
+      expect(sig()).toEqual([25]);
     });
 
     it('should update impact area score signal correctly', () => {
       component.onScoreChange(1, 7);
-      const signal = component.getImpactAreaScore(1);
-      expect(signal().score).toBe(7);
+      const sig = component.getImpactAreaScore(1);
+      expect(sig().score).toBe(7);
     });
 
-    it('should handle null value in updateGlobalTargetSignal', () => {
-      component.onGlobalTargetChange(1, 10);
-      component.onGlobalTargetChange(1, null as any);
-      const signal = component.getImpactAreaGlobalTarget(1);
-      expect(signal().global_target_id).toBeNull();
-    });
-
-    it('should handle null value in updateImpactAreaScoreSignal', () => {
+    it('should handle null value in score update', () => {
       component.onScoreChange(1, 5);
       component.onScoreChange(1, null as any);
-      const signal = component.getImpactAreaScore(1);
-      expect(signal().score).toBeNull();
+      const sig = component.getImpactAreaScore(1);
+      expect(sig().score).toBeNull();
     });
 
-    it('should reuse existing global target signal if already created', () => {
-      const signal1 = component.getImpactAreaGlobalTarget(1);
-      const signal2 = component.getImpactAreaGlobalTarget(1);
+    it('should reuse existing global target ids signal if already created', () => {
+      const signal1 = component.getGlobalTargetIdsSignal(1);
+      const signal2 = component.getGlobalTargetIdsSignal(1);
       expect(signal1).toBe(signal2);
     });
 
@@ -486,43 +616,42 @@ describe('ImpactAreasComponent', () => {
   });
 
   describe('onScoreChange edge cases', () => {
-    it('should handle updating score when impact area already exists with other fields', () => {
+    it('should preserve global targets when updating score', () => {
       const body: ImpactAreasBody = {
         result_impact_areas: [
           {
             impact_area_id: 1,
             impact_area_score_id: 2,
-            global_target_id: 10
+            result_impact_area_global_targets: [{ global_target_id: 10 }]
           }
         ]
       };
       component.body.set(body);
       component.onScoreChange(1, 4);
-      
+
       const updatedBody = component.body();
       expect(updatedBody.result_impact_areas?.[0].impact_area_score_id).toBe(4);
-      expect(updatedBody.result_impact_areas?.[0].global_target_id).toBe(10); // Should preserve
+      expect(updatedBody.result_impact_areas?.[0].result_impact_area_global_targets).toEqual([{ global_target_id: 10 }]);
     });
   });
 
-  describe('onGlobalTargetChange edge cases', () => {
-    it('should handle updating global target when impact area already exists with other fields', () => {
+  describe('onGlobalTargetIdsChange edge cases', () => {
+    it('should preserve score when updating global targets', () => {
       const body: ImpactAreasBody = {
         result_impact_areas: [
           {
             impact_area_id: 1,
             impact_area_score_id: 3,
-            global_target_id: 5
+            result_impact_area_global_targets: [{ global_target_id: 5 }]
           }
         ]
       };
       component.body.set(body);
-      component.onGlobalTargetChange(1, 15);
-      
+      component.onGlobalTargetIdsChange(1, [15]);
+
       const updatedBody = component.body();
-      expect(updatedBody.result_impact_areas?.[0].global_target_id).toBe(15);
-      expect(updatedBody.result_impact_areas?.[0].impact_area_score_id).toBe(3); // Should preserve
+      expect(updatedBody.result_impact_areas?.[0].result_impact_area_global_targets).toEqual([{ global_target_id: 15 }]);
+      expect(updatedBody.result_impact_areas?.[0].impact_area_score_id).toBe(3);
     });
   });
 });
-

--- a/research-indicators/src/app/pages/platform/pages/result/pages/oicr-details/components/impact-areas/impact-areas.component.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/oicr-details/components/impact-areas/impact-areas.component.spec.ts
@@ -7,6 +7,7 @@ import { ImpactAreasBody, BaseService } from '@shared/interfaces/impact-area.int
 import { GlobalTargetsService } from '@shared/services/short-control-list/global-targets.service';
 import { ImpactAreasService } from '@shared/services/short-control-list/impact-areas.service';
 import { GlobalTarget } from '@shared/interfaces/global-target.interface';
+import { MultiSelect } from 'primeng/multiselect';
 
 describe('ImpactAreasComponent', () => {
   let component: ImpactAreasComponent;
@@ -114,6 +115,72 @@ describe('ImpactAreasComponent', () => {
     });
   });
 
+  describe('globalTargetPanelStyle', () => {
+    it('returns only boxSizing when no width was recorded for the area', () => {
+      expect(component.globalTargetPanelStyle(999)).toEqual({ boxSizing: 'border-box' });
+    });
+
+    it('returns only boxSizing when stored width is zero or negative', () => {
+      (component as any).globalTargetPanelWidthsPx.set({ 701: 0 });
+      expect(component.globalTargetPanelStyle(701)).toEqual({ boxSizing: 'border-box' });
+      (component as any).globalTargetPanelWidthsPx.set({ 701: -3 });
+      expect(component.globalTargetPanelStyle(701)).toEqual({ boxSizing: 'border-box' });
+    });
+
+    it('returns width, maxWidth and minWidth when stored width is positive', () => {
+      (component as any).globalTargetPanelWidthsPx.set({ 702: 288 });
+      expect(component.globalTargetPanelStyle(702)).toEqual({
+        boxSizing: 'border-box',
+        width: '288px',
+        maxWidth: '288px',
+        minWidth: '288px'
+      });
+    });
+  });
+
+  describe('onGlobalTargetPanelOpen', () => {
+    it('returns early and does not record width when trigger rect width is zero', () => {
+      const trigger = { getBoundingClientRect: () => ({ width: 0 } as DOMRect) } as HTMLElement;
+      const ms = { overlayViewChild: { alignOverlay: jest.fn() } } as unknown as MultiSelect;
+      component.onGlobalTargetPanelOpen(801, ms, trigger);
+      expect(component.globalTargetPanelStyle(801)).toEqual({ boxSizing: 'border-box' });
+    });
+
+    it('records rounded width, runs change detection, and calls alignOverlay after timeout', fakeAsync(() => {
+      const alignOverlay = jest.fn();
+      const trigger = {
+        getBoundingClientRect: () => ({ width: 199.4 } as DOMRect)
+      } as HTMLElement;
+      const ms = { overlayViewChild: { alignOverlay } } as unknown as MultiSelect;
+      const cdr = (component as unknown as { cdr: { detectChanges: () => void } }).cdr;
+      const detectChangesSpy = jest.spyOn(cdr, 'detectChanges');
+
+      component.onGlobalTargetPanelOpen(802, ms, trigger);
+
+      expect(component.globalTargetPanelStyle(802)).toMatchObject({
+        width: '199px',
+        maxWidth: '199px',
+        minWidth: '199px'
+      });
+      expect(detectChangesSpy).toHaveBeenCalled();
+      expect(alignOverlay).not.toHaveBeenCalled();
+
+      tick();
+      expect(alignOverlay).toHaveBeenCalledTimes(1);
+
+      detectChangesSpy.mockRestore();
+    }));
+
+    it('does not throw when overlayViewChild is undefined', fakeAsync(() => {
+      const trigger = { getBoundingClientRect: () => ({ width: 50 } as DOMRect) } as HTMLElement;
+      const ms = { overlayViewChild: undefined } as unknown as MultiSelect;
+      expect(() => {
+        component.onGlobalTargetPanelOpen(803, ms, trigger);
+        tick();
+      }).not.toThrow();
+    }));
+  });
+
   describe('isGlobalTargetRequired', () => {
     it('should return true when score is 3', () => {
       const body: ImpactAreasBody = {
@@ -161,6 +228,59 @@ describe('ImpactAreasComponent', () => {
       component.body.set(body);
       expect(component.isGlobalTargetRequired(1)).toBe(false);
     });
+  });
+
+  describe('isGlobalTargetInvalid', () => {
+    it('returns true when score is 3 and no global targets selected', fakeAsync(() => {
+      const body: ImpactAreasBody = {
+        result_impact_areas: [
+          {
+            impact_area_id: 1,
+            impact_area_score_id: 3,
+            result_impact_area_global_targets: []
+          }
+        ]
+      };
+      component.body.set(body);
+      tick();
+      flush();
+      fixture.detectChanges();
+      expect(component.isGlobalTargetInvalid(1)).toBe(true);
+    }));
+
+    it('returns false when score is 3 but ids are selected', fakeAsync(() => {
+      const body: ImpactAreasBody = {
+        result_impact_areas: [
+          {
+            impact_area_id: 1,
+            impact_area_score_id: 3,
+            result_impact_area_global_targets: [{ global_target_id: 9 }]
+          }
+        ]
+      };
+      component.body.set(body);
+      tick();
+      flush();
+      fixture.detectChanges();
+      expect(component.isGlobalTargetInvalid(1)).toBe(false);
+    }));
+
+    it('returns false when global target is not required', fakeAsync(() => {
+      const body: ImpactAreasBody = {
+        result_impact_areas: [
+          {
+            impact_area_id: 1,
+            impact_area_score_id: 2,
+            result_impact_area_global_targets: []
+          }
+        ]
+      };
+      component.body.set(body);
+      tick();
+      flush();
+      fixture.detectChanges();
+      expect(component.isGlobalTargetInvalid(1)).toBe(false);
+    }));
   });
 
   describe('getImpactAreaScore', () => {

--- a/research-indicators/src/app/pages/platform/pages/result/pages/oicr-details/components/impact-areas/impact-areas.component.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/oicr-details/components/impact-areas/impact-areas.component.ts
@@ -1,14 +1,17 @@
-import { NgTemplateOutlet } from '@angular/common';
 import { Component, Input, signal, WritableSignal, inject, effect } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MultiSelectModule } from 'primeng/multiselect';
 import { RadioButtonComponent } from '@shared/components/custom-fields/radio-button/radio-button.component';
-import { SelectComponent } from '@shared/components/custom-fields/select/select.component';
 import { ServiceLocatorService } from '@shared/services/service-locator.service';
+import { GlobalTargetsService } from '@shared/services/short-control-list/global-targets.service';
+import { ImpactAreasService } from '@shared/services/short-control-list/impact-areas.service';
 import { ResultImpactArea, ImpactAreasBody, BaseService } from '@shared/interfaces/impact-area.interface';
+import { GlobalTarget } from '@shared/interfaces/global-target.interface';
 
 @Component({
   selector: 'app-impact-areas',
   standalone: true,
-  imports: [RadioButtonComponent, SelectComponent, NgTemplateOutlet],
+  imports: [RadioButtonComponent, FormsModule, MultiSelectModule],
   templateUrl: './impact-areas.component.html'
 })
 export class ImpactAreasComponent {
@@ -16,23 +19,30 @@ export class ImpactAreasComponent {
   @Input() disabled = false;
 
   serviceLocator = inject(ServiceLocatorService);
-  impactAreasService = this.serviceLocator.getService('impactAreas') as BaseService;
-  
-  private readonly globalTargetSignals = new Map<number, WritableSignal<{ global_target_id: number | null }>>();
+  impactAreasService = this.serviceLocator.getService('impactAreas') as BaseService & ImpactAreasService;
+  private readonly globalTargetsService = inject(GlobalTargetsService);
+  private readonly impactAreasForLoad = inject(ImpactAreasService);
+
+  private readonly globalTargetIdLists = new Map<number, WritableSignal<number[]>>();
   private readonly impactAreaScoreSignals = new Map<number, WritableSignal<{ score: number | null }>>();
 
   constructor() {
     effect(() => {
+      for (const a of this.impactAreasForLoad.list()) {
+        void this.globalTargetsService.main(a.id);
+      }
+    });
+
+    effect(() => {
       const body = this.body();
       if (body.result_impact_areas) {
         for (const impactArea of body.result_impact_areas) {
-          const globalTargetId = impactArea.global_target_id;
           const areaId = impactArea.impact_area_id;
           const impactAreaScoreId = impactArea.impact_area_score_id;
-          
+
           if (areaId) {
-            const targetSignal = this.ensureGlobalTargetSignal(areaId);
-            targetSignal.set({ global_target_id: globalTargetId ?? null });
+            const idsSignal = this.ensureGlobalTargetIdsSignal(areaId);
+            idsSignal.set(this.idsFromImpactArea(impactArea));
 
             const scoreSignal = this.ensureImpactAreaScoreSignal(areaId);
             scoreSignal.set({ score: impactAreaScoreId ?? null });
@@ -42,18 +52,67 @@ export class ImpactAreasComponent {
     });
   }
 
+  private idsFromImpactArea(ia: ResultImpactArea): number[] {
+    if (Array.isArray(ia.result_impact_area_global_targets) && ia.result_impact_area_global_targets.length > 0) {
+      return ia.result_impact_area_global_targets.map(t => t.global_target_id);
+    }
+    return [];
+  }
+
   isGlobalTargetRequired(areaId: number): boolean {
-    const impactArea = this.body().result_impact_areas?.find((ia: ResultImpactArea) => ia.impact_area_id === areaId);
-    const score = impactArea?.impact_area_score_id;
-    return score === 3;
+    const impactArea = this.body().result_impact_areas?.find((i: ResultImpactArea) => i.impact_area_id === areaId);
+    return impactArea?.impact_area_score_id === 3;
   }
 
   getImpactAreaScore(areaId: number): WritableSignal<{ score: number | null }> {
     return this.ensureImpactAreaScoreSignal(areaId);
   }
 
-  getImpactAreaGlobalTarget(areaId: number): WritableSignal<{ global_target_id: number | null }> {
-    return this.ensureGlobalTargetSignal(areaId);
+  /** Ids bound to `p-multiSelect` for this impact area. */
+  getGlobalTargetIdsSignal(areaId: number): WritableSignal<number[]> {
+    return this.ensureGlobalTargetIdsSignal(areaId);
+  }
+
+  globalTargetOptions(areaId: number) {
+    return this.globalTargetsService.getList(areaId)();
+  }
+
+  globalTargetLoading(areaId: number): boolean {
+    return this.globalTargetsService.getLoading(areaId)();
+  }
+
+  selectedGlobalTargetRows(areaId: number): GlobalTarget[] {
+    const ids = this.ensureGlobalTargetIdsSignal(areaId)();
+    const options = this.globalTargetOptions(areaId) ?? [];
+    return ids.map(id => {
+      const opt = options.find(o => o.targetId === id);
+      return opt ?? ({ targetId: id, smo_code: '', target: '', impactAreaId: areaId, impactAreaName: '' } as GlobalTarget);
+    });
+  }
+
+  removeGlobalTargetRow(areaId: number, targetId: number) {
+    const next = this.ensureGlobalTargetIdsSignal(areaId)().filter(id => id !== targetId);
+    this.onGlobalTargetIdsChange(areaId, next);
+  }
+
+  onGlobalTargetIdsChange(areaId: number, value: number[] | null) {
+    const ids = Array.isArray(value) ? value : [];
+    this.ensureGlobalTargetIdsSignal(areaId).set(ids);
+
+    const currentBody = this.body();
+    currentBody.result_impact_areas ??= [];
+    let row = currentBody.result_impact_areas.find((ia: ResultImpactArea) => ia.impact_area_id === areaId);
+    if (row === undefined) {
+      row = {
+        impact_area_id: areaId,
+        impact_area_score_id: undefined,
+        result_impact_area_global_targets: undefined
+      };
+      currentBody.result_impact_areas.push(row);
+    }
+    row.result_impact_area_global_targets = ids.length > 0 ? ids.map(global_target_id => ({ global_target_id })) : undefined;
+
+    this.body.set({ ...currentBody });
   }
 
   onScoreChange(areaId: number, value: number) {
@@ -64,7 +123,7 @@ export class ImpactAreasComponent {
       impactArea = {
         impact_area_id: areaId,
         impact_area_score_id: value,
-        global_target_id: undefined,
+        result_impact_area_global_targets: undefined
       };
       currentBody.result_impact_areas.push(impactArea);
     } else {
@@ -75,54 +134,25 @@ export class ImpactAreasComponent {
     this.body.set({ ...currentBody });
   }
 
-  onGlobalTargetChange(areaId: number, value: number) {
-    const currentBody = this.body();
-    currentBody.result_impact_areas ??= [];
-    let impactArea = currentBody.result_impact_areas.find((ia: ResultImpactArea) => ia.impact_area_id === areaId);
-    if (impactArea === undefined) {
-      impactArea = {
-        impact_area_id: areaId,
-        global_target_id: undefined,
-        impact_area_score_id: undefined,
-      };
-      currentBody.result_impact_areas.push(impactArea);
+  private ensureGlobalTargetIdsSignal(areaId: number): WritableSignal<number[]> {
+    if (!this.globalTargetIdLists.has(areaId)) {
+      const ia = this.body().result_impact_areas?.find((i: ResultImpactArea) => i.impact_area_id === areaId);
+      const initial = ia ? this.idsFromImpactArea(ia) : [];
+      this.globalTargetIdLists.set(areaId, signal<number[]>(initial));
     }
-    
-    impactArea.global_target_id = value;
-    this.updateGlobalTargetSignal(areaId, value);
-    
-    this.body.set({ ...currentBody });
-  }
-
-  private ensureGlobalTargetSignal(areaId: number): WritableSignal<{ global_target_id: number | null }> {
-    if (!this.globalTargetSignals.has(areaId)) {
-      const impactArea = this.body().result_impact_areas?.find((ia: ResultImpactArea) => ia.impact_area_id === areaId);
-      const initialValue = impactArea?.global_target_id ?? null;
-      const newSignal = signal({ global_target_id: initialValue });
-      this.globalTargetSignals.set(areaId, newSignal);
-    }
-
-    return this.globalTargetSignals.get(areaId)!;
-  }
-
-  private updateGlobalTargetSignal(areaId: number, targetId: number | null) {
-    const targetSignal = this.ensureGlobalTargetSignal(areaId);
-    targetSignal.set({ global_target_id: targetId });
+    return this.globalTargetIdLists.get(areaId)!;
   }
 
   private ensureImpactAreaScoreSignal(areaId: number): WritableSignal<{ score: number | null }> {
     if (!this.impactAreaScoreSignals.has(areaId)) {
       const impactArea = this.body().result_impact_areas?.find((ia: ResultImpactArea) => ia.impact_area_id === areaId);
       const initialScore = impactArea?.impact_area_score_id ?? null;
-      const newSignal = signal({ score: initialScore });
-      this.impactAreaScoreSignals.set(areaId, newSignal);
+      this.impactAreaScoreSignals.set(areaId, signal({ score: initialScore }));
     }
-
     return this.impactAreaScoreSignals.get(areaId)!;
   }
 
   private updateImpactAreaScoreSignal(areaId: number, score: number | null) {
-    const scoreSignal = this.ensureImpactAreaScoreSignal(areaId);
-    scoreSignal.set({ score });
+    this.ensureImpactAreaScoreSignal(areaId).set({ score });
   }
 }

--- a/research-indicators/src/app/pages/platform/pages/result/pages/oicr-details/components/impact-areas/impact-areas.component.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/oicr-details/components/impact-areas/impact-areas.component.ts
@@ -1,6 +1,6 @@
-import { Component, Input, signal, WritableSignal, inject, effect } from '@angular/core';
+import { ChangeDetectorRef, Component, Input, signal, WritableSignal, inject, effect } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { MultiSelectModule } from 'primeng/multiselect';
+import { MultiSelectModule, MultiSelect } from 'primeng/multiselect';
 import { RadioButtonComponent } from '@shared/components/custom-fields/radio-button/radio-button.component';
 import { ServiceLocatorService } from '@shared/services/service-locator.service';
 import { GlobalTargetsService } from '@shared/services/short-control-list/global-targets.service';
@@ -18,6 +18,7 @@ export class ImpactAreasComponent {
   @Input() body: WritableSignal<ImpactAreasBody> = signal({});
   @Input() disabled = false;
 
+  private readonly cdr = inject(ChangeDetectorRef);
   serviceLocator = inject(ServiceLocatorService);
   impactAreasService = this.serviceLocator.getService('impactAreas') as BaseService & ImpactAreasService;
   private readonly globalTargetsService = inject(GlobalTargetsService);
@@ -25,6 +26,7 @@ export class ImpactAreasComponent {
 
   private readonly globalTargetIdLists = new Map<number, WritableSignal<number[]>>();
   private readonly impactAreaScoreSignals = new Map<number, WritableSignal<{ score: number | null }>>();
+  private readonly globalTargetPanelWidthsPx = signal<Record<number, number>>({});
 
   constructor() {
     effect(() => {
@@ -66,6 +68,32 @@ export class ImpactAreasComponent {
 
   isGlobalTargetInvalid(areaId: number): boolean {
     return this.isGlobalTargetRequired(areaId) && this.ensureGlobalTargetIdsSignal(areaId)().length === 0;
+  }
+
+  globalTargetPanelStyle(areaId: number): Record<string, string> {
+    const w = this.globalTargetPanelWidthsPx()[areaId];
+    const base: Record<string, string> = { boxSizing: 'border-box' };
+    if (w == null || w <= 0) {
+      return base;
+    }
+    return {
+      ...base,
+      width: `${w}px`,
+      maxWidth: `${w}px`,
+      minWidth: `${w}px`
+    };
+  }
+
+  onGlobalTargetPanelOpen(areaId: number, ms: MultiSelect, trigger: HTMLElement) {
+    const w = Math.round(trigger.getBoundingClientRect().width);
+    if (w <= 0) {
+      return;
+    }
+    this.globalTargetPanelWidthsPx.update(prev => ({ ...prev, [areaId]: w }));
+    this.cdr.detectChanges();
+    setTimeout(() => {
+      ms.overlayViewChild?.alignOverlay();
+    });
   }
 
   getImpactAreaScore(areaId: number): WritableSignal<{ score: number | null }> {

--- a/research-indicators/src/app/pages/platform/pages/result/pages/oicr-details/components/impact-areas/impact-areas.component.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/oicr-details/components/impact-areas/impact-areas.component.ts
@@ -64,11 +64,14 @@ export class ImpactAreasComponent {
     return impactArea?.impact_area_score_id === 3;
   }
 
+  isGlobalTargetInvalid(areaId: number): boolean {
+    return this.isGlobalTargetRequired(areaId) && this.ensureGlobalTargetIdsSignal(areaId)().length === 0;
+  }
+
   getImpactAreaScore(areaId: number): WritableSignal<{ score: number | null }> {
     return this.ensureImpactAreaScoreSignal(areaId);
   }
 
-  /** Ids bound to `p-multiSelect` for this impact area. */
   getGlobalTargetIdsSignal(areaId: number): WritableSignal<number[]> {
     return this.ensureGlobalTargetIdsSignal(areaId);
   }

--- a/research-indicators/src/app/pages/platform/pages/result/pages/oicr-details/oicr-details.component.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/oicr-details/oicr-details.component.spec.ts
@@ -572,12 +572,57 @@ describe('OicrDetailsComponent', () => {
       expect(component.body().result_impact_areas![0]).toEqual({
         impact_area_id: 1,
         impact_area_score_id: 2,
-        global_target_id: 3
+        result_impact_area_global_targets: [{ global_target_id: 3 }]
       });
       expect(component.body().result_impact_areas![1]).toEqual({
         impact_area_id: 4,
         impact_area_score_id: undefined,
-        global_target_id: undefined
+        result_impact_area_global_targets: undefined
+      });
+    });
+
+    it('should map result_impact_area_global_targets when API returns nested array', async () => {
+      apiService.GET_Oicr.mockResolvedValue({
+        data: {
+          result_impact_areas: [
+            {
+              impact_area_id: 1,
+              impact_area_score_id: 2,
+              result_impact_area_global_targets: [{ global_target_id: 9 }, { global_target_id: 10 }]
+            }
+          ]
+        }
+      } as any);
+      jest.spyOn(component, 'loadContactPersons').mockResolvedValue();
+
+      await component.getData();
+
+      expect(component.body().result_impact_areas![0].result_impact_area_global_targets).toEqual([
+        { global_target_id: 9 },
+        { global_target_id: 10 }
+      ]);
+    });
+
+    it('should map global_target_ids when provided', async () => {
+      apiService.GET_Oicr.mockResolvedValue({
+        data: {
+          result_impact_areas: [
+            {
+              impact_area_id: 7,
+              impact_area_score_id: 1,
+              global_target_ids: [4, 5]
+            }
+          ]
+        }
+      } as any);
+      jest.spyOn(component, 'loadContactPersons').mockResolvedValue();
+
+      await component.getData();
+
+      expect(component.body().result_impact_areas![0]).toEqual({
+        impact_area_id: 7,
+        impact_area_score_id: 1,
+        result_impact_area_global_targets: [{ global_target_id: 4 }, { global_target_id: 5 }]
       });
     });
   });

--- a/research-indicators/src/app/pages/platform/pages/result/pages/oicr-details/oicr-details.component.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/oicr-details/oicr-details.component.ts
@@ -220,11 +220,33 @@ export default class OicrDetailsComponent {
     // Map result_impact_areas
     const apiImpactAreas = Array.isArray(apiData.result_impact_areas) ? apiData.result_impact_areas : [];
     if (apiImpactAreas.length > 0) {
-      const mappedImpactAreas = apiImpactAreas.map((ia: { impact_area_id: number; impact_area_score_id: number | undefined; global_target_id: number | undefined }) => ({
-        impact_area_id: ia.impact_area_id,
-        impact_area_score_id: ia.impact_area_score_id,
-        global_target_id: ia.global_target_id,
-      }));
+      const mappedImpactAreas = apiImpactAreas.map(
+        (ia: {
+          impact_area_id: number;
+          impact_area_score_id: number | undefined;
+          result_impact_area_global_targets?: { global_target_id: number }[];
+          global_target_id?: number | undefined;
+          global_target_ids?: number[];
+        }) => {
+          let result_impact_area_global_targets: { global_target_id: number }[] | undefined;
+          if (Array.isArray(ia.result_impact_area_global_targets) && ia.result_impact_area_global_targets.length > 0) {
+            result_impact_area_global_targets = ia.result_impact_area_global_targets.map(t => ({
+              global_target_id: t.global_target_id
+            }));
+          } else if (Array.isArray(ia.global_target_ids) && ia.global_target_ids.length > 0) {
+            result_impact_area_global_targets = ia.global_target_ids.map(global_target_id => ({ global_target_id }));
+          } else if (ia.global_target_id != null && ia.global_target_id !== undefined) {
+            result_impact_area_global_targets = [{ global_target_id: ia.global_target_id }];
+          } else {
+            result_impact_area_global_targets = undefined;
+          }
+          return {
+            impact_area_id: ia.impact_area_id,
+            impact_area_score_id: ia.impact_area_score_id,
+            result_impact_area_global_targets
+          };
+        }
+      );
       
       // Update the body with the mapped impact areas
       const currentBody = this.body();

--- a/research-indicators/src/app/pages/platform/pages/result/pages/oicr-details/oicr-details.component.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/oicr-details/oicr-details.component.ts
@@ -225,7 +225,7 @@ export default class OicrDetailsComponent {
           impact_area_id: number;
           impact_area_score_id: number | undefined;
           result_impact_area_global_targets?: { global_target_id: number }[];
-          global_target_id?: number | undefined;
+          global_target_id?: number;
           global_target_ids?: number[];
         }) => {
           let result_impact_area_global_targets: { global_target_id: number }[] | undefined;

--- a/research-indicators/src/app/pages/platform/pages/results-center/components/indicators-tab-filter/indicators-tab-filter.component.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/results-center/components/indicators-tab-filter/indicators-tab-filter.component.spec.ts
@@ -86,13 +86,15 @@ describe('IndicatorsTabFilterComponent', () => {
     const updateSpy = jest.spyOn(component, 'updateArrowVisibility');
 
     component.ngAfterViewInit();
-    expect(addSpy).toHaveBeenCalledWith('resize', expect.any(Function));
+    const resizeAdd = addSpy.mock.calls.find(c => c[0] === 'resize');
+    expect(resizeAdd).toBeDefined();
+    const resizeHandler = resizeAdd![1];
 
     window.dispatchEvent(new Event('resize'));
     expect(updateSpy).toHaveBeenCalled();
 
     component.ngOnDestroy();
-    expect(removeSpy).toHaveBeenCalledWith('resize', expect.any(Function));
+    expect(removeSpy).toHaveBeenCalledWith('resize', resizeHandler);
 
     // restore
     (global as any).ResizeObserver = ResizeObserverMock as any;

--- a/research-indicators/src/app/pages/platform/pages/results-center/components/indicators-tab-filter/indicators-tab-filter.component.ts
+++ b/research-indicators/src/app/pages/platform/pages/results-center/components/indicators-tab-filter/indicators-tab-filter.component.ts
@@ -18,6 +18,7 @@ export class IndicatorsTabFilterComponent implements AfterViewInit, OnDestroy {
   showLeftArrow = signal(false);
   showRightArrow = signal(false);
   private resizeObserver: ResizeObserver | null = null;
+  private readonly onWindowResizeForArrows = () => this.updateArrowVisibility();
 
   indicatorTabs = this.resultsCenterService.api.indicatorTabs.lazy();
 
@@ -33,7 +34,7 @@ export class IndicatorsTabFilterComponent implements AfterViewInit, OnDestroy {
 
         this.resizeObserver.observe(this.filtersContainer.nativeElement);
       } else {
-        window.addEventListener('resize', () => this.updateArrowVisibility());
+        window.addEventListener('resize', this.onWindowResizeForArrows);
       }
 
       // Initial validation
@@ -57,7 +58,7 @@ export class IndicatorsTabFilterComponent implements AfterViewInit, OnDestroy {
     }
     // clear the resize event listener if the fallback was used
     if (typeof ResizeObserver === 'undefined') {
-      window.removeEventListener('resize', () => this.updateArrowVisibility());
+      window.removeEventListener('resize', this.onWindowResizeForArrows);
     }
   }
 

--- a/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.html
+++ b/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.html
@@ -48,14 +48,16 @@
     <app-custom-progress-bar></app-custom-progress-bar>
   } @else {
     <div #tableRppScope class="rpp-dropup w-full border border-[#E8EBED]">
-      <p-table #dt2 [value]="resultsCenterService.resultsListForTable()" [paginator]="true"
+      <p-table #dt2 [value]="resultsCenterService.resultsListForTable()" [paginator]="true" [lazy]="true"
         [first]="resultsCenterService.resultsTablePaginatorFirst()"
         [rows]="resultsCenterService.resultsTablePaginatorRows()"
-        (onPage)="resultsCenterService.handleResultsTablePage($event)"
+        [totalRecords]="resultsCenterService.resultsTableTotalRecords()"
+        (onLazyLoad)="resultsCenterService.handleResultsTableLazyLoad($event)"
         [paginatorDropdownAppendTo]="tableRppScope" [showCurrentPageReport]="true" [scrollable]="true"
         [tableStyle]="{ 'min-width': '100%' }" [rowsPerPageOptions]="[5, 10, 25, 50]"
         currentPageReportTemplate="Showing {first} to {last} of {totalRecords} results"
-        [sortField]="'result_official_code'" [sortOrder]="-1"
+        [sortField]="resultsCenterService.resultsTableSortField()" [sortOrder]="resultsCenterService.resultsTableSortOrder()"
+        [customSort]="true"
         styleClass="p-datatable-gridlines table-custom-styles p-datatable-hoverable-rows">
     <ng-template pTemplate="header">
       <tr>

--- a/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.html
+++ b/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.html
@@ -48,7 +48,9 @@
     <app-custom-progress-bar></app-custom-progress-bar>
   }
 
-  <p-table #dt2 [value]="resultsCenterService.list()" [paginator]="true" [rows]="10"
+  <p-table #dt2 [value]="resultsCenterService.list()" [paginator]="true"
+    [first]="resultsCenterService.resultsTablePaginatorFirst()" [rows]="resultsCenterService.resultsTablePaginatorRows()"
+    (onPage)="resultsCenterService.handleResultsTablePage($event)"
     [showCurrentPageReport]="true" [scrollable]="true"
     [tableStyle]="{ 'min-width': '100%' }" [rowsPerPageOptions]="[5, 10, 25, 50]"
     currentPageReportTemplate="Showing {first} to {last} of {totalRecords} results" [sortField]="'result_official_code'"

--- a/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.html
+++ b/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.html
@@ -46,17 +46,17 @@
 
   @if (resultsCenterService.loading()) {
     <app-custom-progress-bar></app-custom-progress-bar>
-  }
-
-  <p-table #dt2 [value]="resultsCenterService.list()" [paginator]="true"
-    [first]="resultsCenterService.resultsTablePaginatorFirst()" [rows]="resultsCenterService.resultsTablePaginatorRows()"
-    (onPage)="resultsCenterService.handleResultsTablePage($event)"
-    [showCurrentPageReport]="true" [scrollable]="true"
-    [tableStyle]="{ 'min-width': '100%' }" [rowsPerPageOptions]="[5, 10, 25, 50]"
-    currentPageReportTemplate="Showing {first} to {last} of {totalRecords} results" [sortField]="'result_official_code'"
-    [sortOrder]="-1"
-    [globalFilterFields]="resultsCenterService.getAllPathsAsArray()"
-    styleClass="p-datatable-gridlines table-custom-styles p-datatable-hoverable-rows">
+  } @else {
+    <div #tableRppScope class="rpp-dropup w-full border border-[#E8EBED]">
+      <p-table #dt2 [value]="resultsCenterService.resultsListForTable()" [paginator]="true"
+        [first]="resultsCenterService.resultsTablePaginatorFirst()"
+        [rows]="resultsCenterService.resultsTablePaginatorRows()"
+        (onPage)="resultsCenterService.handleResultsTablePage($event)"
+        [paginatorDropdownAppendTo]="tableRppScope" [showCurrentPageReport]="true" [scrollable]="true"
+        [tableStyle]="{ 'min-width': '100%' }" [rowsPerPageOptions]="[5, 10, 25, 50]"
+        currentPageReportTemplate="Showing {first} to {last} of {totalRecords} results"
+        [sortField]="'result_official_code'" [sortOrder]="-1"
+        styleClass="p-datatable-gridlines table-custom-styles p-datatable-hoverable-rows">
     <ng-template pTemplate="header">
       <tr>
         @for (column of getVisibleColumns(); track column.field) {
@@ -203,7 +203,6 @@
       </tr>
     </ng-template>
     <ng-template pTemplate="emptymessage">
-      @if (!resultsCenterService.loading()) {
       @if (resultsCenterService.countFiltersSelected()) {
       <tr>
         <td [attr.colspan]="getVisibleColumns().length" class="text-center p-8">
@@ -245,9 +244,10 @@
         </td>
       </tr>
       }
-      }
     </ng-template>
-  </p-table>
+      </p-table>
+    </div>
+  }
 </div>
 
 <p-menu #menu [popup]="true" [model]="menuItems"></p-menu>

--- a/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.scss
+++ b/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.scss
@@ -2,3 +2,55 @@
   hyphens: manual;
   word-break: break-word;
 }
+
+:host ::ng-deep .p-datatable {
+  width: 100% !important;
+  max-width: 100% !important;
+  display: flex !important;
+  flex-direction: column !important;
+}
+
+:host ::ng-deep .p-datatable-table {
+  width: 100% !important;
+  min-width: 100% !important;
+  flex: 1 !important;
+  min-height: 0 !important;
+}
+
+:host ::ng-deep .p-datatable-wrapper {
+  flex: 1 !important;
+  min-height: 0 !important;
+  overflow: auto !important;
+}
+
+:host ::ng-deep .p-paginator {
+  display: flex !important;
+  justify-content: flex-end !important;
+  align-items: center !important;
+  width: 100% !important;
+  background: white !important;
+  padding: 10px 20px !important;
+  margin-top: auto !important;
+}
+
+:host ::ng-deep .p-datatable .p-paginator {
+  border-top: 1px solid #e8ebed !important;
+}
+
+:host ::ng-deep .p-paginator .p-paginator-current {
+  margin-left: auto !important;
+  margin-right: 0 !important;
+}
+
+:host ::ng-deep .p-paginator .p-paginator-pages {
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
+:host ::ng-deep .p-paginator .p-paginator-first,
+:host ::ng-deep .p-paginator .p-paginator-prev,
+:host ::ng-deep .p-paginator .p-paginator-next,
+:host ::ng-deep .p-paginator .p-paginator-last {
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}

--- a/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.spec.ts
@@ -73,7 +73,8 @@ describe('ResultsCenterTableComponent', () => {
       showFiltersSidebar: signal(false),
       showConfigurationsSidebar: signal(false),
       tableRef: signal<any>(undefined),
-      handleResultsTablePage: jest.fn()
+      main: jest.fn(),
+      handleResultsTableLazyLoad: jest.fn()
     };
 
     mockCache = {

--- a/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.spec.ts
@@ -67,7 +67,10 @@ describe('ResultsCenterTableComponent', () => {
       removeFilter: jest.fn(),
       showFiltersSidebar: signal(false),
       showConfigurationsSidebar: signal(false),
-      tableRef: signal<any>(undefined)
+      tableRef: signal<any>(undefined),
+      resultsTablePaginatorFirst: signal(0),
+      resultsTablePaginatorRows: signal(10),
+      handleResultsTablePage: jest.fn()
     };
 
     mockCache = {

--- a/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.spec.ts
@@ -4,7 +4,7 @@ import { ResultsCenterService } from '../../results-center.service';
 import { CacheService } from '../../../../../../shared/services/cache/cache.service';
 import { AllModalsService } from '../../../../../../shared/services/cache/all-modals.service';
 import { Router, provideRouter } from '@angular/router';
-import { signal } from '@angular/core';
+import { computed, signal } from '@angular/core';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ApiService } from '../../../../../../shared/services/api.service';
 import { CreateResultManagementService } from '../../../../../../shared/components/all-modals/modals-content/create-result-modal/services/create-result-management.service';
@@ -41,6 +41,7 @@ describe('ResultsCenterTableComponent', () => {
     (component as any).dt2 = {
       filterGlobal: jest.fn(),
       first: 0,
+      rows: 10,
       filteredValue: undefined
     } as any;
     fixture.detectChanges();
@@ -49,9 +50,13 @@ describe('ResultsCenterTableComponent', () => {
   beforeEach(async () => {
     jest.spyOn(console, 'error').mockImplementation(() => {});
 
+    const listSig = signal([mockResult]);
     mockService = {
       searchInput: signal(''),
-      list: signal([mockResult]),
+      list: listSig,
+      resultsListForTable: computed(() => listSig()),
+      resultsTablePaginatorFirst: signal(0),
+      resultsTablePaginatorRows: signal(10),
       loading: signal(false),
       primaryContractId: jest.fn().mockReturnValue(null),
       getAllPathsAsArray: jest.fn(() => ['title']),
@@ -68,8 +73,6 @@ describe('ResultsCenterTableComponent', () => {
       showFiltersSidebar: signal(false),
       showConfigurationsSidebar: signal(false),
       tableRef: signal<any>(undefined),
-      resultsTablePaginatorFirst: signal(0),
-      resultsTablePaginatorRows: signal(10),
       handleResultsTablePage: jest.fn()
     };
 
@@ -164,9 +167,11 @@ describe('ResultsCenterTableComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('setSearchInputFilter should update service searchInput', () => {
+  it('setSearchInputFilter should update service searchInput and reset paginator to first page', () => {
+    mockService.resultsTablePaginatorFirst.set(40);
     component.setSearchInputFilter('q');
     expect(mockService.searchInput()).toBe('q');
+    expect(mockService.resultsTablePaginatorFirst()).toBe(0);
   });
 
   it('getActiveFiltersExcludingIndicatorTab and shouldShowFilterMessage', () => {
@@ -726,8 +731,10 @@ describe('ResultsCenterTableComponent', () => {
 
   it('setSearchInputFilter should work even when table not ready', () => {
     (component as any).dt2 = undefined;
+    mockService.resultsTablePaginatorFirst.set(30);
     expect(() => component.setSearchInputFilter('zzz')).not.toThrow();
     expect(mockService.searchInput()).toBe('zzz');
+    expect(mockService.resultsTablePaginatorFirst()).toBe(0);
   });
 
   it('processRowClick should early return when row has no parent', () => {

--- a/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.ts
+++ b/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, ViewChild, signal, AfterViewInit, computed, HostListener, Input, effect } from '@angular/core';
+import { Component, inject, ViewChild, signal, AfterViewInit, OnDestroy, computed, HostListener, Input } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { Table, TableModule } from 'primeng/table';
 import { ButtonModule } from 'primeng/button';
@@ -38,9 +38,10 @@ import { CreateResultManagementService } from '@shared/components/all-modals/mod
     SearchExportControlsComponent,
     CustomProgressBarComponent
   ],
-  templateUrl: './results-center-table.component.html'
+  templateUrl: './results-center-table.component.html',
+  styleUrl: './results-center-table.component.scss'
 })
-export class ResultsCenterTableComponent implements AfterViewInit {
+export class ResultsCenterTableComponent implements AfterViewInit, OnDestroy {
   resultsCenterService = inject(ResultsCenterService);
   private readonly router = inject(Router);
   private readonly cacheService = inject(CacheService);
@@ -49,7 +50,25 @@ export class ResultsCenterTableComponent implements AfterViewInit {
   private readonly apiService = inject(ApiService);
 
   @Input() showNewProjectResultButton = false;
-  @ViewChild('dt2') dt2!: Table;
+
+  private dt2Table: Table | undefined;
+
+  @ViewChild('dt2')
+  set dt2(table: Table | undefined) {
+    this.dt2Table = table;
+    if (table) {
+      this.tableRef.set(table);
+      this.resultsCenterService.tableRef.set(table);
+    } else {
+      this.tableRef.set(undefined);
+      this.resultsCenterService.tableRef.set(undefined);
+    }
+  }
+
+  get dt2(): Table | undefined {
+    return this.dt2Table;
+  }
+
   tableRef = signal<Table | undefined>(undefined);
   private lastClickedElement: Element | null = null;
   private removeDocumentClickListener: (() => void) | null = null;
@@ -60,17 +79,12 @@ export class ResultsCenterTableComponent implements AfterViewInit {
     { label: 'Export', icon: 'pi pi-download' }
   ];
 
-  onSearchInputChange = effect(() => {
-    const searchValue = this.resultsCenterService.searchInput();
-    this.resultsCenterService.list();
-    if (this.dt2) {
-      this.resultsCenterService.resultsTablePaginatorFirst.set(0);
-      this.dt2.first = 0;
-      this.dt2.filterGlobal(searchValue, 'contains');
-    }
-  });
+  ngOnDestroy(): void {
+    this.removeDocumentClickListener?.();
+  }
 
   setSearchInputFilter(query: string) {
+    this.resultsCenterService.resultsTablePaginatorFirst.set(0);
     this.resultsCenterService.searchInput.set(query);
   }
 
@@ -453,9 +467,6 @@ export class ResultsCenterTableComponent implements AfterViewInit {
   }
 
   ngAfterViewInit() {
-    this.tableRef.set(this.dt2);
-    this.resultsCenterService.tableRef.set(this.dt2);
-
     const onDocClickCapture = (event: MouseEvent) => {
       const target = event.target as Element | null;
       if (!target) return;

--- a/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.ts
+++ b/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.ts
@@ -64,6 +64,7 @@ export class ResultsCenterTableComponent implements AfterViewInit {
     const searchValue = this.resultsCenterService.searchInput();
     this.resultsCenterService.list();
     if (this.dt2) {
+      this.resultsCenterService.resultsTablePaginatorFirst.set(0);
       this.dt2.first = 0;
       this.dt2.filterGlobal(searchValue, 'contains');
     }

--- a/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.ts
+++ b/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.ts
@@ -86,6 +86,7 @@ export class ResultsCenterTableComponent implements AfterViewInit, OnDestroy {
   setSearchInputFilter(query: string) {
     this.resultsCenterService.resultsTablePaginatorFirst.set(0);
     this.resultsCenterService.searchInput.set(query);
+    void this.resultsCenterService.main();
   }
 
   getScrollHeight = computed(

--- a/research-indicators/src/app/pages/platform/pages/results-center/result-table-sort.util.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/results-center/result-table-sort.util.spec.ts
@@ -1,0 +1,13 @@
+import { tableSortPathToApiSortField } from './result-table-sort.util';
+
+describe('tableSortPathToApiSortField', () => {
+  it('maps known table column paths to API sort fields', () => {
+    expect(tableSortPathToApiSortField('result_official_code')).toBe('code');
+    expect(tableSortPathToApiSortField('title')).toBe('result-title');
+    expect(tableSortPathToApiSortField('created_at')).toBe('creation-date');
+  });
+
+  it('defaults unknown paths to code', () => {
+    expect(tableSortPathToApiSortField('unknown-field')).toBe('code');
+  });
+});

--- a/research-indicators/src/app/pages/platform/pages/results-center/result-table-sort.util.ts
+++ b/research-indicators/src/app/pages/platform/pages/results-center/result-table-sort.util.ts
@@ -1,0 +1,16 @@
+const PATH_TO_API_SORT_FIELD: Record<string, string> = {
+  result_official_code: 'code',
+  title: 'result-title',
+  'indicators.name': 'indicator',
+  'result_status.name': 'status',
+  'result_contracts.contract_id': 'project-code',
+  primaryLeverSort: 'primary-lever',
+  report_year_id: 'live-version',
+  snapshot_years: 'snapshot-version',
+  'created_by_user.first_name': 'creator',
+  created_at: 'creation-date'
+};
+
+export function tableSortPathToApiSortField(path: string): string {
+  return PATH_TO_API_SORT_FIELD[path] ?? 'code';
+}

--- a/research-indicators/src/app/pages/platform/pages/results-center/results-center.component.ts
+++ b/research-indicators/src/app/pages/platform/pages/results-center/results-center.component.ts
@@ -203,10 +203,10 @@ export default class ResultsCenterComponent implements OnInit, OnDestroy {
       this.pinnedTab.set(newPinnedTab);
       this.resultsCenterService.pinnedTab.set(newPinnedTab);
 
-      if (newPinnedTab === 'all') {
-        this.resultsCenterService.myResultsFilterItem.set(this.resultsCenterService.myResultsFilterItems[0]);
+      if (newPinnedTab === 'my') {
+        this.loadMyResults();
       } else {
-        this.resultsCenterService.myResultsFilterItem.set(this.resultsCenterService.myResultsFilterItems[1]);
+        this.loadAllResults();
       }
 
       setTimeout(() => {

--- a/research-indicators/src/app/pages/platform/pages/results-center/results-center.service.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/results-center/results-center.service.spec.ts
@@ -1152,15 +1152,17 @@ describe('ResultsCenterService', () => {
   });
 
   describe('clearAllFilters', () => {
-    it('should set create-user-codes from user id when pinnedTab is my', () => {
-      service.pinnedTab.set('my');
+    it('should set create-user-codes from user id when active tab is My Results (Clear Filters must not change tab)', () => {
+      service.pinnedTab.set('all');
+      service.myResultsFilterItem.set(service.myResultsFilterItems[1]);
       service.clearAllFilters();
       expect(service.resultsFilter()['create-user-codes']).toEqual(['123']);
       expect(service.myResultsFilterItem()).toEqual(service.myResultsFilterItems[1]);
     });
 
-    it('should clear create-user-codes when pinnedTab is all', () => {
-      service.pinnedTab.set('all');
+    it('should clear create-user-codes when active tab is All Results (Clear Filters must not switch to My Results)', () => {
+      service.pinnedTab.set('my');
+      service.myResultsFilterItem.set(service.myResultsFilterItems[0]);
       service.clearAllFilters();
       expect(service.resultsFilter()['create-user-codes']).toEqual([]);
       expect(service.myResultsFilterItem()).toEqual(service.myResultsFilterItems[0]);
@@ -1731,6 +1733,8 @@ describe('ResultsCenterService', () => {
       service.myResultsFilterItem.set(service.myResultsFilterItems[1]);
       service.searchInput.set('abc');
       service.primaryContractId.set('contract-1');
+      service.resultsTablePaginatorFirst.set(50);
+      service.resultsTablePaginatorRows.set(25);
       service.resultsFilter.update(prev => ({ ...prev, 'indicator-codes-tabs': [2] }));
 
       service.activateStatePersistence('demo');
@@ -1742,6 +1746,8 @@ describe('ResultsCenterService', () => {
       expect(savedState.myResultsFilterItemId).toBe('my');
       expect(savedState.primaryContractId).toBe('contract-1');
       expect(savedState.searchInput).toBe('abc');
+      expect(savedState.resultsTablePaginatorFirst).toBe(50);
+      expect(savedState.resultsTablePaginatorRows).toBe(25);
     });
 
     it('should persist all as default tab id when myResultsFilterItem is undefined', () => {
@@ -1805,7 +1811,9 @@ describe('ResultsCenterService', () => {
           'indicator-codes-tabs': [2]
         },
         searchInput: 'saved search',
-        primaryContractId: 'contract-2'
+        primaryContractId: 'contract-2',
+        resultsTablePaginatorFirst: 100,
+        resultsTablePaginatorRows: 25
       };
       jest.spyOn(Storage.prototype, 'getItem').mockReturnValue(JSON.stringify(persistedState));
 
@@ -1818,6 +1826,8 @@ describe('ResultsCenterService', () => {
       expect(service.appliedFilters()['indicator-codes-tabs']).toEqual([2]);
       expect(service.searchInput()).toBe('saved search');
       expect(service.primaryContractId()).toBe('contract-2');
+      expect(service.resultsTablePaginatorFirst()).toBe(100);
+      expect(service.resultsTablePaginatorRows()).toBe(25);
       expect(mockApiService.indicatorTabs.lazy().list().find(item => item.indicator_id === 2)?.active).toBe(true);
       expect(mockApiService.indicatorTabs.lazy().list().find(item => item.indicator_id === 1)?.active).toBe(false);
     });
@@ -1858,6 +1868,8 @@ describe('ResultsCenterService', () => {
       });
       expect(service.searchInput()).toBe('');
       expect(service.primaryContractId()).toBeNull();
+      expect(service.resultsTablePaginatorFirst()).toBe(0);
+      expect(service.resultsTablePaginatorRows()).toBe(10);
       expect(mockApiService.indicatorTabs.lazy().list().every(item => item.active === false)).toBe(true);
     });
 

--- a/research-indicators/src/app/pages/platform/pages/results-center/results-center.service.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/results-center/results-center.service.spec.ts
@@ -853,13 +853,22 @@ describe('ResultsCenterService', () => {
       expect(tableMock.rows).toBe(25);
     });
 
-    it('should clamp first to last page when aligned index exceeds total', () => {
+    it('should clamp first to last standard page when aligned index exceeds total (no total - rows overlap)', () => {
       const tableMock = { first: 0, rows: 10, totalRecords: 60 } as any;
       service.tableRef.set(tableMock);
       service.resultsTablePaginatorFirst.set(50);
       service.resultsTablePaginatorRows.set(10);
       service.handleResultsTablePage({ first: 0, rows: 25 });
-      expect(service.resultsTablePaginatorFirst()).toBe(35);
+      expect(service.resultsTablePaginatorFirst()).toBe(50);
+    });
+
+    it('should clamp to lastPageFirst = floor((total-1)/rows)*rows when same rows (e.g. total 33, rows 10 → first 30)', () => {
+      const tableMock = { first: 0, rows: 10, totalRecords: 33 } as any;
+      service.tableRef.set(tableMock);
+      service.resultsTablePaginatorFirst.set(0);
+      service.resultsTablePaginatorRows.set(10);
+      service.handleResultsTablePage({ first: 50, rows: 10 });
+      expect(service.resultsTablePaginatorFirst()).toBe(30);
     });
   });
 

--- a/research-indicators/src/app/pages/platform/pages/results-center/results-center.service.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/results-center/results-center.service.spec.ts
@@ -826,6 +826,40 @@ describe('ResultsCenterService', () => {
       expect(tableMock.sortField).toBe('result_official_code');
       expect(tableMock.sortOrder).toBe(-1);
       expect(tableMock.first).toBe(0);
+      expect(service.resultsTablePaginatorFirst()).toBe(0);
+    });
+  });
+
+  describe('handleResultsTablePage', () => {
+    it('should use event.first when rows per page unchanged', () => {
+      const tableMock = { first: 0, rows: 10, totalRecords: 100 } as any;
+      service.tableRef.set(tableMock);
+      service.resultsTablePaginatorFirst.set(10);
+      service.resultsTablePaginatorRows.set(10);
+      service.handleResultsTablePage({ first: 20, rows: 10 });
+      expect(service.resultsTablePaginatorFirst()).toBe(20);
+      expect(tableMock.first).toBe(20);
+    });
+
+    it('should align first when rows per page changes even if event.first is 0', () => {
+      const tableMock = { first: 0, rows: 10, totalRecords: 100 } as any;
+      service.tableRef.set(tableMock);
+      service.resultsTablePaginatorFirst.set(40);
+      service.resultsTablePaginatorRows.set(10);
+      service.handleResultsTablePage({ first: 0, rows: 25 });
+      expect(service.resultsTablePaginatorFirst()).toBe(25);
+      expect(service.resultsTablePaginatorRows()).toBe(25);
+      expect(tableMock.first).toBe(25);
+      expect(tableMock.rows).toBe(25);
+    });
+
+    it('should clamp first to last page when aligned index exceeds total', () => {
+      const tableMock = { first: 0, rows: 10, totalRecords: 60 } as any;
+      service.tableRef.set(tableMock);
+      service.resultsTablePaginatorFirst.set(50);
+      service.resultsTablePaginatorRows.set(10);
+      service.handleResultsTablePage({ first: 0, rows: 25 });
+      expect(service.resultsTablePaginatorFirst()).toBe(35);
     });
   });
 

--- a/research-indicators/src/app/pages/platform/pages/results-center/results-center.service.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/results-center/results-center.service.spec.ts
@@ -128,6 +128,7 @@ describe('ResultsCenterService', () => {
       expect(service.showConfigurationSidebar()).toBe(false);
       expect(service.loading()).toBe(false);
       expect(service.list()).toEqual([]);
+      expect(service.resultsListForTable()).toEqual([]);
       expect(service.searchInput()).toBe('');
       expect(service.showConfigurationsSidebar()).toBe(false);
       expect(service.confirmFiltersSignal()).toBe(false);
@@ -830,45 +831,90 @@ describe('ResultsCenterService', () => {
     });
   });
 
-  describe('handleResultsTablePage', () => {
+  describe('handleResultsTableLazyLoad', () => {
     it('should use event.first when rows per page unchanged', () => {
       const tableMock = { first: 0, rows: 10, totalRecords: 100 } as any;
       service.tableRef.set(tableMock);
+      service.resultsTableTotalRecords.set(100);
       service.resultsTablePaginatorFirst.set(10);
       service.resultsTablePaginatorRows.set(10);
-      service.handleResultsTablePage({ first: 20, rows: 10 });
+      service.handleResultsTableLazyLoad({ first: 20, rows: 10 });
       expect(service.resultsTablePaginatorFirst()).toBe(20);
-      expect(tableMock.first).toBe(20);
     });
 
     it('should align first when rows per page changes even if event.first is 0', () => {
       const tableMock = { first: 0, rows: 10, totalRecords: 100 } as any;
       service.tableRef.set(tableMock);
+      service.resultsTableTotalRecords.set(100);
       service.resultsTablePaginatorFirst.set(40);
       service.resultsTablePaginatorRows.set(10);
-      service.handleResultsTablePage({ first: 0, rows: 25 });
+      service.handleResultsTableLazyLoad({ first: 0, rows: 25 });
       expect(service.resultsTablePaginatorFirst()).toBe(25);
       expect(service.resultsTablePaginatorRows()).toBe(25);
-      expect(tableMock.first).toBe(25);
-      expect(tableMock.rows).toBe(25);
     });
 
     it('should clamp first to last standard page when aligned index exceeds total (no total - rows overlap)', () => {
       const tableMock = { first: 0, rows: 10, totalRecords: 60 } as any;
       service.tableRef.set(tableMock);
+      service.resultsTableTotalRecords.set(60);
       service.resultsTablePaginatorFirst.set(50);
       service.resultsTablePaginatorRows.set(10);
-      service.handleResultsTablePage({ first: 0, rows: 25 });
+      service.handleResultsTableLazyLoad({ first: 0, rows: 25 });
       expect(service.resultsTablePaginatorFirst()).toBe(50);
     });
 
     it('should clamp to lastPageFirst = floor((total-1)/rows)*rows when same rows (e.g. total 33, rows 10 → first 30)', () => {
       const tableMock = { first: 0, rows: 10, totalRecords: 33 } as any;
       service.tableRef.set(tableMock);
+      service.resultsTableTotalRecords.set(33);
       service.resultsTablePaginatorFirst.set(0);
       service.resultsTablePaginatorRows.set(10);
-      service.handleResultsTablePage({ first: 50, rows: 10 });
+      service.handleResultsTableLazyLoad({ first: 50, rows: 10 });
       expect(service.resultsTablePaginatorFirst()).toBe(30);
+    });
+
+    it('should update sort signals when lazy load includes sortField', () => {
+      service.resultsTableTotalRecords.set(100);
+      service.handleResultsTableLazyLoad({
+        first: 0,
+        rows: 10,
+        sortField: 'title',
+        sortOrder: 1
+      } as any);
+      expect(service.resultsTableSortField()).toBe('title');
+      expect(service.resultsTableSortOrder()).toBe(1);
+
+      service.handleResultsTableLazyLoad({
+        first: 0,
+        rows: 10,
+        sortField: 'result_official_code',
+        sortOrder: -1
+      } as any);
+      expect(service.resultsTableSortField()).toBe('result_official_code');
+      expect(service.resultsTableSortOrder()).toBe(-1);
+    });
+
+    it('should default missing first and rows from signals', () => {
+      service.resultsTableTotalRecords.set(100);
+      service.resultsTablePaginatorFirst.set(5);
+      service.resultsTablePaginatorRows.set(10);
+      service.handleResultsTableLazyLoad({} as any);
+      expect(service.resultsTablePaginatorFirst()).toBe(0);
+      expect(service.resultsTablePaginatorRows()).toBe(10);
+    });
+
+    it('should treat rows 0 as page size 10 when aligning paginator', () => {
+      service.resultsTableTotalRecords.set(50);
+      service.resultsTablePaginatorFirst.set(20);
+      service.resultsTablePaginatorRows.set(10);
+      service.handleResultsTableLazyLoad({ first: 0, rows: 0 } as any);
+      expect(service.resultsTablePaginatorRows()).toBe(0);
+      expect(service.resultsTablePaginatorFirst()).toBe(20);
+    });
+
+    it('should coerce undefined first in clampPaginatorFirstToStandardGrid', () => {
+      const clamp = (service as any).clampPaginatorFirstToStandardGrid.bind(service);
+      expect(clamp(undefined, 10, 100)).toBe(0);
     });
   });
 
@@ -1175,6 +1221,12 @@ describe('ResultsCenterService', () => {
       service.clearAllFilters();
       expect(service.resultsFilter()['create-user-codes']).toEqual([]);
       expect(service.myResultsFilterItem()).toEqual(service.myResultsFilterItems[0]);
+    });
+
+    it('should treat undefined tab as All Results for create-user-codes', () => {
+      service.myResultsFilterItem.set(undefined as any);
+      service.clearAllFilters();
+      expect(service.resultsFilter()['create-user-codes']).toEqual([]);
     });
 
     it('should clear all filters and reset state', () => {
@@ -1822,7 +1874,9 @@ describe('ResultsCenterService', () => {
         searchInput: 'saved search',
         primaryContractId: 'contract-2',
         resultsTablePaginatorFirst: 100,
-        resultsTablePaginatorRows: 25
+        resultsTablePaginatorRows: 25,
+        resultsTableSortField: 'title',
+        resultsTableSortOrder: 1
       };
       jest.spyOn(Storage.prototype, 'getItem').mockReturnValue(JSON.stringify(persistedState));
 
@@ -1837,6 +1891,8 @@ describe('ResultsCenterService', () => {
       expect(service.primaryContractId()).toBe('contract-2');
       expect(service.resultsTablePaginatorFirst()).toBe(100);
       expect(service.resultsTablePaginatorRows()).toBe(25);
+      expect(service.resultsTableSortField()).toBe('title');
+      expect(service.resultsTableSortOrder()).toBe(1);
       expect(mockApiService.indicatorTabs.lazy().list().find(item => item.indicator_id === 2)?.active).toBe(true);
       expect(mockApiService.indicatorTabs.lazy().list().find(item => item.indicator_id === 1)?.active).toBe(false);
     });
@@ -1896,17 +1952,30 @@ describe('ResultsCenterService', () => {
     });
   });
 
+  describe('invalidateResultsListFetchCache', () => {
+    it('should clear fetch dedupe so main runs fetch again with same params', async () => {
+      await service.main();
+      expect(mockGetResultsService.fetchPaginated).toHaveBeenCalledTimes(1);
+      await service.main();
+      expect(mockGetResultsService.fetchPaginated).toHaveBeenCalledTimes(1);
+      service.invalidateResultsListFetchCache();
+      await service.main();
+      expect(mockGetResultsService.fetchPaginated).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe('main', () => {
-    it('should pass filter-primary-contract when primaryContractId is set', async () => {
+    it('should pass contract-codes when primaryContractId is set', async () => {
       service.primaryContractId.set('contract-123');
       await service.main();
       expect(mockGetResultsService.fetchPaginated).toHaveBeenCalledWith(
-        expect.objectContaining({ 'filter-primary-contract': ['contract-123'] }),
+        expect.objectContaining({ 'contract-codes': ['contract-123'] }),
         expect.objectContaining({
           page: 1,
           limit: 10,
           sortField: 'code',
-          sortOrder: 'DESC'
+          sortOrder: 'DESC',
+          search: ''
         }),
         expect.anything()
       );
@@ -2027,7 +2096,7 @@ describe('ResultsCenterService', () => {
 
     it('should handle results with no created_by_user', async () => {
       const resultsWithoutUser = [{ ...mockResults[0], created_by_user: undefined }];
-      mockGetResultsService.getInstance.mockResolvedValueOnce(signal(resultsWithoutUser));
+      mockGetResultsService.fetchPaginated.mockResolvedValueOnce({ results: resultsWithoutUser, total: 1 });
 
       await service.main();
 

--- a/research-indicators/src/app/pages/platform/pages/results-center/results-center.service.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/results-center/results-center.service.spec.ts
@@ -64,7 +64,7 @@ describe('ResultsCenterService', () => {
     } as any;
 
     const mockGetResultsServiceObj = {
-      getInstance: jest.fn().mockResolvedValue(signal(mockResults))
+      fetchPaginated: jest.fn().mockResolvedValue({ results: mockResults, total: 1 })
     } as any;
 
     TestBed.configureTestingModule({
@@ -107,7 +107,7 @@ describe('ResultsCenterService', () => {
           ResultsCenterService,
           { provide: ApiService, useValue: { indicatorTabs: mockIndicatorTabsLoaded } as any },
           { provide: CacheService, useValue: { dataCache: signal(mockDataCache) } },
-          { provide: GetResultsService, useValue: { getInstance: jest.fn().mockResolvedValue(signal(mockResults)) } }
+          { provide: GetResultsService, useValue: { fetchPaginated: jest.fn().mockResolvedValue({ results: mockResults, total: 1 }) } }
         ]
       });
       TestBed.inject(ResultsCenterService);
@@ -910,7 +910,7 @@ describe('ResultsCenterService', () => {
             }
           },
           { provide: CacheService, useValue: { dataCache: signal(mockDataCache) } },
-          { provide: GetResultsService, useValue: { getInstance: jest.fn().mockResolvedValue(signal(mockResults)) } }
+          { provide: GetResultsService, useValue: { fetchPaginated: jest.fn().mockResolvedValue({ results: mockResults, total: 1 }) } }
         ]
       });
       TestBed.inject(ResultsCenterService);
@@ -1900,8 +1900,14 @@ describe('ResultsCenterService', () => {
     it('should pass filter-primary-contract when primaryContractId is set', async () => {
       service.primaryContractId.set('contract-123');
       await service.main();
-      expect(mockGetResultsService.getInstance).toHaveBeenCalledWith(
+      expect(mockGetResultsService.fetchPaginated).toHaveBeenCalledWith(
         expect.objectContaining({ 'filter-primary-contract': ['contract-123'] }),
+        expect.objectContaining({
+          page: 1,
+          limit: 10,
+          sortField: 'code',
+          sortOrder: 'DESC'
+        }),
         expect.anything()
       );
     });
@@ -1934,7 +1940,7 @@ describe('ResultsCenterService', () => {
           result_levers: [{ is_primary: 0, lever: { short_name: 'Lever 1' } }]
         }
       ];
-      mockGetResultsService.getInstance.mockResolvedValueOnce(signal(resultsWithoutPrimary));
+      mockGetResultsService.fetchPaginated.mockResolvedValueOnce({ results: resultsWithoutPrimary, total: 1 });
 
       await service.main();
 
@@ -1952,7 +1958,7 @@ describe('ResultsCenterService', () => {
           ]
         }
       ] as any;
-      mockGetResultsService.getInstance.mockResolvedValueOnce(signal(resultsWithLeverNoShortName));
+      mockGetResultsService.fetchPaginated.mockResolvedValueOnce({ results: resultsWithLeverNoShortName, total: 1 });
       await service.main();
       const list = service.list();
       expect(list).toHaveLength(1);
@@ -1969,7 +1975,7 @@ describe('ResultsCenterService', () => {
           ]
         }
       ];
-      mockGetResultsService.getInstance.mockResolvedValueOnce(signal(resultsWithPrimary));
+      mockGetResultsService.fetchPaginated.mockResolvedValueOnce({ results: resultsWithPrimary, total: 1 });
 
       await service.main();
 
@@ -1978,7 +1984,7 @@ describe('ResultsCenterService', () => {
     });
 
     it('should handle errors when loading results', async () => {
-      mockGetResultsService.getInstance.mockRejectedValueOnce(new Error('API Error'));
+      mockGetResultsService.fetchPaginated.mockRejectedValueOnce(new Error('API Error'));
 
       // Mock console.error to prevent error output in tests
       const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
@@ -2006,15 +2012,15 @@ describe('ResultsCenterService', () => {
     it('should not update list when context changes during request', async () => {
       const initialList = [{ result_official_code: 'OLD' }] as any;
       service.list.set(initialList);
-      let resolveInstance!: (v: WritableSignal<Result[]>) => void;
-      const instancePromise = new Promise<WritableSignal<Result[]>>(r => {
-        resolveInstance = r;
+      let resolveFetch!: (v: { results: Result[]; total: number }) => void;
+      const fetchPromise = new Promise<{ results: Result[]; total: number }>(r => {
+        resolveFetch = r;
       });
-      mockGetResultsService.getInstance.mockImplementationOnce(() => instancePromise as any);
+      mockGetResultsService.fetchPaginated.mockImplementationOnce(() => fetchPromise as any);
       const mainPromise = service.main();
       await Promise.resolve();
       service.primaryContractId.set('other-contract');
-      resolveInstance(signal(mockResults));
+      resolveFetch({ results: mockResults, total: 1 });
       await mainPromise;
       expect(service.list()).toEqual(initialList);
     });
@@ -2030,7 +2036,7 @@ describe('ResultsCenterService', () => {
 
     it('should handle created_by_user with null first_name and last_name', async () => {
       const resultsWithNullNames = [{ ...mockResults[0], created_by_user: { first_name: null, last_name: null } }];
-      mockGetResultsService.getInstance.mockResolvedValueOnce(signal(resultsWithNullNames));
+      mockGetResultsService.fetchPaginated.mockResolvedValueOnce({ results: resultsWithNullNames, total: 1 });
 
       await service.main();
 

--- a/research-indicators/src/app/pages/platform/pages/results-center/results-center.service.ts
+++ b/research-indicators/src/app/pages/platform/pages/results-center/results-center.service.ts
@@ -7,6 +7,7 @@ import { TableColumn } from './result-center.interface';
 import { TableFilters } from './class/table.filters.class';
 import { GetAllIndicators } from '../../../../shared/interfaces/get-all-indicators.interface';
 import { Table } from 'primeng/table';
+import { ObjectUtils } from 'primeng/utils';
 import { ApiService } from '../../../../shared/services/api.service';
 import { MultiselectComponent } from '../../../../shared/components/custom-fields/multiselect/multiselect.component';
 
@@ -17,6 +18,8 @@ interface ResultsCenterPersistedState {
   appliedFilters: ResultFilter;
   searchInput: string;
   primaryContractId: string | null;
+  resultsTablePaginatorFirst: number;
+  resultsTablePaginatorRows: number;
 }
 @Injectable({
   providedIn: 'root'
@@ -164,6 +167,25 @@ export class ResultsCenterService {
       .flatMap(column => column.filterPaths ?? [column.path])
   );
 
+  resultsListForTable = computed(() => {
+    const items = this.list();
+    const q = (this.searchInput() ?? '').trim().toLowerCase();
+    if (!q) {
+      return items;
+    }
+    const paths = this.getAllPathsAsArray();
+    return items.filter(row =>
+      paths.some(path => {
+        const raw = ObjectUtils.resolveFieldData(row, path);
+        if (raw == null) {
+          return false;
+        }
+        const text = Array.isArray(raw) ? raw.map(String).join(' ') : String(raw);
+        return text.toLowerCase().includes(q);
+      })
+    );
+  });
+
   resultsFilter = signal<ResultFilter>({ 'indicator-codes': [], 'lever-codes': [], 'create-user-codes': [] });
   primaryContractId = signal<string | null>(null);
   resultsConfig = signal<ResultConfig>({
@@ -199,7 +221,9 @@ export class ResultsCenterService {
       resultsFilter: this.resultsFilter(),
       appliedFilters: this.appliedFilters(),
       searchInput: this.searchInput(),
-      primaryContractId: this.primaryContractId()
+      primaryContractId: this.primaryContractId(),
+      resultsTablePaginatorFirst: this.resultsTablePaginatorFirst(),
+      resultsTablePaginatorRows: this.resultsTablePaginatorRows()
     };
 
     globalThis.sessionStorage?.setItem(this.getStorageKey(activeKey), JSON.stringify(state));
@@ -453,7 +477,7 @@ export class ResultsCenterService {
     if (table != null && typeof table.totalRecords === 'number') {
       return table.totalRecords;
     }
-    return this.list().length;
+    return this.resultsListForTable().length;
   }
 
   private alignResultsTableFirstAfterRowsChange(anchorFirst: number, newRows: number, total: number): number {
@@ -619,10 +643,8 @@ export class ResultsCenterService {
       levers: []
     }));
 
-    const pinnedItem = this.pinnedTab() === 'my' ? this.myResultsFilterItems[1] : this.myResultsFilterItems[0];
-    this.myResultsFilterItem.set(pinnedItem);
-
-    const createUserCodes = pinnedItem.id === 'my' ? [this.cache.dataCache().user.sec_user_id.toString()] : [];
+    const activeTab = this.myResultsFilterItem() ?? this.myResultsFilterItems[0];
+    const createUserCodes = activeTab.id === 'my' ? [this.cache.dataCache().user.sec_user_id.toString()] : [];
 
     this.resultsFilter.set({
       'indicator-codes': [],
@@ -772,6 +794,8 @@ export class ResultsCenterService {
       this.appliedFilters.set(appliedFilters);
       this.searchInput.set(state.searchInput ?? '');
       this.primaryContractId.set(state.primaryContractId ?? null);
+      this.resultsTablePaginatorFirst.set(state.resultsTablePaginatorFirst ?? 0);
+      this.resultsTablePaginatorRows.set(state.resultsTablePaginatorRows ?? 10);
       this.syncIndicatorTabSelection(resultsFilter['indicator-codes-tabs']?.[0] ?? 0);
 
       return true;

--- a/research-indicators/src/app/pages/platform/pages/results-center/results-center.service.ts
+++ b/research-indicators/src/app/pages/platform/pages/results-center/results-center.service.ts
@@ -184,6 +184,9 @@ export class ResultsCenterService {
   cache = inject(CacheService);
 
   tableRef = signal<Table | undefined>(undefined);
+  resultsTablePaginatorFirst = signal(0);
+  resultsTablePaginatorRows = signal(10);
+
   persistViewState = effect(() => {
     const activeKey = this.activeStateKey();
     if (!activeKey) {
@@ -431,6 +434,48 @@ export class ResultsCenterService {
       this.loading.set(false);
     }
   }
+  handleResultsTablePage(event: { first: number; rows: number }): void {
+    const newRows = event.rows ?? 10;
+    const previousFirst = this.resultsTablePaginatorFirst();
+    const previousRows = this.resultsTablePaginatorRows();
+    const table = this.tableRef();
+    const total = this.getResultsTablePaginatorTotalRecords(table);
+    const nextFirst = previousRows === newRows ? (event.first ?? 0) : this.alignResultsTableFirstAfterRowsChange(previousFirst, newRows, total);
+    this.resultsTablePaginatorFirst.set(nextFirst);
+    this.resultsTablePaginatorRows.set(newRows);
+    if (table) {
+      table.first = nextFirst;
+      table.rows = newRows;
+    }
+  }
+
+  private getResultsTablePaginatorTotalRecords(table: Table | undefined): number {
+    if (table != null && typeof table.totalRecords === 'number') {
+      return table.totalRecords;
+    }
+    return this.list().length;
+  }
+
+  private alignResultsTableFirstAfterRowsChange(anchorFirst: number, newRows: number, total: number): number {
+    const safeRows = newRows > 0 ? newRows : 10;
+    let newFirst = Math.floor(anchorFirst / safeRows) * safeRows;
+    if (total > 0) {
+      const maxFirst = Math.max(0, total - safeRows);
+      if (newFirst > maxFirst) {
+        newFirst = maxFirst;
+      }
+    }
+    return newFirst;
+  }
+
+  private resetResultsTablePaginatorToFirstPage(): void {
+    this.resultsTablePaginatorFirst.set(0);
+    const table = this.tableRef();
+    if (table) {
+      table.first = 0;
+    }
+  }
+
   getStatusSeverity(status: string): 'success' | 'info' | 'warning' | 'danger' | undefined {
     const severityMap: Record<string, 'success' | 'info' | 'warning' | 'danger'> = {
       SUBMITTED: 'info',
@@ -466,8 +511,8 @@ export class ResultsCenterService {
       table.clear();
       table.sortField = 'result_official_code';
       table.sortOrder = -1;
-      table.first = 0;
     }
+    this.resetResultsTablePaginatorToFirstPage();
   };
 
   showFilterSidebar(): void {
@@ -504,10 +549,7 @@ export class ResultsCenterService {
       'create-user-codes': preserveCreateUserCodes
     }));
 
-    const table = this.tableRef();
-    if (table) {
-      table.first = 0;
-    }
+    this.resetResultsTablePaginatorToFirstPage();
     this.main();
   };
 
@@ -549,8 +591,8 @@ export class ResultsCenterService {
     if (table) {
       table.sortField = 'result_official_code';
       table.sortOrder = -1;
-      table.first = 0;
     }
+    this.resetResultsTablePaginatorToFirstPage();
 
     this.tableFilters.update(prev => ({
       ...prev,
@@ -631,6 +673,7 @@ export class ResultsCenterService {
       table.sortField = 'result_official_code';
       table.sortOrder = -1;
     }
+    this.resetResultsTablePaginatorToFirstPage();
     this.main();
   }
 
@@ -673,6 +716,7 @@ export class ResultsCenterService {
       table.sortField = 'result_official_code';
       table.sortOrder = -1;
     }
+    this.resetResultsTablePaginatorToFirstPage();
     this.onSelectFilterTab(0);
   }
 

--- a/research-indicators/src/app/pages/platform/pages/results-center/results-center.service.ts
+++ b/research-indicators/src/app/pages/platform/pages/results-center/results-center.service.ts
@@ -464,7 +464,10 @@ export class ResultsCenterService {
     const previousRows = this.resultsTablePaginatorRows();
     const table = this.tableRef();
     const total = this.getResultsTablePaginatorTotalRecords(table);
-    const nextFirst = previousRows === newRows ? (event.first ?? 0) : this.alignResultsTableFirstAfterRowsChange(previousFirst, newRows, total);
+    const nextFirst =
+      previousRows === newRows
+        ? this.clampPaginatorFirstToStandardGrid(event.first ?? 0, newRows, total)
+        : this.alignResultsTableFirstAfterRowsChange(previousFirst, newRows, total);
     this.resultsTablePaginatorFirst.set(nextFirst);
     this.resultsTablePaginatorRows.set(newRows);
     if (table) {
@@ -480,16 +483,23 @@ export class ResultsCenterService {
     return this.resultsListForTable().length;
   }
 
-  private alignResultsTableFirstAfterRowsChange(anchorFirst: number, newRows: number, total: number): number {
-    const safeRows = newRows > 0 ? newRows : 10;
-    let newFirst = Math.floor(anchorFirst / safeRows) * safeRows;
+  /** Keeps `first` on a standard page boundary: multiples of `rows`, last page = floor((total-1)/rows)*rows. */
+  private clampPaginatorFirstToStandardGrid(first: number, rows: number, total: number): number {
+    const safeRows = rows > 0 ? rows : 10;
+    let f = Math.floor((first ?? 0) / safeRows) * safeRows;
     if (total > 0) {
-      const maxFirst = Math.max(0, total - safeRows);
-      if (newFirst > maxFirst) {
-        newFirst = maxFirst;
+      const lastPageFirst = Math.max(0, Math.floor((total - 1) / safeRows) * safeRows);
+      if (f > lastPageFirst) {
+        f = lastPageFirst;
       }
     }
-    return newFirst;
+    return Math.max(0, f);
+  }
+
+  private alignResultsTableFirstAfterRowsChange(anchorFirst: number, newRows: number, total: number): number {
+    const safeRows = newRows > 0 ? newRows : 10;
+    const candidate = Math.floor(anchorFirst / safeRows) * safeRows;
+    return this.clampPaginatorFirstToStandardGrid(candidate, newRows, total);
   }
 
   private resetResultsTablePaginatorToFirstPage(): void {

--- a/research-indicators/src/app/pages/platform/pages/results-center/results-center.service.ts
+++ b/research-indicators/src/app/pages/platform/pages/results-center/results-center.service.ts
@@ -2,12 +2,12 @@ import { inject, Injectable, signal, effect, computed } from '@angular/core';
 import { GetResultsService } from '../../../../shared/services/control-list/get-results.service';
 import { Result, ResultConfig, ResultFilter } from '../../../../shared/interfaces/result/result.interface';
 import { MenuItem } from 'primeng/api';
+import { tableSortPathToApiSortField } from './result-table-sort.util';
 import { CacheService } from '../../../../shared/services/cache/cache.service';
 import { TableColumn } from './result-center.interface';
 import { TableFilters } from './class/table.filters.class';
 import { GetAllIndicators } from '../../../../shared/interfaces/get-all-indicators.interface';
-import { Table } from 'primeng/table';
-import { ObjectUtils } from 'primeng/utils';
+import { Table, TableLazyLoadEvent } from 'primeng/table';
 import { ApiService } from '../../../../shared/services/api.service';
 import { MultiselectComponent } from '../../../../shared/components/custom-fields/multiselect/multiselect.component';
 
@@ -20,6 +20,8 @@ interface ResultsCenterPersistedState {
   primaryContractId: string | null;
   resultsTablePaginatorFirst: number;
   resultsTablePaginatorRows: number;
+  resultsTableSortField: string;
+  resultsTableSortOrder: number;
 }
 @Injectable({
   providedIn: 'root'
@@ -167,24 +169,8 @@ export class ResultsCenterService {
       .flatMap(column => column.filterPaths ?? [column.path])
   );
 
-  resultsListForTable = computed(() => {
-    const items = this.list();
-    const q = (this.searchInput() ?? '').trim().toLowerCase();
-    if (!q) {
-      return items;
-    }
-    const paths = this.getAllPathsAsArray();
-    return items.filter(row =>
-      paths.some(path => {
-        const raw = ObjectUtils.resolveFieldData(row, path);
-        if (raw == null) {
-          return false;
-        }
-        const text = Array.isArray(raw) ? raw.map(String).join(' ') : String(raw);
-        return text.toLowerCase().includes(q);
-      })
-    );
-  });
+  /** Current page rows (search is applied server-side via `search` query param). */
+  resultsListForTable = computed(() => this.list());
 
   resultsFilter = signal<ResultFilter>({ 'indicator-codes': [], 'lever-codes': [], 'create-user-codes': [] });
   primaryContractId = signal<string | null>(null);
@@ -208,6 +194,10 @@ export class ResultsCenterService {
   tableRef = signal<Table | undefined>(undefined);
   resultsTablePaginatorFirst = signal(0);
   resultsTablePaginatorRows = signal(10);
+  resultsTableTotalRecords = signal(0);
+  private lastSuccessfulResultsFetchKey: string | null = null;
+  resultsTableSortField = signal<string>('result_official_code');
+  resultsTableSortOrder = signal<-1 | 1>(-1);
 
   persistViewState = effect(() => {
     const activeKey = this.activeStateKey();
@@ -223,7 +213,9 @@ export class ResultsCenterService {
       searchInput: this.searchInput(),
       primaryContractId: this.primaryContractId(),
       resultsTablePaginatorFirst: this.resultsTablePaginatorFirst(),
-      resultsTablePaginatorRows: this.resultsTablePaginatorRows()
+      resultsTablePaginatorRows: this.resultsTablePaginatorRows(),
+      resultsTableSortField: this.resultsTableSortField(),
+      resultsTableSortOrder: this.resultsTableSortOrder()
     };
 
     globalThis.sessionStorage?.setItem(this.getStorageKey(activeKey), JSON.stringify(state));
@@ -384,6 +376,15 @@ export class ResultsCenterService {
     }
   );
 
+  private invalidateResultsFetchDedupe(): void {
+    this.lastSuccessfulResultsFetchKey = null;
+  }
+
+  /** Ensures the next `main()` runs a network request (e.g. linked-results modal vs. cached results-center fetch). */
+  invalidateResultsListFetchCache(): void {
+    this.invalidateResultsFetchDedupe();
+  }
+
   async main() {
     this.loading.set(true);
     const primaryContractIdAtRequest = this.primaryContractId();
@@ -418,10 +419,37 @@ export class ResultsCenterService {
       }
 
       const primaryContractId = this.primaryContractId();
-      const finalFilter = primaryContractId ? ({ ...baseFilter, 'filter-primary-contract': [primaryContractId] } as ResultFilter) : baseFilter;
+      const finalFilter = primaryContractId ? ({ ...baseFilter, 'contract-codes': [primaryContractId] } as ResultFilter) : baseFilter;
 
-      const response = await this.getResultsService.getInstance(finalFilter, this.resultsConfig());
-      const rawResults = response();
+      const rows = this.resultsTablePaginatorRows();
+      const first = this.resultsTablePaginatorFirst();
+      const page = Math.floor(first / rows) + 1;
+
+      const fetchKey = JSON.stringify({
+        filter: finalFilter,
+        page,
+        limit: rows,
+        sortField: tableSortPathToApiSortField(this.resultsTableSortField()),
+        sortOrder: this.resultsTableSortOrder() === 1 ? 'ASC' : 'DESC',
+        search: this.searchInput().trim(),
+        resultsConfig: this.resultsConfig()
+      });
+
+      if (fetchKey === this.lastSuccessfulResultsFetchKey) {
+        return;
+      }
+
+      const { results: rawResults, total } = await this.getResultsService.fetchPaginated(
+        finalFilter,
+        {
+          page,
+          limit: rows,
+          sortField: tableSortPathToApiSortField(this.resultsTableSortField()),
+          sortOrder: this.resultsTableSortOrder() === 1 ? 'ASC' : 'DESC',
+          search: this.searchInput().trim()
+        },
+        this.resultsConfig()
+      );
 
       const enhancedResults = rawResults.map(result => {
         const primaryLevers = Array.isArray(result.result_levers) ? result.result_levers.filter(rl => rl.is_primary === 1) : [];
@@ -446,41 +474,40 @@ export class ResultsCenterService {
 
       const stillSameContext = this.primaryContractId() === primaryContractIdAtRequest && this.myResultsFilterItem()?.id === activeTabIdAtRequest;
       if (stillSameContext) {
+        this.resultsTableTotalRecords.set(total);
         this.list.set(enhancedResults);
+        this.lastSuccessfulResultsFetchKey = fetchKey;
       }
     } catch (error) {
       console.error('Error loading results:', error);
+      this.lastSuccessfulResultsFetchKey = null;
       const stillSameContext = this.primaryContractId() === primaryContractIdAtRequest && this.myResultsFilterItem()?.id === activeTabIdAtRequest;
       if (stillSameContext) {
+        this.resultsTableTotalRecords.set(0);
         this.list.set([]);
       }
     } finally {
       this.loading.set(false);
     }
   }
-  handleResultsTablePage(event: { first: number; rows: number }): void {
-    const newRows = event.rows ?? 10;
+  handleResultsTableLazyLoad(event: TableLazyLoadEvent): void {
+    const newRows = event.rows ?? this.resultsTablePaginatorRows();
     const previousFirst = this.resultsTablePaginatorFirst();
     const previousRows = this.resultsTablePaginatorRows();
-    const table = this.tableRef();
-    const total = this.getResultsTablePaginatorTotalRecords(table);
+    const total = this.resultsTableTotalRecords();
+    const requestedFirst = event.first ?? 0;
     const nextFirst =
       previousRows === newRows
-        ? this.clampPaginatorFirstToStandardGrid(event.first ?? 0, newRows, total)
+        ? this.clampPaginatorFirstToStandardGrid(requestedFirst, newRows, total)
         : this.alignResultsTableFirstAfterRowsChange(previousFirst, newRows, total);
     this.resultsTablePaginatorFirst.set(nextFirst);
     this.resultsTablePaginatorRows.set(newRows);
-    if (table) {
-      table.first = nextFirst;
-      table.rows = newRows;
+    if (event.sortField != null && event.sortField !== '') {
+      this.resultsTableSortField.set(String(event.sortField));
+      const order = event.sortOrder as number | undefined;
+      this.resultsTableSortOrder.set(order === 1 ? 1 : -1);
     }
-  }
-
-  private getResultsTablePaginatorTotalRecords(table: Table | undefined): number {
-    if (table != null && typeof table.totalRecords === 'number') {
-      return table.totalRecords;
-    }
-    return this.resultsListForTable().length;
+    void this.main();
   }
 
   /** Keeps `first` on a standard page boundary: multiples of `rows`, last page = floor((total-1)/rows)*rows. */
@@ -520,6 +547,7 @@ export class ResultsCenterService {
   }
 
   onActiveItemChange = (event: MenuItem): void => {
+    this.invalidateResultsFetchDedupe();
     this.myResultsFilterItem.set(event);
 
     this.searchInput.set('');
@@ -540,6 +568,8 @@ export class ResultsCenterService {
     this.onSelectFilterTab(0);
     this.cleanMultiselects();
 
+    this.resultsTableSortField.set('result_official_code');
+    this.resultsTableSortOrder.set(-1);
     const table = this.tableRef();
     if (table) {
       table.clear();
@@ -558,6 +588,7 @@ export class ResultsCenterService {
   }
 
   applyFilters = () => {
+    this.invalidateResultsFetchDedupe();
     const currentTab = this.myResultsFilterItem();
     const preserveCreateUserCodes = currentTab?.id === 'my' ? this.resultsFilter()['create-user-codes'] || [] : [];
 
@@ -588,6 +619,7 @@ export class ResultsCenterService {
   };
 
   onSelectFilterTab(indicatorId: number) {
+    this.invalidateResultsFetchDedupe();
     this.api.indicatorTabs.lazy().list.update(prev =>
       prev.map((item: GetAllIndicators) => ({
         ...item,
@@ -621,6 +653,8 @@ export class ResultsCenterService {
 
   cleanFilters() {
     this.cleanMultiselects();
+    this.resultsTableSortField.set('result_official_code');
+    this.resultsTableSortOrder.set(-1);
     const table = this.tableRef();
     if (table) {
       table.sortField = 'result_official_code';
@@ -640,6 +674,7 @@ export class ResultsCenterService {
   }
 
   clearAllFilters() {
+    this.invalidateResultsFetchDedupe();
     this.cleanMultiselects();
 
     this.tableFilters.set(new TableFilters());
@@ -699,6 +734,8 @@ export class ResultsCenterService {
       this.cleanMultiselects();
     }, 0);
 
+    this.resultsTableSortField.set('result_official_code');
+    this.resultsTableSortOrder.set(-1);
     const table = this.tableRef();
     if (table) {
       table.clear();
@@ -710,6 +747,7 @@ export class ResultsCenterService {
   }
 
   clearAllFiltersWithPreserve(preserveIndicatorCodes: readonly number[]): void {
+    this.invalidateResultsFetchDedupe();
     this.tableFilters.set(new TableFilters());
     this.tableFilters.update(prev => ({
       ...prev,
@@ -742,6 +780,8 @@ export class ResultsCenterService {
     // clear search input
     this.searchInput.set('');
     this.cleanMultiselects();
+    this.resultsTableSortField.set('result_official_code');
+    this.resultsTableSortOrder.set(-1);
     const table = this.tableRef();
     if (table) {
       table.clear();
@@ -806,6 +846,8 @@ export class ResultsCenterService {
       this.primaryContractId.set(state.primaryContractId ?? null);
       this.resultsTablePaginatorFirst.set(state.resultsTablePaginatorFirst ?? 0);
       this.resultsTablePaginatorRows.set(state.resultsTablePaginatorRows ?? 10);
+      this.resultsTableSortField.set(state.resultsTableSortField ?? 'result_official_code');
+      this.resultsTableSortOrder.set(state.resultsTableSortOrder === 1 ? 1 : -1);
       this.syncIndicatorTabSelection(resultsFilter['indicator-codes-tabs']?.[0] ?? 0);
 
       return true;

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.spec.ts
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.spec.ts
@@ -703,7 +703,11 @@ describe('CreateOicrFormComponent', () => {
     };
     const mockRegion = { sub_national_id: 42 };
     const mockInstance = { removeRegionById: jest.fn(), endpointParams: { isoAlpha2: 'US' } };
-    component.multiselectInstances = { find: jest.fn().mockReturnValue(mockInstance) } as any;
+    component.multiselectInstances = {
+      find: jest.fn((predicate: (m: { endpointParams?: { isoAlpha2?: string } }) => boolean) =>
+        predicate(mockInstance) ? mockInstance : undefined
+      )
+    } as any;
     mockCreateResultManagementService.createOicrBody.set({
       ...mockCreateResultManagementService.createOicrBody(),
       step_three: {
@@ -1133,6 +1137,19 @@ describe('CreateOicrFormComponent', () => {
     });
     expect(mockAllModalsService.setSubmitBackAction).toHaveBeenCalled();
     expect(mockAllModalsService.openModal).toHaveBeenCalledWith('submitResult');
+  });
+
+  it('should invoke setSubmitBackAction callback to run handleSubmitBack from openSubmitResultModal', async () => {
+    const backSpy = jest.spyOn(component, 'handleSubmitBack').mockResolvedValue(undefined);
+    (component as any).currentContract = signal(null);
+    component.activeIndex = signal(0);
+    mockCreateResultManagementService.resultTitle = signal(null);
+    mockCreateResultManagementService.statusId = signal(null);
+    component.openSubmitResultModal();
+    const submitBackFn = mockAllModalsService.setSubmitBackAction.mock.calls.pop()![0] as () => Promise<void>;
+    await submitBackFn();
+    expect(backSpy).toHaveBeenCalled();
+    backSpy.mockRestore();
   });
 
   it('should handle openSubmitResultModal with contract without levers', () => {
@@ -1761,6 +1778,14 @@ describe('CreateOicrFormComponent', () => {
   });
 
   describe('computed properties', () => {
+    it('isRegionsRequired should evaluate computed body', () => {
+      mockCreateResultManagementService.createOicrBody.set({
+        ...mockCreateResultManagementService.createOicrBody(),
+        step_three: { geo_scope_id: 2 }
+      });
+      expect(component.isRegionsRequired()).toBeDefined();
+    });
+
     it('isCountriesRequired should return correct value', () => {
       mockCreateResultManagementService.createOicrBody.set({
         ...mockCreateResultManagementService.createOicrBody(),
@@ -2401,6 +2426,34 @@ describe('CreateOicrFormComponent', () => {
       
       expect(mockAllModalsService.disablePostponeOption.set).toHaveBeenCalledWith(true);
       expect(mockAllModalsService.disableRejectOption.set).toHaveBeenCalledWith(false);
+    });
+
+    it('should invoke setSubmitBackAction callback to run handleSubmitBack', async () => {
+      const backSpy = jest.spyOn(component, 'handleSubmitBack').mockResolvedValue(undefined);
+      mockCreateResultManagementService.statusId.set(9);
+      (component as any).currentContract = signal({
+        agreement_id: '123',
+        description: 'Test',
+        project_lead_description: 'Lead',
+        start_date: '2023-01-01',
+        endDateGlobal: '2023-12-31',
+        levers: {
+          id: 1,
+          full_name: 'Test Lever',
+          short_name: 'TL',
+          other_names: 'Test',
+          lever_url: 'http://test.com'
+        }
+      });
+      mockCreateResultManagementService.resultTitle.set('Test Title');
+      component.activeIndex.set(2);
+
+      component.openSubmitResultModalForReviewAgain();
+
+      const submitBackFn = mockAllModalsService.setSubmitBackAction.mock.calls.pop()![0] as () => Promise<void>;
+      await submitBackFn();
+      expect(backSpy).toHaveBeenCalled();
+      backSpy.mockRestore();
     });
 
     it('should disable reject option when statusId is 15', () => {

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-result-form/create-result-form.component.spec.ts
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-result-form/create-result-form.component.spec.ts
@@ -257,7 +257,7 @@ describe('CreateResultFormComponent', () => {
         title: 'Existing',
         result_id: 1
       };
-      apiServiceMock.GET_Results!.mockResolvedValue({ data: [resultItem] } as any);
+      apiServiceMock.GET_Results!.mockResolvedValue({ data: { results: [resultItem], total: 1 } } as any);
 
       await component.openExistingResultModal('TIP', '456');
 
@@ -276,7 +276,7 @@ describe('CreateResultFormComponent', () => {
       const first = { result_official_code: '111', platform_code: 'TIP', title: 'First', result_id: 1 };
       const second = { result_official_code: '999', platform_code: 'TIP', title: 'Target', result_id: 2 };
       const third = { result_official_code: '999', platform_code: 'PRMS', title: 'Other platform', result_id: 3 };
-      apiServiceMock.GET_Results!.mockResolvedValue({ data: [first, second, third] } as any);
+      apiServiceMock.GET_Results!.mockResolvedValue({ data: { results: [first, second, third], total: 3 } } as any);
 
       await component.openExistingResultModal('TIP', '999');
 
@@ -292,7 +292,7 @@ describe('CreateResultFormComponent', () => {
 
     it('should use single result when find returns undefined (list.length === 1 fallback)', async () => {
       const single = { result_official_code: '111', platform_code: 'TIP', title: 'Only One', result_id: 1 };
-      apiServiceMock.GET_Results!.mockResolvedValue({ data: [single] } as any);
+      apiServiceMock.GET_Results!.mockResolvedValue({ data: { results: [single], total: 1 } } as any);
 
       await component.openExistingResultModal('TIP', '999');
 
@@ -309,7 +309,7 @@ describe('CreateResultFormComponent', () => {
     it('should not open modal when find returns undefined and list has multiple items', async () => {
       const a = { result_official_code: '111', platform_code: 'TIP', title: 'A', result_id: 1 };
       const b = { result_official_code: '222', platform_code: 'TIP', title: 'B', result_id: 2 };
-      apiServiceMock.GET_Results!.mockResolvedValue({ data: [a, b] } as any);
+      apiServiceMock.GET_Results!.mockResolvedValue({ data: { results: [a, b], total: 2 } } as any);
 
       await component.openExistingResultModal('TIP', '999');
 
@@ -325,7 +325,7 @@ describe('CreateResultFormComponent', () => {
         result_id: 5,
         snapshot_years: [2024, 2025]
       };
-      apiServiceMock.GET_Results!.mockResolvedValue({ data: [resultItem] } as any);
+      apiServiceMock.GET_Results!.mockResolvedValue({ data: { results: [resultItem], total: 1 } } as any);
 
       await component.openExistingResultModal('TIP', '888');
 
@@ -348,7 +348,7 @@ describe('CreateResultFormComponent', () => {
     });
 
     it('should not open modal when data is empty', async () => {
-      apiServiceMock.GET_Results!.mockResolvedValue({ data: [] } as any);
+      apiServiceMock.GET_Results!.mockResolvedValue({ data: { results: [], total: 0 } } as any);
 
       await component.openExistingResultModal('TIP', '999');
 

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-result-form/create-result-form.component.ts
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-result-form/create-result-form.component.ts
@@ -323,8 +323,8 @@ export class CreateResultFormComponent {
         'audit-data': true,
         'audit-data-object': true
       };
-      const response = await this.api.GET_Results(filter, resultConfig);
-      const list: Result[] = Array.isArray(response?.data) ? response.data : [];
+      const response = await this.api.GET_Results(filter, resultConfig, { page: 1, limit: 1000, sortField: 'code' });
+      const list: Result[] = response?.data?.results ?? [];
       const result = list.find(
         (r: Result) => String(r.result_official_code) === resultOfficialCode && r.platform_code === platformCode
       ) ?? (list.length === 1 ? list[0] : null);

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/result-ai-assistant/result-ai-assistant.component.spec.ts
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/result-ai-assistant/result-ai-assistant.component.spec.ts
@@ -35,7 +35,7 @@ describe('ResultAiAssistantComponent', () => {
   function createFile(name: string, sizeBytes = 1000, content = 'dummy') {
     const file = new File([content], name, { type: 'application/octet-stream' });
     Object.defineProperty(file, 'size', { value: sizeBytes });
-    (file).arrayBuffer = jest.fn().mockResolvedValue(new TextEncoder().encode(content).buffer);
+    file.arrayBuffer = jest.fn().mockResolvedValue(new TextEncoder().encode(content).buffer);
     return file;
   }
 
@@ -105,7 +105,10 @@ describe('ResultAiAssistantComponent', () => {
   });
 
   it('should load badTypes from GET_IssueCategories in constructor', async () => {
-    const categories = [{ id: 1, name: 'Category A' }, { id: 2, name: 'Category B' }];
+    const categories = [
+      { id: 1, name: 'Category A' },
+      { id: 2, name: 'Category B' }
+    ];
     (apiServiceMock.GET_IssueCategories as jest.Mock).mockResolvedValue({ data: categories });
     const f = TestBed.createComponent(ResultAiAssistantComponent);
     f.detectChanges();
@@ -261,7 +264,11 @@ describe('ResultAiAssistantComponent', () => {
     component.selectedFile = file;
     textMiningServiceMock.executeTextMining.mockResolvedValueOnce({ content: [] });
     await component.handleAnalyzingDocument();
-    expect(actionsServiceMock.showToast).toHaveBeenCalledWith({ severity: 'error', summary: 'Error', detail: 'Something went wrong. Please try again.' });
+    expect(actionsServiceMock.showToast).toHaveBeenCalledWith({
+      severity: 'error',
+      summary: 'Error',
+      detail: 'Something went wrong. Please try again.'
+    });
     expect(component.documentAnalyzed()).toBe(false);
   });
 
@@ -485,14 +492,39 @@ describe('ResultAiAssistantComponent', () => {
 
   it('mapResultRawAiToAIAssistantResult should coalesce optional fields and contract_code', () => {
     component.body.update(b => ({ ...b, contract_id: '123' }));
-    const input = [{
-      indicator: 'i', title: 't', description: 'd', keywords: [], geoscope_level: 'global', regions: [], countries: [],
-      training_type: 'tt', length_of_training: 1, start_date: 's', end_date: 'e', degree: 'deg', delivery_modality: 'dm',
-      total_participants: 10, evidence_for_stage: 'ev', policy_type: 'pol',
-      main_contact_person: { name: 'n l', code: 'c', similarity_score: 0.8 }, stage_in_policy_process: 'st',
-      male_participants: undefined, female_participants: undefined, non_binary_participants: undefined,
-      innovation_nature: 'in', innovation_type: 'it', assess_readiness: 'ar', anticipated_users: 'au', organization_type: 'ot', organization_sub_type: 'ost', organizations: [], innovation_actors_detailed: []
-    }];
+    const input = [
+      {
+        indicator: 'i',
+        title: 't',
+        description: 'd',
+        keywords: [],
+        geoscope_level: 'global',
+        regions: [],
+        countries: [],
+        training_type: 'tt',
+        length_of_training: 1,
+        start_date: 's',
+        end_date: 'e',
+        degree: 'deg',
+        delivery_modality: 'dm',
+        total_participants: 10,
+        evidence_for_stage: 'ev',
+        policy_type: 'pol',
+        main_contact_person: { name: 'n l', code: 'c', similarity_score: 0.8 },
+        stage_in_policy_process: 'st',
+        male_participants: undefined,
+        female_participants: undefined,
+        non_binary_participants: undefined,
+        innovation_nature: 'in',
+        innovation_type: 'it',
+        assess_readiness: 'ar',
+        anticipated_users: 'au',
+        organization_type: 'ot',
+        organization_sub_type: 'ost',
+        organizations: [],
+        innovation_actors_detailed: []
+      }
+    ];
     const out = (component as any).mapResultRawAiToAIAssistantResult(input);
     expect(out[0].geoscope_level).toBe('global');
     expect(out[0].regions).toEqual([]);
@@ -533,13 +565,10 @@ describe('ResultAiAssistantComponent', () => {
     it('extractOrganizationNames should return [] when missing or empty and filter empty names', () => {
       expect((component as any).extractOrganizationNames(undefined)).toEqual([]);
       expect((component as any).extractOrganizationNames([])).toEqual([]);
-      expect(
-        (component as any).extractOrganizationNames([
-          { institution_name: 'A' },
-          { institution_name: '' },
-          { institution_name: 'B' }
-        ])
-      ).toEqual(['A', 'B']);
+      expect((component as any).extractOrganizationNames([{ institution_name: 'A' }, { institution_name: '' }, { institution_name: 'B' }])).toEqual([
+        'A',
+        'B'
+      ]);
     });
 
     it('mapResultRawAiToAIAssistantResult should derive org fields from organizations_detailed when omitted', () => {
@@ -590,7 +619,11 @@ describe('ResultAiAssistantComponent', () => {
     component.selectedFile = file;
     fileManagerServiceMock.uploadFile.mockResolvedValueOnce({ data: { filename: '' } });
     await expect(component.handleAnalyzingDocument()).rejects.toBeInstanceOf(Error);
-    expect(actionsServiceMock.showToast).toHaveBeenCalledWith({ severity: 'error', summary: 'Error', detail: 'Something went wrong. Please try again.' });
+    expect(actionsServiceMock.showToast).toHaveBeenCalledWith({
+      severity: 'error',
+      summary: 'Error',
+      detail: 'Something went wrong. Please try again.'
+    });
   });
 
   it('handleAnalyzingDocument should ignore parse errors and continue', async () => {
@@ -604,14 +637,14 @@ describe('ResultAiAssistantComponent', () => {
   it('onContractIdChange should update contractId and body', () => {
     const newContractId = 'contract-123';
     component.onContractIdChange(newContractId);
-    
+
     expect(component.contractId).toBe(newContractId);
     expect(component.body().contract_id).toBe(newContractId);
   });
 
   it('onContractIdChange should handle null contractId', () => {
     component.onContractIdChange(null);
-    
+
     expect(component.contractId).toBe(null);
     expect(component.body().contract_id).toBe(null);
   });
@@ -725,10 +758,7 @@ describe('ResultAiAssistantComponent', () => {
     const file = createFile('a.pdf');
     component.selectedFile = file;
     textMiningServiceMock.executeTextMining.mockResolvedValueOnce({
-      content: [
-        { text: JSON.stringify({ json_content: { results: [{ title: 'valid' }] } }) },
-        { notext: 'should be skipped' }
-      ]
+      content: [{ text: JSON.stringify({ json_content: { results: [{ title: 'valid' }] } }) }, { notext: 'should be skipped' }]
     });
     await component.handleAnalyzingDocument();
     expect(component.documentAnalyzed()).toBe(true);
@@ -830,7 +860,10 @@ describe('ResultAiAssistantComponent', () => {
   });
 
   it('submitFeedback should include selected issue category names in comment when negative', async () => {
-    component.badTypes = [{ id: 1, name: 'Wrong format' }, { id: 2, name: 'Incomplete data' }];
+    component.badTypes = [
+      { id: 1, name: 'Wrong format' },
+      { id: 2, name: 'Incomplete data' }
+    ];
     component.feedbackType.set('negative');
     component.selectedType = ['1', '2'];
     component.body.update(b => ({ ...b, feedbackText: 'Extra notes' }));
@@ -917,5 +950,3 @@ describe('ResultAiAssistantComponent', () => {
     expect(result.results).toEqual([{ title: 'existing' }]);
   });
 });
-
-

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/result-ai-assistant/result-ai-assistant.component.spec.ts
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/result-ai-assistant/result-ai-assistant.component.spec.ts
@@ -10,6 +10,7 @@ import { GetContractsService } from '@shared/services/control-list/get-contracts
 import { CreateResultManagementService } from '../../services/create-result-management.service';
 import { CacheService } from '@shared/services/cache/cache.service';
 import { signal } from '@angular/core';
+import { OrganizationDetailed } from '../../models/AIAssistantResult';
 
 jest.mock('pdfjs-dist', () => {
   return {
@@ -500,6 +501,88 @@ describe('ResultAiAssistantComponent', () => {
     expect(out[0].female_participants).toBe(0);
     expect(out[0].non_binary_participants).toBe('0');
     expect(out[0].contract_code).toBe('123');
+  });
+
+  describe('organization extraction helpers', () => {
+    it('extractOrganizationTypes should return [] when missing or empty and unique types when present', () => {
+      expect((component as any).extractOrganizationTypes(undefined)).toEqual([]);
+      expect((component as any).extractOrganizationTypes([])).toEqual([]);
+      const orgs: OrganizationDetailed[] = [
+        { type: 'Gov', institution_name: 'a' },
+        { type: 'Gov', institution_name: 'b' },
+        { type: undefined, institution_name: 'c' },
+        { type: 'NGO', institution_name: 'd' }
+      ];
+      expect((component as any).extractOrganizationTypes(orgs)).toEqual(['Gov', 'NGO']);
+    });
+
+    it('extractOrganizationSubTypes should return undefined when empty or no subtypes', () => {
+      expect((component as any).extractOrganizationSubTypes(undefined)).toBeUndefined();
+      expect((component as any).extractOrganizationSubTypes([])).toBeUndefined();
+      expect((component as any).extractOrganizationSubTypes([{ type: 't', institution_name: 'n' }])).toBeUndefined();
+    });
+
+    it('extractOrganizationSubTypes should join sub_type and other_type', () => {
+      const orgs: OrganizationDetailed[] = [
+        { sub_type: 's1', institution_name: 'a' },
+        { other_type: 'o2', institution_name: 'b' }
+      ];
+      expect((component as any).extractOrganizationSubTypes(orgs)).toBe('s1, o2');
+    });
+
+    it('extractOrganizationNames should return [] when missing or empty and filter empty names', () => {
+      expect((component as any).extractOrganizationNames(undefined)).toEqual([]);
+      expect((component as any).extractOrganizationNames([])).toEqual([]);
+      expect(
+        (component as any).extractOrganizationNames([
+          { institution_name: 'A' },
+          { institution_name: '' },
+          { institution_name: 'B' }
+        ])
+      ).toEqual(['A', 'B']);
+    });
+
+    it('mapResultRawAiToAIAssistantResult should derive org fields from organizations_detailed when omitted', () => {
+      component.body.update(b => ({ ...b, contract_id: 'CID' }));
+      const base = {
+        indicator: 'Innovation Development',
+        title: 't',
+        description: 'd',
+        keywords: [] as string[],
+        geoscope_level: 'g',
+        regions: [] as string[],
+        countries: [],
+        training_type: '',
+        length_of_training: '',
+        start_date: '',
+        end_date: '',
+        degree: '',
+        delivery_modality: '',
+        total_participants: 0,
+        evidence_for_stage: '',
+        policy_type: '',
+        main_contact_person: { name: 'n', code: '', similarity_score: 0 },
+        stage_in_policy_process: '',
+        innovation_nature: 'in',
+        innovation_type: 'it',
+        assess_readiness: 1,
+        anticipated_users: 'au',
+        innovation_actors_detailed: [] as []
+      };
+      const input = [
+        {
+          ...base,
+          organizations_detailed: [
+            { type: 'Univ', sub_type: 'Dept', institution_name: 'U1' },
+            { type: 'Univ', other_type: 'Lab', institution_name: 'U2' }
+          ]
+        }
+      ];
+      const out = (component as any).mapResultRawAiToAIAssistantResult(input);
+      expect(out[0].organization_type).toEqual(['Univ']);
+      expect(out[0].organization_sub_type).toBe('Dept, Lab');
+      expect(out[0].organizations).toEqual(['U1', 'U2']);
+    });
   });
 
   it('handleAnalyzingDocument should throw and toast on upload missing filename', async () => {

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/result-information-modal/result-information-modal.component.html
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/result-information-modal/result-information-modal.component.html
@@ -130,7 +130,7 @@
 
     <div class="mt-8 flex flex-wrap gap-3">
       @if (result()?.public_link) {
-      <button type="button" (click)="openDocumentLink()" [pTooltip]="externalSystemRedirectTooltip"
+      <button type="button" (click)="openDocumentLink()" [pTooltip]="publicLinkTooltip"
         tooltipPosition="top"
         class="flex cursor-pointer items-center gap-2 border-1 border-[#035BA9] text-[#035BA9] px-6 py-2 rounded-[13px] text-[15px] disabled:cursor-default disabled:bg-[#E8EBED] disabled:border-[#E8EBED] disabled:text-[#A2A9AF]">
         Open public link

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/result-information-modal/result-information-modal.component.html
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/result-information-modal/result-information-modal.component.html
@@ -130,15 +130,16 @@
 
     <div class="mt-8 flex flex-wrap gap-3">
       @if (result()?.public_link) {
-      <button type="button" (click)="openDocumentLink()"
-        [pTooltip]="externalSystemRedirectTooltip" tooltipPosition="top"
+      <button type="button" (click)="openDocumentLink()" [pTooltip]="externalSystemRedirectTooltip"
+        tooltipPosition="top"
         class="flex cursor-pointer items-center gap-2 border-1 border-[#035BA9] text-[#035BA9] px-6 py-2 rounded-[13px] text-[15px] disabled:cursor-default disabled:bg-[#E8EBED] disabled:border-[#E8EBED] disabled:text-[#A2A9AF]">
         Open public link
         <i class="pi pi-file-pdf !text-[14px]"></i>
       </button>
       }
-      <button type="button" (click)="openExternalLink()"
-        [pTooltip]="externalSystemRedirectTooltip" tooltipPosition="top"
+      @if (result()?.external_link) {
+      <button type="button" (click)="openExternalLink()" [pTooltip]="externalSystemRedirectTooltip"
+        tooltipPosition="top"
         class="flex cursor-pointer items-center gap-2  bg-[#035BA9] text-white px-6 py-2 rounded-[13px] text-[15px] disabled:cursor-default disabled:bg-[#E8EBED] disabled:border-[#E8EBED] disabled:text-[#A2A9AF]">
         @if (result()?.platform_code === 'TIP') {
         Open link to result
@@ -151,6 +152,7 @@
         }
         <i class="pi pi-external-link !text-[12px]"></i>
       </button>
+      }
     </div>
   </div>
   }

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/result-information-modal/result-information-modal.component.html
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/result-information-modal/result-information-modal.component.html
@@ -129,14 +129,16 @@
     </div>
 
     <div class="mt-8 flex flex-wrap gap-3">
-      @if (result()?.platform_code === 'AICCRA' && result()?.public_link) {
+      @if (result()?.public_link) {
       <button type="button" (click)="openDocumentLink()"
+        [pTooltip]="externalSystemRedirectTooltip" tooltipPosition="top"
         class="flex cursor-pointer items-center gap-2 border-1 border-[#035BA9] text-[#035BA9] px-6 py-2 rounded-[13px] text-[15px] disabled:cursor-default disabled:bg-[#E8EBED] disabled:border-[#E8EBED] disabled:text-[#A2A9AF]">
         Open public link
         <i class="pi pi-file-pdf !text-[14px]"></i>
       </button>
       }
       <button type="button" (click)="openExternalLink()"
+        [pTooltip]="externalSystemRedirectTooltip" tooltipPosition="top"
         class="flex cursor-pointer items-center gap-2  bg-[#035BA9] text-white px-6 py-2 rounded-[13px] text-[15px] disabled:cursor-default disabled:bg-[#E8EBED] disabled:border-[#E8EBED] disabled:text-[#A2A9AF]">
         @if (result()?.platform_code === 'TIP') {
         Open link to result

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/result-information-modal/result-information-modal.component.spec.ts
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/result-information-modal/result-information-modal.component.spec.ts
@@ -422,7 +422,7 @@ describe('ResultInformationModalComponent', () => {
       openSpy.mockRestore();
     });
 
-    it('should not open when platform is not AICCRA', () => {
+    it('should open public_link for PRMS platform', () => {
       selectedResultSignal.set({
         platform_code: 'PRMS',
         public_link: 'https://doc.example.com'
@@ -430,7 +430,7 @@ describe('ResultInformationModalComponent', () => {
       fixture.detectChanges();
       const openSpy = jest.spyOn(globalThis, 'open').mockImplementation(() => null);
       component.openDocumentLink();
-      expect(openSpy).not.toHaveBeenCalled();
+      expect(openSpy).toHaveBeenCalledWith('https://doc.example.com', '_blank', 'noopener');
       openSpy.mockRestore();
     });
   });

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/result-information-modal/result-information-modal.component.ts
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/result-information-modal/result-information-modal.component.ts
@@ -87,9 +87,6 @@ export class ResultInformationModalComponent {
     const currentResult = this.result();
     const link = currentResult?.public_link;
     if (!currentResult || !link) return;
-
-    if (currentResult.platform_code === PLATFORM_CODES.AICCRA) {
-      globalThis.open(link, '_blank', 'noopener');
-    }
+    globalThis.open(link, '_blank', 'noopener');
   }
 }

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/result-information-modal/result-information-modal.component.ts
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/result-information-modal/result-information-modal.component.ts
@@ -16,6 +16,8 @@ import { PLATFORM_CODES } from '@shared/constants/platform-codes';
 })
 export class ResultInformationModalComponent {
   readonly externalSystemRedirectTooltip = 'You will be redirected to the Information System where this information was captured.';
+  readonly publicLinkTooltip =
+    'You will be redirected to the public source where the full result metadata is available.';
   allModals = inject(AllModalsService);
 
   result = computed(() => this.allModals.selectedResultForInfo());

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/result-information-modal/result-information-modal.component.ts
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/result-information-modal/result-information-modal.component.ts
@@ -2,6 +2,7 @@ import { Component, inject, computed } from '@angular/core';
 import { CommonModule, DatePipe } from '@angular/common';
 import { AllModalsService } from '@shared/services/cache/all-modals.service';
 import { ButtonModule } from 'primeng/button';
+import { TooltipModule } from 'primeng/tooltip';
 import { S3ImageUrlPipe } from '@shared/pipes/s3-image-url.pipe';
 import { Result } from '@shared/interfaces/result/result.interface';
 import { CustomTagComponent } from '@shared/components/custom-tag/custom-tag.component';
@@ -10,10 +11,11 @@ import { PLATFORM_CODES } from '@shared/constants/platform-codes';
 
 @Component({
   selector: 'app-result-information-modal',
-  imports: [CommonModule, ButtonModule, DatePipe, S3ImageUrlPipe, CustomTagComponent],
+  imports: [CommonModule, ButtonModule, TooltipModule, DatePipe, S3ImageUrlPipe, CustomTagComponent],
   templateUrl: './result-information-modal.component.html'
 })
 export class ResultInformationModalComponent {
+  readonly externalSystemRedirectTooltip = 'You will be redirected to the Information System where this information was captured.';
   allModals = inject(AllModalsService);
 
   result = computed(() => this.allModals.selectedResultForInfo());
@@ -42,26 +44,22 @@ export class ResultInformationModalComponent {
   getPrimaryContract(): string | null {
     const r = this.result();
     if (!r?.result_contracts) return null;
-    
+
     const contracts = Array.isArray(r.result_contracts) ? r.result_contracts : [r.result_contracts];
-    const primaryContract = contracts.find((contract: { is_primary?: number | string; contract_id?: string }) => 
-      Number(contract.is_primary) === 1
-    );
-    
+    const primaryContract = contracts.find((contract: { is_primary?: number | string; contract_id?: string }) => Number(contract.is_primary) === 1);
+
     return primaryContract?.contract_id ?? null;
   }
 
   getContributingContracts(): string[] {
     const r = this.result();
     if (!r?.result_contracts) return [];
-    
+
     const contracts = Array.isArray(r.result_contracts) ? r.result_contracts : [r.result_contracts];
     const contributing = contracts
-      .filter((contract: { is_primary?: number | string; contract_id?: string }) => 
-        Number(contract.is_primary) !== 1 && contract.contract_id
-      )
+      .filter((contract: { is_primary?: number | string; contract_id?: string }) => Number(contract.is_primary) !== 1 && contract.contract_id)
       .map((contract: { contract_id: string }) => contract.contract_id);
-    
+
     return contributing;
   }
 
@@ -76,7 +74,10 @@ export class ResultInformationModalComponent {
     const link = currentResult?.external_link;
     if (!currentResult || !link) return;
 
-    const isSupportedPlatform = currentResult.platform_code === PLATFORM_CODES.TIP || currentResult.platform_code === PLATFORM_CODES.AICCRA || currentResult.platform_code === PLATFORM_CODES.PRMS;
+    const isSupportedPlatform =
+      currentResult.platform_code === PLATFORM_CODES.TIP ||
+      currentResult.platform_code === PLATFORM_CODES.AICCRA ||
+      currentResult.platform_code === PLATFORM_CODES.PRMS;
     if (isSupportedPlatform) {
       globalThis.open(link, '_blank', 'noopener');
     }
@@ -92,5 +93,3 @@ export class ResultInformationModalComponent {
     }
   }
 }
-
-

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/select-linked-results-modal/select-linked-results-modal.component.html
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/select-linked-results-modal/select-linked-results-modal.component.html
@@ -9,7 +9,7 @@
     <app-search-export-controls [applyLabel]="'Apply Filters'"
       [badge]="resultsCenterService.countTableFiltersSelected()"
       [showOverlayDot]="!!resultsCenterService.countTableFiltersSelected()" [showClear]="true"
-      [searchValue]="searchInput()" [searchPlaceholder]="'Find a result by code, title or creator'"
+      [searchValue]="resultsCenterService.searchInput()" [searchPlaceholder]="'Find a result by code, title or creator'"
       (searchChange)="setSearchInputFilter($event)" (apply)="showFiltersSidebar()" (clear)="clearFilters()">
     </app-search-export-controls>
 
@@ -21,14 +21,18 @@
     <app-custom-progress-bar></app-custom-progress-bar>
   }
 
-  <p-table #dt2 [value]="resultsCenterService.list()" [paginator]="true"
-    [first]="linkedTablePaginatorFirst()" [rows]="linkedTablePaginatorRows()" (onPage)="onLinkedResultsTablePage($event)"
-    class="border border-[#E4EAEE] rounded-[18px] border-t-0"
+  <div class="w-full border border-[#E4EAEE] rounded-[18px] border-t-0 overflow-visible">
+  <p-table #dt2 [value]="resultsCenterService.list()" [paginator]="true" [lazy]="true"
+    [first]="resultsCenterService.resultsTablePaginatorFirst()" [rows]="resultsCenterService.resultsTablePaginatorRows()"
+    [totalRecords]="resultsCenterService.resultsTableTotalRecords()"
+    (onLazyLoad)="handleLinkedTableLazyLoad($event)"
+    [paginatorDropdownAppendTo]="'body'"
+    class="border-0 rounded-[18px]"
     [scrollHeight]="getScrollHeight()" [showCurrentPageReport]="true" [scrollable]="true"
     [tableStyle]="{ 'min-width': '100%' }" [rowsPerPageOptions]="[5, 10, 25, 50]"
-    currentPageReportTemplate="Showing {first} to {last} of {totalRecords} results" [sortField]="'result_official_code'"
-    [sortOrder]="-1"
-    [globalFilterFields]="resultsCenterService.getAllPathsAsArray()"
+    currentPageReportTemplate="Showing {first} to {last} of {totalRecords} results"
+    [sortField]="resultsCenterService.resultsTableSortField()" [sortOrder]="resultsCenterService.resultsTableSortOrder()"
+    [customSort]="true"
     styleClass="p-datatable-gridlines table-custom-styles p-datatable-hoverable-rows">
     <ng-template pTemplate="header">
       <tr>
@@ -40,7 +44,7 @@
         @for (column of resultsCenterService.tableColumns(); track column.field) {
         @if (column.field !== 'versions' && (!column.hideIf || !column.hideIf())) {
         <th class="{{ column.minWidth }} {{ column.maxWidth }} !text-[#173F6F]"
-          [pSortableColumn]="column.path" scope="col">
+          [pSortableColumn]="column?.hideFilterIf?.() ? '' : column.path" scope="col">
           <div class="flex items-center font-[500] leading-4.5 gap-2 text-[14px] ">
             {{
             column.field === 'project'
@@ -51,7 +55,9 @@
             ? 'Year'
             : column.header
             }}
+            @if (!column?.hideFilterIf?.()) {
             <p-sortIcon field="{{ column.path }}"></p-sortIcon>
+            }
           </div>
         </th>
         }
@@ -177,6 +183,7 @@
       }
     </ng-template>
   </p-table>
+  </div>
 </div>
 
 

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/select-linked-results-modal/select-linked-results-modal.component.html
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/select-linked-results-modal/select-linked-results-modal.component.html
@@ -21,7 +21,8 @@
     <app-custom-progress-bar></app-custom-progress-bar>
   }
 
-  <p-table #dt2 [value]="resultsCenterService.list()" [paginator]="true" [rows]="10"
+  <p-table #dt2 [value]="resultsCenterService.list()" [paginator]="true"
+    [first]="linkedTablePaginatorFirst()" [rows]="linkedTablePaginatorRows()" (onPage)="onLinkedResultsTablePage($event)"
     class="border border-[#E4EAEE] rounded-[18px] border-t-0"
     [scrollHeight]="getScrollHeight()" [showCurrentPageReport]="true" [scrollable]="true"
     [tableStyle]="{ 'min-width': '100%' }" [rowsPerPageOptions]="[5, 10, 25, 50]"

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/select-linked-results-modal/select-linked-results-modal.component.spec.ts
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/select-linked-results-modal/select-linked-results-modal.component.spec.ts
@@ -81,6 +81,13 @@ describe('SelectLinkedResultsModalComponent', () => {
       getAllPathsAsArray: jest.fn().mockReturnValue([]),
       tableColumns: jest.fn().mockReturnValue([]),
       searchInput: Object.assign(jest.fn().mockReturnValue('') as any, { set: jest.fn() }),
+      resultsTablePaginatorFirst: Object.assign(jest.fn().mockReturnValue(0) as any, { set: jest.fn() }),
+      resultsTablePaginatorRows: Object.assign(jest.fn().mockReturnValue(10) as any, { set: jest.fn() }),
+      resultsTableTotalRecords: Object.assign(jest.fn().mockReturnValue(0) as any, { set: jest.fn() }),
+      resultsTableSortField: Object.assign(jest.fn().mockReturnValue('result_official_code') as any, { set: jest.fn() }),
+      resultsTableSortOrder: Object.assign(jest.fn().mockReturnValue(-1) as any, { set: jest.fn() }),
+      handleResultsTableLazyLoad: jest.fn(),
+      invalidateResultsListFetchCache: jest.fn(),
       myResultsFilterItem: Object.assign(jest.fn().mockReturnValue({ id: 'all', label: 'All Results' }) as any, { set: jest.fn() }),
       myResultsFilterItems: [{ id: 'all', label: 'All Results' }, { id: 'my', label: 'My Results' }],
       // @ts-expect-error partial mock
@@ -160,9 +167,11 @@ describe('SelectLinkedResultsModalComponent', () => {
   });
 
   describe('basic behaviors', () => {
-    it('should set searchInput from query string', () => {
+    it('should set service search, reset page and call main', () => {
       component.setSearchInputFilter('search text');
-      expect(component.searchInput()).toBe('search text');
+      expect(resultsCenterService.searchInput.set).toHaveBeenCalledWith('search text');
+      expect(resultsCenterService.resultsTablePaginatorFirst.set).toHaveBeenCalledWith(0);
+      expect(resultsCenterService.main).toHaveBeenCalled();
     });
 
     it('should compute selectedCount based on selectedResults', () => {
@@ -595,31 +604,11 @@ describe('SelectLinkedResultsModalComponent', () => {
     });
   });
 
-  describe('onSearchInputChange effect', () => {
-    it('should call filterGlobal when dt2 is available', () => {
-      const mockTable = {
-        filterGlobal: jest.fn(),
-        first: 0
-      };
-      (component as any).dt2 = mockTable;
-      component.linkedTablePaginatorFirst.set(40);
-
-      component.searchInput.set('test search');
-      fixture.detectChanges();
-
-      expect(component.linkedTablePaginatorFirst()).toBe(0);
-      expect(mockTable.filterGlobal).toHaveBeenCalledWith('test search', 'contains');
-    });
-
-    it('should not call filterGlobal when dt2 is not available', () => {
-      (component as any).dt2 = undefined;
-      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-      
-      component.searchInput.set('test search');
-      fixture.detectChanges();
-      
-      expect(consoleErrorSpy).not.toHaveBeenCalled();
-      consoleErrorSpy.mockRestore();
+  describe('handleLinkedTableLazyLoad', () => {
+    it('should delegate to resultsCenterService.handleResultsTableLazyLoad', () => {
+      const ev = { first: 25, rows: 25 } as any;
+      component.handleLinkedTableLazyLoad(ev);
+      expect(resultsCenterService.handleResultsTableLazyLoad).toHaveBeenCalledWith(ev);
     });
   });
 
@@ -631,6 +620,9 @@ describe('SelectLinkedResultsModalComponent', () => {
       
       await (component as any).onModalOpened();
       
+      expect(resultsCenterService.invalidateResultsListFetchCache).toHaveBeenCalled();
+      expect(resultsCenterService.resultsTablePaginatorFirst.set).toHaveBeenCalledWith(0);
+      expect(resultsCenterService.resultsTablePaginatorRows.set).toHaveBeenCalledWith(10);
       expect(resultsCenterService.myResultsFilterItem.set).toHaveBeenCalledWith({ id: 'all', label: 'All Results' });
       expect(applySpy).toHaveBeenCalledWith({ resetIndicatorFilters: true });
       expect(loadResultsSpy).toHaveBeenCalled();
@@ -706,6 +698,7 @@ describe('SelectLinkedResultsModalComponent', () => {
       
       await (component as any).loadResultsForModal();
       
+      expect(resultsCenterService.invalidateResultsListFetchCache).toHaveBeenCalled();
       expect(resultsCenterService.list.set).toHaveBeenCalledWith([]);
       expect(resultsCenterService.loading.set).toHaveBeenCalledWith(true);
       expect(resultsCenterService.resultsFilter.update).toHaveBeenCalled();
@@ -904,50 +897,20 @@ describe('SelectLinkedResultsModalComponent', () => {
   });
 
   describe('resetTableToFirstPage', () => {
-    it('should reset dt2.first and linkedTablePaginatorFirst when dt2 exists', () => {
-      const mockTable = { first: 5, filterGlobal: jest.fn() };
+    it('should reset dt2.first and service paginator when dt2 exists', () => {
+      const mockTable = { first: 5 };
       (component as any).dt2 = mockTable;
-      component.linkedTablePaginatorFirst.set(30);
 
       (component as any).resetTableToFirstPage();
 
-      expect(component.linkedTablePaginatorFirst()).toBe(0);
+      expect(resultsCenterService.resultsTablePaginatorFirst.set).toHaveBeenCalledWith(0);
       expect(mockTable.first).toBe(0);
     });
 
     it('should not throw when dt2 is undefined', () => {
       (component as any).dt2 = undefined;
-      component.linkedTablePaginatorFirst.set(10);
       expect(() => (component as any).resetTableToFirstPage()).not.toThrow();
-      expect(component.linkedTablePaginatorFirst()).toBe(0);
-    });
-  });
-
-  describe('onLinkedResultsTablePage', () => {
-    it('should use event.first when rows unchanged', () => {
-      const mockTable = { first: 0, rows: 10, totalRecords: 100 } as any;
-      (component as any).dt2 = mockTable;
-      component.linkedTablePaginatorFirst.set(10);
-      component.linkedTablePaginatorRows.set(10);
-
-      component.onLinkedResultsTablePage({ first: 20, rows: 10 });
-
-      expect(component.linkedTablePaginatorFirst()).toBe(20);
-      expect(mockTable.first).toBe(20);
-    });
-
-    it('should align first when rows per page changes even if event.first is 0', () => {
-      const mockTable = { first: 0, rows: 10, totalRecords: 100 } as any;
-      (component as any).dt2 = mockTable;
-      component.linkedTablePaginatorFirst.set(40);
-      component.linkedTablePaginatorRows.set(10);
-
-      component.onLinkedResultsTablePage({ first: 0, rows: 25 });
-
-      expect(component.linkedTablePaginatorFirst()).toBe(25);
-      expect(component.linkedTablePaginatorRows()).toBe(25);
-      expect(mockTable.first).toBe(25);
-      expect(mockTable.rows).toBe(25);
+      expect(resultsCenterService.resultsTablePaginatorFirst.set).toHaveBeenCalledWith(0);
     });
   });
 
@@ -976,14 +939,13 @@ describe('SelectLinkedResultsModalComponent', () => {
   describe('resetModalFilters', () => {
     it('should reset all modal filters and state', async () => {
       component.selectedResults.set([createResult()]);
-      component.searchInput.set('test');
       const clearSpy = jest.spyOn(component, 'clearFilters').mockResolvedValue(undefined);
       
       (component as any).resetModalFilters();
       
       expect(resultsCenterService.showFiltersSidebar.set).toHaveBeenCalledWith(false);
       expect(component.selectedResults()).toEqual([]);
-      expect(component.searchInput()).toBe('');
+      expect(resultsCenterService.searchInput.set).toHaveBeenCalledWith('');
       expect(clearSpy).toHaveBeenCalled();
     });
   });

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/select-linked-results-modal/select-linked-results-modal.component.spec.ts
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/select-linked-results-modal/select-linked-results-modal.component.spec.ts
@@ -602,10 +602,12 @@ describe('SelectLinkedResultsModalComponent', () => {
         first: 0
       };
       (component as any).dt2 = mockTable;
-      
+      component.linkedTablePaginatorFirst.set(40);
+
       component.searchInput.set('test search');
       fixture.detectChanges();
-      
+
+      expect(component.linkedTablePaginatorFirst()).toBe(0);
       expect(mockTable.filterGlobal).toHaveBeenCalledWith('test search', 'contains');
     });
 
@@ -902,18 +904,50 @@ describe('SelectLinkedResultsModalComponent', () => {
   });
 
   describe('resetTableToFirstPage', () => {
-    it('should reset dt2.first to 0 when dt2 exists', () => {
+    it('should reset dt2.first and linkedTablePaginatorFirst when dt2 exists', () => {
       const mockTable = { first: 5, filterGlobal: jest.fn() };
       (component as any).dt2 = mockTable;
+      component.linkedTablePaginatorFirst.set(30);
 
       (component as any).resetTableToFirstPage();
 
+      expect(component.linkedTablePaginatorFirst()).toBe(0);
       expect(mockTable.first).toBe(0);
     });
 
     it('should not throw when dt2 is undefined', () => {
       (component as any).dt2 = undefined;
+      component.linkedTablePaginatorFirst.set(10);
       expect(() => (component as any).resetTableToFirstPage()).not.toThrow();
+      expect(component.linkedTablePaginatorFirst()).toBe(0);
+    });
+  });
+
+  describe('onLinkedResultsTablePage', () => {
+    it('should use event.first when rows unchanged', () => {
+      const mockTable = { first: 0, rows: 10, totalRecords: 100 } as any;
+      (component as any).dt2 = mockTable;
+      component.linkedTablePaginatorFirst.set(10);
+      component.linkedTablePaginatorRows.set(10);
+
+      component.onLinkedResultsTablePage({ first: 20, rows: 10 });
+
+      expect(component.linkedTablePaginatorFirst()).toBe(20);
+      expect(mockTable.first).toBe(20);
+    });
+
+    it('should align first when rows per page changes even if event.first is 0', () => {
+      const mockTable = { first: 0, rows: 10, totalRecords: 100 } as any;
+      (component as any).dt2 = mockTable;
+      component.linkedTablePaginatorFirst.set(40);
+      component.linkedTablePaginatorRows.set(10);
+
+      component.onLinkedResultsTablePage({ first: 0, rows: 25 });
+
+      expect(component.linkedTablePaginatorFirst()).toBe(25);
+      expect(component.linkedTablePaginatorRows()).toBe(25);
+      expect(mockTable.first).toBe(25);
+      expect(mockTable.rows).toBe(25);
     });
   });
 

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/select-linked-results-modal/select-linked-results-modal.component.spec.ts
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/select-linked-results-modal/select-linked-results-modal.component.spec.ts
@@ -174,6 +174,13 @@ describe('SelectLinkedResultsModalComponent', () => {
       expect(resultsCenterService.main).toHaveBeenCalled();
     });
 
+    it('should reset PrimeNG table first when dt2 is available', () => {
+      const dt = { first: 40 };
+      (component as any).dt2 = dt;
+      component.setSearchInputFilter('x');
+      expect(dt.first).toBe(0);
+    });
+
     it('should compute selectedCount based on selectedResults', () => {
       expect(component.selectedCount()).toBe(0);
       component.selectedResults.set([createResult({ result_id: 1 }), createResult({ result_id: 2 })]);

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/select-linked-results-modal/select-linked-results-modal.component.ts
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/select-linked-results-modal/select-linked-results-modal.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnDestroy, computed, effect, inject, signal, ViewChild } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { Table, TableModule } from 'primeng/table';
+import { Table, TableLazyLoadEvent, TableModule } from 'primeng/table';
 import { ButtonModule } from 'primeng/button';
 import { InputTextModule } from 'primeng/inputtext';
 import { CheckboxModule } from 'primeng/checkbox';
@@ -53,9 +53,6 @@ export class SelectLinkedResultsModalComponent implements OnDestroy {
   @ViewChild('dt2') dt2!: Table;
 
   selectedResults = signal<Result[]>([]);
-  searchInput = signal('');
-  linkedTablePaginatorFirst = signal(0);
-  linkedTablePaginatorRows = signal(10);
   saving = signal(false);
   private modalWasOpen = false;
   private savedMyResultsFilterItem: import('primeng/api').MenuItem | undefined;
@@ -90,24 +87,22 @@ export class SelectLinkedResultsModalComponent implements OnDestroy {
     { allowSignalWrites: true }
   );
 
-  onSearchInputChange = effect(() => {
-    const searchValue = this.searchInput();
-    this.resultsCenterService.list();
-    if (this.dt2) {
-      this.linkedTablePaginatorFirst.set(0);
-      this.dt2.first = 0;
-      this.dt2.filterGlobal(searchValue, 'contains');
-    }
-  });
-
   ngOnDestroy(): void {
     this.modalVisibilityWatcher.destroy();
-    this.onSearchInputChange.destroy();
     this.syncSelectedResultsWatcher.destroy();
   }
 
   setSearchInputFilter(query: string) {
-    this.searchInput.set(query);
+    this.resultsCenterService.resultsTablePaginatorFirst.set(0);
+    this.resultsCenterService.searchInput.set(query);
+    if (this.dt2) {
+      this.dt2.first = 0;
+    }
+    void this.resultsCenterService.main();
+  }
+
+  handleLinkedTableLazyLoad(event: TableLazyLoadEvent): void {
+    this.resultsCenterService.handleResultsTableLazyLoad(event);
   }
 
   getResultHref(result: Result, platformCode?: string): string {
@@ -262,50 +257,17 @@ export class SelectLinkedResultsModalComponent implements OnDestroy {
   clearFilters(): void {
     this.resultsCenterService.clearAllFiltersWithPreserve([...MODAL_INDICATOR_CODES]);
     this.applyModalIndicatorFilter({ resetIndicatorFilters: true });
-    this.searchInput.set('');
+    this.resultsCenterService.searchInput.set('');
     this.resetTableToFirstPage();
     void this.loadResultsForModal();
   }
 
   getScrollHeight = computed(() => `calc(100vh - ${this.cacheService.headerHeight() + this.cacheService.navbarHeight() + 400}px)`);
 
-  onLinkedResultsTablePage(event: { first: number; rows: number }): void {
-    const newRows = event.rows ?? 10;
-    const previousFirst = this.linkedTablePaginatorFirst();
-    const previousRows = this.linkedTablePaginatorRows();
-    const table = this.dt2;
-    const total = this.getLinkedTablePaginatorTotalRecords(table);
-    const nextFirst = previousRows === newRows ? (event.first ?? 0) : this.alignLinkedTableFirstAfterRowsChange(previousFirst, newRows, total);
-    this.linkedTablePaginatorFirst.set(nextFirst);
-    this.linkedTablePaginatorRows.set(newRows);
-    if (table) {
-      table.first = nextFirst;
-      table.rows = newRows;
-    }
-  }
-
-  private getLinkedTablePaginatorTotalRecords(table: Table | undefined): number {
-    if (table != null && typeof table.totalRecords === 'number') {
-      return table.totalRecords;
-    }
-    return this.resultsCenterService.list().length;
-  }
-
-  private alignLinkedTableFirstAfterRowsChange(anchorFirst: number, newRows: number, total: number): number {
-    const safeRows = newRows > 0 ? newRows : 10;
-    let newFirst = Math.floor(anchorFirst / safeRows) * safeRows;
-    if (total > 0) {
-      const maxFirst = Math.max(0, total - safeRows);
-      if (newFirst > maxFirst) {
-        newFirst = maxFirst;
-      }
-    }
-    return newFirst;
-  }
-
   private async onModalOpened(): Promise<void> {
-    this.linkedTablePaginatorFirst.set(0);
-    this.linkedTablePaginatorRows.set(10);
+    this.resultsCenterService.invalidateResultsListFetchCache();
+    this.resultsCenterService.resultsTablePaginatorFirst.set(0);
+    this.resultsCenterService.resultsTablePaginatorRows.set(10);
     this.savedMyResultsFilterItem = this.resultsCenterService.myResultsFilterItem();
     this.resultsCenterService.myResultsFilterItem.set(this.resultsCenterService.myResultsFilterItems[0]);
 
@@ -334,6 +296,7 @@ export class SelectLinkedResultsModalComponent implements OnDestroy {
 
   private async loadResultsForModal(): Promise<void> {
     try {
+      this.resultsCenterService.invalidateResultsListFetchCache();
       this.resultsCenterService.list.set([]);
       this.resultsCenterService.loading.set(true);
 
@@ -381,7 +344,7 @@ export class SelectLinkedResultsModalComponent implements OnDestroy {
   private resetModalFilters(): void {
     this.resultsCenterService.showFiltersSidebar.set(false);
     this.selectedResults.set([]);
-    this.searchInput.set('');
+    this.resultsCenterService.searchInput.set('');
 
     if (this.savedMyResultsFilterItem) {
       this.resultsCenterService.myResultsFilterItem.set(this.savedMyResultsFilterItem);
@@ -417,7 +380,7 @@ export class SelectLinkedResultsModalComponent implements OnDestroy {
   }
 
   private resetTableToFirstPage(): void {
-    this.linkedTablePaginatorFirst.set(0);
+    this.resultsCenterService.resultsTablePaginatorFirst.set(0);
     if (this.dt2) {
       this.dt2.first = 0;
     }

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/select-linked-results-modal/select-linked-results-modal.component.ts
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/select-linked-results-modal/select-linked-results-modal.component.ts
@@ -54,6 +54,8 @@ export class SelectLinkedResultsModalComponent implements OnDestroy {
 
   selectedResults = signal<Result[]>([]);
   searchInput = signal('');
+  linkedTablePaginatorFirst = signal(0);
+  linkedTablePaginatorRows = signal(10);
   saving = signal(false);
   private modalWasOpen = false;
   private savedMyResultsFilterItem: import('primeng/api').MenuItem | undefined;
@@ -80,7 +82,7 @@ export class SelectLinkedResultsModalComponent implements OnDestroy {
       const currentSelected = this.selectedResults();
       const syncedIds = syncedResults.map(r => r.result_id).sort((a, b) => a - b);
       const currentIds = currentSelected.map(r => r.result_id).sort((a, b) => a - b);
-      
+
       if (JSON.stringify(syncedIds) !== JSON.stringify(currentIds)) {
         this.selectedResults.set(syncedResults);
       }
@@ -92,6 +94,7 @@ export class SelectLinkedResultsModalComponent implements OnDestroy {
     const searchValue = this.searchInput();
     this.resultsCenterService.list();
     if (this.dt2) {
+      this.linkedTablePaginatorFirst.set(0);
       this.dt2.first = 0;
       this.dt2.filterGlobal(searchValue, 'contains');
     }
@@ -199,7 +202,7 @@ export class SelectLinkedResultsModalComponent implements OnDestroy {
   toggleSelection(result: Result) {
     const current = this.selectedResults();
     const index = current.findIndex(r => r.result_id === result.result_id);
-    
+
     if (index >= 0) {
       const updated = current.filter(r => r.result_id !== result.result_id);
       this.selectedResults.set(updated);
@@ -251,7 +254,6 @@ export class SelectLinkedResultsModalComponent implements OnDestroy {
       this.saving.set(false);
     }
   }
-  
 
   showFiltersSidebar() {
     this.resultsCenterService.showFiltersSidebar.set(true);
@@ -265,11 +267,45 @@ export class SelectLinkedResultsModalComponent implements OnDestroy {
     void this.loadResultsForModal();
   }
 
-  getScrollHeight = computed(
-    () => `calc(100vh - ${this.cacheService.headerHeight() + this.cacheService.navbarHeight() + 400}px)`
-  );
+  getScrollHeight = computed(() => `calc(100vh - ${this.cacheService.headerHeight() + this.cacheService.navbarHeight() + 400}px)`);
+
+  onLinkedResultsTablePage(event: { first: number; rows: number }): void {
+    const newRows = event.rows ?? 10;
+    const previousFirst = this.linkedTablePaginatorFirst();
+    const previousRows = this.linkedTablePaginatorRows();
+    const table = this.dt2;
+    const total = this.getLinkedTablePaginatorTotalRecords(table);
+    const nextFirst = previousRows === newRows ? (event.first ?? 0) : this.alignLinkedTableFirstAfterRowsChange(previousFirst, newRows, total);
+    this.linkedTablePaginatorFirst.set(nextFirst);
+    this.linkedTablePaginatorRows.set(newRows);
+    if (table) {
+      table.first = nextFirst;
+      table.rows = newRows;
+    }
+  }
+
+  private getLinkedTablePaginatorTotalRecords(table: Table | undefined): number {
+    if (table != null && typeof table.totalRecords === 'number') {
+      return table.totalRecords;
+    }
+    return this.resultsCenterService.list().length;
+  }
+
+  private alignLinkedTableFirstAfterRowsChange(anchorFirst: number, newRows: number, total: number): number {
+    const safeRows = newRows > 0 ? newRows : 10;
+    let newFirst = Math.floor(anchorFirst / safeRows) * safeRows;
+    if (total > 0) {
+      const maxFirst = Math.max(0, total - safeRows);
+      if (newFirst > maxFirst) {
+        newFirst = maxFirst;
+      }
+    }
+    return newFirst;
+  }
 
   private async onModalOpened(): Promise<void> {
+    this.linkedTablePaginatorFirst.set(0);
+    this.linkedTablePaginatorRows.set(10);
     this.savedMyResultsFilterItem = this.resultsCenterService.myResultsFilterItem();
     this.resultsCenterService.myResultsFilterItem.set(this.resultsCenterService.myResultsFilterItems[0]);
 
@@ -325,7 +361,6 @@ export class SelectLinkedResultsModalComponent implements OnDestroy {
   }
 
   private applyModalIndicatorFilter(options: { resetIndicatorFilters?: boolean; tabsOverride?: readonly number[] } = {}): void {
-
     const { resetIndicatorFilters = false } = options;
     const hasActiveIndicatorFilter =
       (this.resultsCenterService.tableFilters().indicators?.length ?? 0) > 0 ||
@@ -336,7 +371,7 @@ export class SelectLinkedResultsModalComponent implements OnDestroy {
     const setIndicators = (prev: ResultFilter) => ({
       ...prev,
       'indicator-codes-tabs': tabs,
-      'indicator-codes-filter': resetIndicatorFilters ? [] : prev['indicator-codes-filter'] ?? []
+      'indicator-codes-filter': resetIndicatorFilters ? [] : (prev['indicator-codes-filter'] ?? [])
     });
 
     this.resultsCenterService.resultsFilter.update(prev => setIndicators(prev));
@@ -382,9 +417,9 @@ export class SelectLinkedResultsModalComponent implements OnDestroy {
   }
 
   private resetTableToFirstPage(): void {
+    this.linkedTablePaginatorFirst.set(0);
     if (this.dt2) {
       this.dt2.first = 0;
     }
   }
 }
-

--- a/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.html
+++ b/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.html
@@ -22,8 +22,9 @@
       [filterBy]="this.filterBy || this.optionLabel" [optionLabel]="this.optionLabel" [showToggleAll]="false"
       [optionValue]="this.optionValue" [(ngModel)]="this.body().value" (ngModelChange)="this.setValue($event)"
       [disabled]="disabled" [virtualScroll]="enableVirtualScroll" [placeholder]="placeholder"
-      [virtualScrollItemSize]="this.itemHeight" [scrollHeight]="this.scrollHeight"
-      [panelStyle]="{ width: '100%', minWidth: '100%' }" [appendTo]="appendTo">
+      [virtualScrollItemSize]="virtualScrollEstimateSize()" [scrollHeight]="this.scrollHeight"
+      [panelStyle]="multiselectPanelStyle" [appendTo]="appendTo" (onPanelShow)="onMultiselectPanelShow()"
+      (onPanelHide)="onMultiselectPanelHide()">
       @if (this.service?.isOpenSearch()) {
       <ng-template pTemplate="header">
         <div class="p-dropdown-header">
@@ -45,7 +46,7 @@
       </ng-template>
 
       <ng-template let-item pTemplate="item">
-        <div class="flex items-center block whitespace-normal break-words gap-2">
+        <div class="flex w-full min-w-0 items-start whitespace-normal break-words gap-2">
           @if (this.item) {
           <ng-container *ngTemplateOutlet="this.item; context: { $implicit: item }"></ng-container>
           } @else {

--- a/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.html
+++ b/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.html
@@ -106,7 +106,7 @@
     [class.selected-items--custom-surface]="!!selectedItemsSurfaceColor?.trim()"
     [style.--multiselect-selected-surface]="selectedItemsSurfaceColor?.trim() || null">
     @for (row of selectedOptions(); track $index) {
-    <div class="item  {{ dark ? ' !bg-[#e8ebed] !border-[#c6cdd1]/40' : 'abc-grey-100' }} rounded-[6px]"
+    <div class="item  {{ dark ? ' !bg-[#e8ebed] !border-[#c6cdd1]/40' : 'abc-grey-100' }}"
       [class.item--full-row]="hideRemoveIcon">
       <div class="selected-row-main">
         <ng-container *ngTemplateOutlet="rows || defaultTemplate; context: { $implicit: row }"></ng-container>

--- a/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.html
+++ b/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.html
@@ -106,7 +106,7 @@
     [class.selected-items--custom-surface]="!!selectedItemsSurfaceColor?.trim()"
     [style.--multiselect-selected-surface]="selectedItemsSurfaceColor?.trim() || null">
     @for (row of selectedOptions(); track $index) {
-    <div class="item  {{ dark ? ' !bg-[#e8ebed] !border-[#c6cdd1]/40' : 'abc-grey-100' }}"
+    <div class="item  {{ dark ? ' !bg-[#e8ebed] !border-[#c6cdd1]/40' : 'abc-grey-100' }} rounded-[6px]"
       [class.item--full-row]="hideRemoveIcon">
       <div class="selected-row-main">
         <ng-container *ngTemplateOutlet="rows || defaultTemplate; context: { $implicit: row }"></ng-container>

--- a/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.html
+++ b/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.html
@@ -85,7 +85,7 @@
 
   @if (!this.hideSelected && !this.hideTemplate) {
   @if (this.currentResultIsLoading() || !(this.optionsSig().length)) {
-  @for (row of list; track $index) {
+  @for (row of list; track trackSelectedOptionRow($index, row)) {
   <p-skeleton width="100%" height="41px" styleClass="mb-2" />
   }
   } @else {
@@ -106,7 +106,7 @@
     [class.selected-items--stack-gap]="hideRemoveIcon"
     [class.selected-items--custom-surface]="!!selectedItemsSurfaceColor?.trim()"
     [style.--multiselect-selected-surface]="selectedItemsSurfaceColor?.trim() || null">
-    @for (row of selectedOptions(); track $index) {
+    @for (row of selectedOptions(); track trackSelectedOptionRow($index, row)) {
     <div class="item  {{ dark ? ' !bg-[#e8ebed] !border-[#c6cdd1]/40' : 'abc-grey-100' }}"
       [class.item--full-row]="hideRemoveIcon">
       <div class="selected-row-main">

--- a/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.html
+++ b/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.html
@@ -101,19 +101,29 @@
   <span class="block text-[14.5px] pb-3 pt-6 text-[#777C83]">{{ textSpan }}</span>
   }
   <div class="selected-items {{ !textSpan && selectedOptions().length ? 'mt-6' : '' }}"
-    [class.show-scroll]="!this.disabledSelectedScroll" [class.columns-xl]="columnsOnXl">
+    [class.show-scroll]="!this.disabledSelectedScroll" [class.columns-xl]="columnsOnXl"
+    [class.selected-items--stack-gap]="hideRemoveIcon">
     @for (row of selectedOptions(); track $index) {
-    <div class="item  {{ dark ? ' !bg-[#e8ebed] !border-[#c6cdd1]/40' : 'abc-grey-100' }}">
-      <ng-container *ngTemplateOutlet="rows || defaultTemplate; context: { $implicit: row }"></ng-container>
+    <div class="item  {{ dark ? ' !bg-[#e8ebed] !border-[#c6cdd1]/40' : 'abc-grey-100' }}"
+      [class.item--full-row]="hideRemoveIcon">
+      <div class="selected-row-main">
+        <ng-container *ngTemplateOutlet="rows || defaultTemplate; context: { $implicit: row }"></ng-container>
+      </div>
+      @if (!hideRemoveIcon) {
       @if (removeCondition(row) && !this.disabled) {
       @if (!row.disabled) {
-      <i class="text-[#CF0808] cursor-pointer material-symbols-rounded" (click)="removeOption(row)"
-        (keydown.enter)="removeOption(row)">
-        cancel
-      </i>
+      <button type="button"
+        class="multiselect-row-remove shrink-0 cursor-pointer border-0 bg-transparent p-0 leading-none text-[#CF0808] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#CF0808]/30 rounded"
+        (click)="removeOption(row)" (keydown.enter)="removeOption(row)" aria-label="Remove">
+        <i class="pi pi-times-circle !text-[20px]"></i>
+      </button>
       }
       } @else {
-      <i class="text-[#A2A9AF] material-symbols-rounded" [pTooltip]="removeTooltip" tooltipPosition="top"> cancel </i>
+      <span class="inline-flex shrink-0 text-[#A2A9AF]" [pTooltip]="removeTooltip" tooltipPosition="top" tabindex="0"
+        role="img" [attr.aria-label]="removeTooltip || 'Cannot remove'">
+        <i class="pi pi-times-circle !text-[20px]"></i>
+      </span>
+      }
       }
     </div>
     }

--- a/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.html
+++ b/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.html
@@ -104,8 +104,8 @@
   <div class="selected-items {{ !textSpan && selectedOptions().length ? 'mt-6' : '' }}"
     [class.show-scroll]="!this.disabledSelectedScroll" [class.columns-xl]="columnsOnXl"
     [class.selected-items--stack-gap]="hideRemoveIcon"
-    [class.selected-items--custom-surface]="!!selectedItemsSurfaceColor?.trim()"
-    [style.--multiselect-selected-surface]="selectedItemsSurfaceColor?.trim() || null">
+    [class.selected-items--custom-surface]="!!selectedItemsSurfaceColor.trim()"
+    [style.--multiselect-selected-surface]="selectedItemsSurfaceColor.trim() || null">
     @for (row of selectedOptions(); track trackSelectedOptionRow($index, row)) {
     <div class="item  {{ dark ? ' !bg-[#e8ebed] !border-[#c6cdd1]/40' : 'abc-grey-100' }}"
       [class.item--full-row]="hideRemoveIcon">
@@ -122,8 +122,8 @@
       </button>
       }
       } @else {
-      <span class="inline-flex shrink-0 text-[#A2A9AF]" [pTooltip]="removeTooltip" tooltipPosition="top" tabindex="0"
-        role="img" [attr.aria-label]="removeTooltip || 'Cannot remove'">
+      <span class="inline-flex shrink-0 text-[#A2A9AF]" [pTooltip]="removeTooltip" tooltipPosition="top" role="img"
+        [attr.aria-label]="removeTooltip || 'Cannot remove'">
         <i class="pi pi-times-circle !text-[20px]"></i>
       </span>
       }

--- a/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.html
+++ b/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.html
@@ -102,7 +102,9 @@
   }
   <div class="selected-items {{ !textSpan && selectedOptions().length ? 'mt-6' : '' }}"
     [class.show-scroll]="!this.disabledSelectedScroll" [class.columns-xl]="columnsOnXl"
-    [class.selected-items--stack-gap]="hideRemoveIcon">
+    [class.selected-items--stack-gap]="hideRemoveIcon"
+    [class.selected-items--custom-surface]="!!selectedItemsSurfaceColor?.trim()"
+    [style.--multiselect-selected-surface]="selectedItemsSurfaceColor?.trim() || null">
     @for (row of selectedOptions(); track $index) {
     <div class="item  {{ dark ? ' !bg-[#e8ebed] !border-[#c6cdd1]/40' : 'abc-grey-100' }}"
       [class.item--full-row]="hideRemoveIcon">

--- a/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.html
+++ b/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.html
@@ -122,9 +122,9 @@
       </button>
       }
       } @else {
-      <span class="inline-flex shrink-0 text-[#A2A9AF]" [pTooltip]="removeTooltip" tooltipPosition="top" role="img"
+      <span class="inline-flex shrink-0 text-[#A2A9AF]" [pTooltip]="removeTooltip" tooltipPosition="top"
         [attr.aria-label]="removeTooltip || 'Cannot remove'">
-        <i class="pi pi-times-circle !text-[20px]"></i>
+        <i class="pi pi-times-circle !text-[20px]" aria-hidden="true"></i>
       </span>
       }
       }

--- a/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.scss
+++ b/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.scss
@@ -10,6 +10,10 @@
       max-height: 380px;
       overflow-y: auto;
     }
+
+    &.selected-items--stack-gap {
+      gap: 14px;
+    }
   }
 
   .item {
@@ -19,7 +23,18 @@
     justify-content: space-between;
     align-items: center;
     background-color: #f4f7f9;
-    gap: 20px;
+    gap: 12px;
+
+    .selected-row-main {
+      flex: 1;
+      min-width: 0;
+      width: 100%;
+    }
+
+    &.item--full-row {
+      align-items: flex-start;
+      justify-content: flex-start;
+    }
   }
 }
 
@@ -27,8 +42,11 @@
   flex-direction: row !important;
   flex-wrap: wrap;
 }
+
 .selected-items.columns-xl .item {
   width: 100%;
+  background-color: #f6f6f6;
+  border-color: #d1d6db;
 }
 
 @media (min-width: 1280px) {

--- a/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.scss
+++ b/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.scss
@@ -6,6 +6,15 @@
     display: flex;
     flex-direction: column;
 
+    &:not(.selected-items--stack-gap) {
+      border-radius: 6px;
+      overflow: hidden;
+    }
+
+    &.selected-items--stack-gap .item {
+      border-radius: 6px;
+    }
+
     &.show-scroll {
       max-height: 380px;
       overflow-y: auto;

--- a/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.scss
+++ b/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.scss
@@ -14,6 +14,13 @@
     &.selected-items--stack-gap {
       gap: 14px;
     }
+
+    &.selected-items--custom-surface {
+      .item {
+        background-color: var(--multiselect-selected-surface);
+        border-color: #d1d6db;
+      }
+    }
   }
 
   .item {
@@ -45,8 +52,6 @@
 
 .selected-items.columns-xl .item {
   width: 100%;
-  background-color: #f6f6f6;
-  border-color: #d1d6db;
 }
 
 @media (min-width: 1280px) {

--- a/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.scss
+++ b/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.scss
@@ -72,7 +72,7 @@
   }
 }
 
-@media (min-width: 1560px) {
+@media (min-width: 1960px) {
   .selected-items.columns-xl {
     gap: 16px;
   }

--- a/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.spec.ts
+++ b/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.spec.ts
@@ -1186,6 +1186,102 @@ describe('MultiselectComponent', () => {
     expect(component.virtualScrollEstimateSize()).toBe(60);
   });
 
+  describe('trackSelectedOptionRow / optionRowTrackKeyFromRow', () => {
+    beforeEach(() => {
+      component.optionValue = 'id';
+    });
+
+    it('should stringify boolean option value as true/false', () => {
+      expect(component.trackSelectedOptionRow(0, { id: true })).toBe('true');
+      expect(component.trackSelectedOptionRow(1, { id: false })).toBe('false');
+    });
+
+    it('should stringify bigint option value', () => {
+      expect(component.trackSelectedOptionRow(0, { id: BigInt(99) })).toBe('99');
+    });
+
+    it('should return index when raw type is unsupported (e.g. object)', () => {
+      expect(component.trackSelectedOptionRow(3, { id: { nested: 1 } } as any)).toBe(3);
+    });
+
+    it('should return index when option key is empty string', () => {
+      expect(component.trackSelectedOptionRow(4, { id: '' })).toBe(4);
+    });
+
+    it('should return index when row is null or primitive', () => {
+      expect(component.trackSelectedOptionRow(2, null)).toBe(2);
+      expect(component.trackSelectedOptionRow(2, 'x' as any)).toBe(2);
+    });
+
+    it('should return index when optionValue is not set', () => {
+      component.optionValue = '';
+      expect(component.trackSelectedOptionRow(6, { id: 1 })).toBe(6);
+    });
+  });
+
+  describe('setValue merged[attr] fallback', () => {
+    it('should set id on merged object when prev and options lack the key', () => {
+      mockUtilsService.getNestedProperty.mockReturnValue([]);
+      mockService.list.mockReturnValue([]);
+      component.ngOnInit();
+
+      component.setValue([42]);
+
+      expect(component.body().value).toEqual([42]);
+    });
+
+    it('should use empty prevItems when getNestedProperty returns null (line 306 ?? branch)', () => {
+      mockUtilsService.getNestedProperty.mockReturnValue(null);
+      mockService.list.mockReturnValue([{ id: 7, name: 'X' }]);
+      component.ngOnInit();
+
+      component.setValue([7]);
+
+      expect(component.body().value).toEqual([7]);
+    });
+  });
+
+  it('syncBodyWithSignal should update body when lengths differ (cover line 207)', () => {
+    component.signal = signal({ testField: [{ id: 1 }, { id: 2 }] });
+    component.optionValue = 'id';
+    component.signalOptionValue = 'testField';
+    component.body.set({ value: [1] });
+    mockUtilsService.getNestedProperty.mockReturnValue([{ id: 1 }, { id: 2 }]);
+    TestBed.flushEffects();
+    expect(component.body().value).toEqual([1, 2]);
+  });
+
+  it('syncBodyWithSignal should coerce non-array body value to empty array before compare (line 204)', () => {
+    component.signal = signal({ testField: [{ id: 1 }, { id: 2 }] });
+    component.optionValue = 'id';
+    component.signalOptionValue = 'testField';
+    component.body.set({ value: 'not-an-array' as any });
+    mockUtilsService.getNestedProperty.mockReturnValue([{ id: 1 }, { id: 2 }]);
+    TestBed.flushEffects();
+    expect(component.body().value).toEqual([1, 2]);
+  });
+
+  it('availableOptions uses listWithDisabled when useDisabled is truthy (line 121)', () => {
+    component.optionsDisabled.set([{ id: 1 }]);
+    mockService.list.mockReturnValue([
+      { id: 1, name: 'A' },
+      { id: 2, name: 'B' }
+    ]);
+    component.ngOnInit();
+    mockUtilsService.getNestedProperty.mockReturnValue([]);
+    const opts = component.availableOptions();
+    expect(opts.some(o => o.id === 1)).toBe(true);
+  });
+
+  it('setValue uses empty event and options when event is not array and optionsSig is undefined-valued (lines 306-308)', () => {
+    mockUtilsService.getNestedProperty.mockReturnValue([]);
+    mockService.list.mockReturnValue([]);
+    component.ngOnInit();
+    (component as any).optionsSig = signal(undefined as any);
+    component.setValue(999 as any);
+    expect(component.body().value).toBe(999);
+  });
+
   describe('loadData', () => {
     it('should await service.main when defined', async () => {
       const main = jest.fn().mockResolvedValue(undefined);

--- a/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.spec.ts
+++ b/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { MultiselectComponent } from './multiselect.component';
-import { signal } from '@angular/core';
+import { ElementRef, signal } from '@angular/core';
 import { SimpleChanges } from '@angular/core';
 import { ActionsService } from '../../../services/actions.service';
 import { ServiceLocatorService } from '../../../services/service-locator.service';
@@ -57,6 +57,7 @@ describe('MultiselectComponent', () => {
     await TestBed.configureTestingModule({
       providers: [
         MultiselectComponent,
+        { provide: ElementRef, useValue: new ElementRef(document.createElement('div')) },
         { provide: ActionsService, useValue: mockActionsService },
         { provide: ServiceLocatorService, useValue: mockServiceLocator },
         { provide: CacheService, useValue: mockCacheService },

--- a/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.spec.ts
+++ b/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { MultiselectComponent } from './multiselect.component';
-import { ElementRef, signal } from '@angular/core';
+import { ElementRef, PLATFORM_ID, signal } from '@angular/core';
 import { SimpleChanges } from '@angular/core';
 import { ActionsService } from '../../../services/actions.service';
 import { ServiceLocatorService } from '../../../services/service-locator.service';
@@ -971,7 +971,7 @@ describe('MultiselectComponent', () => {
       { id: 1, name: 'Option 1' },
       { id: 2, name: 'Option 2' }
     ]);
-    component.useDisabled = signal(false);
+    component.optionsDisabled.set([]);
 
     // Access availableOptions computed which uses the filter
     const result = component.availableOptions();
@@ -983,8 +983,12 @@ describe('MultiselectComponent', () => {
   it('ngOnChanges should rebind service and load when serviceName or serviceParams change', () => {
     const loadDataSpy = jest.spyOn(component as any, 'loadData').mockResolvedValue(undefined);
     const bindSpy = jest.spyOn(component as any, 'bindServiceSignals').mockImplementation(() => {});
-    const otherService = { list: jest.fn().mockReturnValue([]), loading: jest.fn().mockReturnValue(false) };
-    mockServiceLocator.getService.mockReturnValue(otherService);
+    const otherService = {
+      list: jest.fn().mockReturnValue([]),
+      loading: jest.fn().mockReturnValue(false),
+      isOpenSearch: jest.fn().mockReturnValue(false)
+    };
+    mockServiceLocator.getService.mockReturnValue(otherService as any);
     component.serviceName = 'regions';
 
     component.ngOnChanges({
@@ -1007,5 +1011,230 @@ describe('MultiselectComponent', () => {
 
     expect(bindSpy).toHaveBeenCalled();
     expect(loadDataSpy).toHaveBeenCalled();
+  });
+
+  describe('removeById', () => {
+    it('should remove option when service finds matching id', () => {
+      component.ngOnInit();
+      mockService.list.mockReturnValue([
+        { id: 1, name: 'A' },
+        { id: 2, name: 'B' }
+      ]);
+      mockUtilsService.getNestedProperty.mockReturnValue([
+        { id: 1, name: 'A' },
+        { id: 2, name: 'B' }
+      ]);
+      component.signal = signal({ testField: [
+        { id: 1, name: 'A' },
+        { id: 2, name: 'B' }
+      ] });
+      const removeSpy = jest.spyOn(component, 'removeOption');
+      component.removeById(2);
+      expect(removeSpy).toHaveBeenCalledWith({ id: 2, name: 'B' });
+    });
+
+    it('should not call removeOption when id not in service list', () => {
+      component.ngOnInit();
+      mockService.list.mockReturnValue([{ id: 1, name: 'A' }]);
+      const removeSpy = jest.spyOn(component, 'removeOption');
+      component.removeById(99);
+      expect(removeSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('multiselect overlay width (panel show/hide)', () => {
+    it('applyMultiselectPanelMaxWidth sets widths and calls alignOverlay when root, trigger, and panel exist', () => {
+      const host = document.createElement('div');
+      const trigger = document.createElement('div');
+      trigger.className = 'p-multiselect';
+      jest.spyOn(trigger, 'getBoundingClientRect').mockReturnValue({ width: 240 } as DOMRect);
+      host.appendChild(trigger);
+      (component as any).hostEl = { nativeElement: host };
+
+      const panel = document.createElement('div');
+      panel.className = 'p-multiselect-overlay';
+      const root = document.createElement('div');
+      root.appendChild(panel);
+      const alignOverlay = jest.fn();
+      (component as any).primeMultiSelect = { overlayViewChild: { overlayEl: root, alignOverlay } };
+
+      (component as any).applyMultiselectPanelMaxWidth();
+
+      expect(root.style.maxWidth).toBe('240px');
+      expect(panel.style.maxWidth).toBe('240px');
+      expect(alignOverlay).toHaveBeenCalled();
+    });
+
+    it('applyMultiselectPanelMaxWidth returns early when overlay root missing', () => {
+      (component as any).primeMultiSelect = { overlayViewChild: { overlayEl: null } };
+      expect(() => (component as any).applyMultiselectPanelMaxWidth()).not.toThrow();
+    });
+
+    it('applyMultiselectPanelMaxWidth returns early when primeMultiSelect is undefined', () => {
+      (component as any).primeMultiSelect = undefined;
+      expect(() => (component as any).applyMultiselectPanelMaxWidth()).not.toThrow();
+    });
+
+    it('applyMultiselectPanelMaxWidth sets root only when overlay panel element is absent', () => {
+      const host = document.createElement('div');
+      const trigger = document.createElement('div');
+      trigger.className = 'p-multiselect';
+      jest.spyOn(trigger, 'getBoundingClientRect').mockReturnValue({ width: 180 } as DOMRect);
+      host.appendChild(trigger);
+      (component as any).hostEl = { nativeElement: host };
+      const root = document.createElement('div');
+      const alignOverlay = jest.fn();
+      (component as any).primeMultiSelect = { overlayViewChild: { overlayEl: root, alignOverlay } };
+
+      (component as any).applyMultiselectPanelMaxWidth();
+
+      expect(root.style.maxWidth).toBe('180px');
+      expect(alignOverlay).toHaveBeenCalled();
+    });
+
+    it('applyMultiselectPanelMaxWidth returns early when trigger missing', () => {
+      const root = document.createElement('div');
+      (component as any).hostEl = { nativeElement: document.createElement('div') };
+      (component as any).primeMultiSelect = { overlayViewChild: { overlayEl: root } };
+      (component as any).applyMultiselectPanelMaxWidth();
+      expect(root.style.maxWidth).toBe('');
+    });
+
+    it('applyMultiselectPanelMaxWidth returns early when width under 1', () => {
+      const host = document.createElement('div');
+      const trigger = document.createElement('div');
+      trigger.className = 'p-multiselect';
+      jest.spyOn(trigger, 'getBoundingClientRect').mockReturnValue({ width: 0 } as DOMRect);
+      host.appendChild(trigger);
+      (component as any).hostEl = { nativeElement: host };
+      const root = document.createElement('div');
+      (component as any).primeMultiSelect = { overlayViewChild: { overlayEl: root } };
+      (component as any).applyMultiselectPanelMaxWidth();
+      expect(root.style.maxWidth).toBe('');
+    });
+
+    it('clearMultiselectPanelMaxWidth removes styles on root and panel', () => {
+      const panel = document.createElement('div');
+      panel.className = 'p-multiselect-overlay';
+      const root = document.createElement('div');
+      root.style.maxWidth = '100px';
+      root.appendChild(panel);
+      (component as any).primeMultiSelect = { overlayViewChild: { overlayEl: root } };
+      (component as any).clearMultiselectPanelMaxWidth();
+      expect(root.style.maxWidth).toBe('');
+      expect(panel.style.maxWidth).toBe('');
+    });
+
+    it('clearMultiselectPanelMaxWidth returns when root missing', () => {
+      (component as any).primeMultiSelect = { overlayViewChild: { overlayEl: null } };
+      expect(() => (component as any).clearMultiselectPanelMaxWidth()).not.toThrow();
+    });
+
+    it('clearMultiselectPanelMaxWidth clears root only when panel element is absent', () => {
+      const root = document.createElement('div');
+      root.style.maxWidth = '100px';
+      (component as any).primeMultiSelect = { overlayViewChild: { overlayEl: root } };
+      (component as any).clearMultiselectPanelMaxWidth();
+      expect(root.style.maxWidth).toBe('');
+    });
+
+    it('onMultiselectPanelShow runs apply path in browser (rAF + runOutsideAngular)', () => {
+      const ngZone = (component as any).ngZone;
+      jest.spyOn(ngZone, 'runOutsideAngular').mockImplementation((fn: any) => {
+        (fn as () => void)();
+      });
+      jest.spyOn(window, 'requestAnimationFrame').mockImplementation((cb: FrameRequestCallback) => {
+        cb(0);
+        return 0;
+      });
+      const applySpy = jest.spyOn(component as any, 'applyMultiselectPanelMaxWidth').mockImplementation(() => {});
+
+      component.onMultiselectPanelShow();
+
+      expect(applySpy).toHaveBeenCalled();
+      jest.restoreAllMocks();
+    });
+
+    it('onMultiselectPanelHide clears width in browser', () => {
+      const clearSpy = jest.spyOn(component as any, 'clearMultiselectPanelMaxWidth').mockImplementation(() => {});
+      component.onMultiselectPanelHide();
+      expect(clearSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('bindServiceSignals getList/getLoading branch', () => {
+    it('should wire optionsSig and loadingSig from getList and getLoading', () => {
+      const listSig = signal([{ id: 1, name: 'A' }]);
+      const loadSig = signal(true);
+      (component as any).service = {
+        getList: jest.fn().mockReturnValue(listSig),
+        getLoading: jest.fn().mockReturnValue(loadSig)
+      };
+      (component as any).bindServiceSignals();
+      expect(component.optionsSig).toBe(listSig);
+      expect(component.loadingSig).toBe(loadSig);
+    });
+  });
+
+  it('multiselectPanelStyle returns full width when appendTo is self', () => {
+    component.appendTo = 'self';
+    expect(component.multiselectPanelStyle).toEqual({ width: '100%', minWidth: '100%' });
+  });
+
+  it('virtualScrollEstimateSize returns 60 when optionLabel2 is set', () => {
+    component.optionLabel2 = 'secondary';
+    expect(component.virtualScrollEstimateSize()).toBe(60);
+  });
+
+  describe('loadData', () => {
+    it('should await service.main when defined', async () => {
+      const main = jest.fn().mockResolvedValue(undefined);
+      (component as any).service = {
+        main,
+        list: signal([]),
+        loading: signal(false),
+        isOpenSearch: signal(false)
+      };
+      (component as any).bindServiceSignals();
+      await (component as any).loadData();
+      expect(main).toHaveBeenCalled();
+    });
+  });
+
+  describe('SSR (non-browser) panel callbacks', () => {
+    let ssrComponent: MultiselectComponent;
+
+    beforeEach(async () => {
+      TestBed.resetTestingModule();
+      await TestBed.configureTestingModule({
+        providers: [
+          MultiselectComponent,
+          { provide: ElementRef, useValue: new ElementRef(document.createElement('div')) },
+          { provide: ActionsService, useValue: mockActionsService },
+          { provide: ServiceLocatorService, useValue: mockServiceLocator },
+          { provide: CacheService, useValue: mockCacheService },
+          { provide: UtilsService, useValue: mockUtilsService },
+          { provide: AllModalsService, useValue: mockAllModalsService },
+          { provide: PLATFORM_ID, useValue: 'server' }
+        ]
+      }).compileComponents();
+      ssrComponent = TestBed.inject(MultiselectComponent);
+    });
+
+    afterEach(() => {
+      TestBed.resetTestingModule();
+    });
+
+    it('onMultiselectPanelShow does not apply when not browser', () => {
+      const spy = jest.spyOn(ssrComponent as any, 'applyMultiselectPanelMaxWidth');
+      ssrComponent.onMultiselectPanelShow();
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('onMultiselectPanelHide does not clear when not browser', () => {
+      const spy = jest.spyOn(ssrComponent as any, 'clearMultiselectPanelMaxWidth');
+      ssrComponent.onMultiselectPanelHide();
+      expect(spy).not.toHaveBeenCalled();
+    });
   });
 });

--- a/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.ts
+++ b/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.ts
@@ -80,6 +80,7 @@ export class MultiselectComponent implements OnInit, OnChanges {
   @Input() appendTo: 'body' | 'self' = 'body';
   @Input() dark = false;
   @Input() optionFilter: (item: any) => boolean = () => true;
+  @Input() hideRemoveIcon = false;
   selectEvent = output<any>();
   environment = environment;
 

--- a/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.ts
+++ b/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.ts
@@ -8,17 +8,21 @@ import {
   effect,
   inject,
   Input,
+  PLATFORM_ID,
   signal,
   TemplateRef,
+  ViewChild,
   WritableSignal,
   OnInit,
   OnChanges,
   SimpleChanges,
-  output
+  output,
+  ElementRef,
+  NgZone
 } from '@angular/core';
-import { MultiSelectModule } from 'primeng/multiselect';
+import { MultiSelectModule, MultiSelect } from 'primeng/multiselect';
 import { FormsModule } from '@angular/forms';
-import { NgTemplateOutlet } from '@angular/common';
+import { isPlatformBrowser, NgTemplateOutlet } from '@angular/common';
 import { ActionsService } from '../../../services/actions.service';
 import { ServiceLocatorService } from '../../../services/service-locator.service';
 import { ControlListServices } from '../../../interfaces/services.interface';
@@ -43,6 +47,11 @@ export class MultiselectComponent implements OnInit, OnChanges {
   actions = inject(ActionsService);
   serviceLocator = inject(ServiceLocatorService);
   allModalsService = inject(AllModalsService);
+  private readonly hostEl = inject(ElementRef<HTMLElement>);
+  private readonly platformId = inject(PLATFORM_ID);
+  private readonly ngZone = inject(NgZone);
+
+  @ViewChild(MultiSelect) private primeMultiSelect?: MultiSelect;
 
   @ContentChild('rows') rows!: TemplateRef<any>;
   @ContentChild('selectedItems') selectedItems!: TemplateRef<any>;
@@ -50,6 +59,8 @@ export class MultiselectComponent implements OnInit, OnChanges {
 
   @Input() signal: WritableSignal<any> = signal({});
   @Input() optionLabel = '';
+  /** When set (e.g. second field name), uses 60px min row height like app-select — pairs with p-scroller autoSize for wrapping labels. */
+  @Input() optionLabel2 = '';
   @Input() optionValue = '';
   @Input() signalOptionValue = '';
   @Input() serviceName: ControlListServices = '';
@@ -78,16 +89,19 @@ export class MultiselectComponent implements OnInit, OnChanges {
   @Input() itemHeight = 41;
   @Input() enableVirtualScroll = true;
   @Input() appendTo: 'body' | 'self' = 'body';
+
+  get multiselectPanelStyle(): { width: string; minWidth: string } | null {
+    return this.appendTo === 'self' ? { width: '100%', minWidth: '100%' } : null;
+  }
   @Input() dark = false;
   @Input() optionFilter: (item: any) => boolean = () => true;
   @Input() hideRemoveIcon = false;
-  /** Background for the selected-items area and each row; use with columns XL (e.g. `#E8EBED`). */
   @Input() selectedItemsSurfaceColor = '';
   selectEvent = output<any>();
   environment = environment;
 
   service: any;
-  // Local per-component signals for parameterized services
+  private inFlightLoadByKey = new Map<string, Promise<void>>();
   optionsSig: WritableSignal<any[]> = signal<any[]>([]);
   loadingSig: WritableSignal<boolean> = signal<boolean>(false);
 
@@ -228,14 +242,33 @@ export class MultiselectComponent implements OnInit, OnChanges {
     }
   }
 
+  virtualScrollEstimateSize(): number {
+    return this.optionLabel2 ? 60 : this.itemHeight;
+  }
+
+  private loadKey(): string {
+    return `${String(this.serviceName)}::${JSON.stringify(this.serviceParams)}`;
+  }
+
   private async loadData() {
-    if (this.service && typeof this.service.main === 'function') {
-      try {
-        await this.service.main(this.serviceParams as any);
-      } catch {
-        // ignore
-      }
+    if (!this.service || typeof this.service.main !== 'function') {
+      return;
     }
+    const key = this.loadKey();
+    let run = this.inFlightLoadByKey.get(key);
+    if (!run) {
+      run = (async () => {
+        try {
+          await this.service.main(this.serviceParams as any);
+        } catch {
+          // ignore
+        } finally {
+          this.inFlightLoadByKey.delete(key);
+        }
+      })();
+      this.inFlightLoadByKey.set(key, run);
+    }
+    await run;
   }
 
   onFilter(event: any) {
@@ -299,6 +332,61 @@ export class MultiselectComponent implements OnInit, OnChanges {
       this.utils.setNestedPropertyWithReduce(current, this.signalOptionValue, updatedOptions);
       return { ...current };
     });
+  }
+
+  onMultiselectPanelShow(): void {
+    if (!isPlatformBrowser(this.platformId)) {
+      return;
+    }
+    this.ngZone.runOutsideAngular(() => {
+      requestAnimationFrame(() => this.applyMultiselectPanelMaxWidth());
+    });
+  }
+
+  onMultiselectPanelHide(): void {
+    if (!isPlatformBrowser(this.platformId)) {
+      return;
+    }
+    this.clearMultiselectPanelMaxWidth();
+  }
+
+  private applyMultiselectPanelMaxWidth(): void {
+    const overlay = this.primeMultiSelect?.overlayViewChild;
+    const root = overlay?.overlayEl;
+    if (!root) {
+      return;
+    }
+    const trigger = this.hostEl.nativeElement.querySelector('.p-multiselect');
+    if (!trigger) {
+      return;
+    }
+    const w = Math.max(0, Math.round(trigger.getBoundingClientRect().width));
+    if (w < 1) {
+      return;
+    }
+    const panel = root.querySelector('.p-multiselect-overlay') as HTMLElement | null;
+    root.style.maxWidth = `${w}px`;
+    root.style.boxSizing = 'border-box';
+    if (panel) {
+      panel.style.maxWidth = `${w}px`;
+      panel.style.boxSizing = 'border-box';
+    }
+    overlay.alignOverlay();
+  }
+
+  private clearMultiselectPanelMaxWidth(): void {
+    const overlay = this.primeMultiSelect?.overlayViewChild;
+    const root = overlay?.overlayEl;
+    if (!root) {
+      return;
+    }
+    const panel = root.querySelector('.p-multiselect-overlay') as HTMLElement | null;
+    root.style.removeProperty('max-width');
+    root.style.removeProperty('box-sizing');
+    if (panel) {
+      panel.style.removeProperty('max-width');
+      panel.style.removeProperty('box-sizing');
+    }
   }
 
   removeById(id: string | number) {

--- a/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.ts
+++ b/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.ts
@@ -246,6 +246,21 @@ export class MultiselectComponent implements OnInit, OnChanges {
     return this.optionLabel2 ? 60 : this.itemHeight;
   }
 
+  trackSelectedOptionRow(index: number, row: unknown): string | number {
+    return this.optionRowTrackKeyFromRow(row) ?? index;
+  }
+
+  private optionRowTrackKeyFromRow(row: unknown): string | number | undefined {
+    if (!this.optionValue || row === null || row === undefined || typeof row !== 'object') return undefined;
+    const raw = (row as Record<string, unknown>)[this.optionValue];
+    if (raw === undefined || raw === null || raw === '') return undefined;
+    const t = typeof raw;
+    if (t === 'number' || t === 'string') return raw as number | string;
+    if (t === 'boolean') return raw ? 'true' : 'false';
+    if (t === 'bigint') return (raw as bigint).toString();
+    return undefined;
+  }
+
   private loadKey(): string {
     return `${String(this.serviceName)}::${JSON.stringify(this.serviceParams)}`;
   }
@@ -287,24 +302,22 @@ export class MultiselectComponent implements OnInit, OnChanges {
     this.body.set({ value: event });
 
     this.signal.update((current: any) => {
-      const existingValues = this.objectArrayToIdArray(this.utils.getNestedProperty(current, this.signalOptionValue), this.optionValue);
+      const attr = this.optionValue;
+      const prevItems = this.utils.getNestedProperty(current, this.signalOptionValue) ?? [];
+      const eventIds = Array.isArray(event) ? event : [];
+      const optionsList = this.optionsSig() ?? [];
 
-      // Find new options to add
-      const newOption = this.optionsSig().find(
-        (option: any) => event?.includes(option[this.optionValue]) && !existingValues?.includes(option[this.optionValue])
-      );
+      const nextItems = eventIds.map((id: number) => {
+        const fromPrev = prevItems.find((item: any) => item[attr] == id);
+        const fromOptions = optionsList.find((option: any) => option[attr] == id);
+        const merged: Record<string, unknown> = { ...(fromPrev ?? {}), ...(fromOptions ?? {}) };
+        if (merged[attr] == null) {
+          merged[attr] = id;
+        }
+        return merged as any;
+      });
 
-      if (newOption) {
-        /* istanbul ignore next */
-        const currentValues = this.utils.getNestedProperty(current, this.signalOptionValue) ?? [];
-        this.utils.setNestedPropertyWithReduce(current, this.signalOptionValue, [...currentValues, newOption]);
-      }
-
-      // Remove options that are no longer selected
-      const filteredOptions = this.utils
-        .getNestedProperty(current, this.signalOptionValue)
-        .filter((item: any) => event?.includes(item[this.optionValue]));
-      this.utils.setNestedPropertyWithReduce(current, this.signalOptionValue, filteredOptions);
+      this.utils.setNestedPropertyWithReduce(current, this.signalOptionValue, nextItems);
 
       this.selectEvent.emit(current);
       return { ...current };
@@ -330,6 +343,7 @@ export class MultiselectComponent implements OnInit, OnChanges {
       this.body.set({ value: this.objectArrayToIdArray(updatedOptions, this.optionValue) });
 
       this.utils.setNestedPropertyWithReduce(current, this.signalOptionValue, updatedOptions);
+      this.selectEvent.emit({ ...current });
       return { ...current };
     });
   }

--- a/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.ts
+++ b/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.ts
@@ -81,6 +81,8 @@ export class MultiselectComponent implements OnInit, OnChanges {
   @Input() dark = false;
   @Input() optionFilter: (item: any) => boolean = () => true;
   @Input() hideRemoveIcon = false;
+  /** Background for the selected-items area and each row; use with columns XL (e.g. `#E8EBED`). */
+  @Input() selectedItemsSurfaceColor = '';
   selectEvent = output<any>();
   environment = environment;
 

--- a/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.ts
+++ b/research-indicators/src/app/shared/components/custom-fields/multiselect/multiselect.component.ts
@@ -311,9 +311,7 @@ export class MultiselectComponent implements OnInit, OnChanges {
         const fromPrev = prevItems.find((item: any) => item[attr] == id);
         const fromOptions = optionsList.find((option: any) => option[attr] == id);
         const merged: Record<string, unknown> = { ...(fromPrev ?? {}), ...(fromOptions ?? {}) };
-        if (merged[attr] == null) {
-          merged[attr] = id;
-        }
+        merged[attr] ??= id;
         return merged as any;
       });
 

--- a/research-indicators/src/app/shared/components/custom-fields/select/select.component.spec.ts
+++ b/research-indicators/src/app/shared/components/custom-fields/select/select.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { SelectComponent } from './select.component';
-import { signal } from '@angular/core';
+import { signal, SimpleChange } from '@angular/core';
 import { ServiceLocatorService } from '../../../services/service-locator.service';
 import { CacheService } from '../../../services/cache/cache.service';
 import { UtilsService } from '../../../services/utils.service';
@@ -383,4 +383,72 @@ describe('SelectComponent', () => {
     expect(component.loadingSig).toBe(loadingSignal);
   });
 
+  it('ngOnChanges should call initializeService when only serviceParams change', () => {
+    const initSpy = jest.spyOn(component as any, 'initializeService').mockImplementation(() => {});
+    component.ngOnInit();
+    initSpy.mockClear();
+
+    component.ngOnChanges({
+      serviceParams: new SimpleChange({ a: 1 }, { a: 2 }, false)
+    });
+
+    expect(initSpy).toHaveBeenCalled();
+    initSpy.mockRestore();
+  });
+
+  it('ngOnChanges should update isRequiredSignal when isRequired input changes', () => {
+    component.isRequired = false;
+    component.ngOnInit();
+    expect(component.isRequiredSignal()).toBe(false);
+
+    component.isRequired = true;
+    component.ngOnChanges({
+      isRequired: new SimpleChange(false, true, false)
+    });
+
+    expect(component.isRequiredSignal()).toBe(true);
+  });
+
+  it('onSectionLoad uses getNestedProperty for dotted body when first segment is not an array (line 103)', () => {
+    mockCacheService.currentResultIsLoading.set(true);
+
+    const fixture = TestBed.createComponent(SelectComponent);
+    const comp = fixture.componentInstance;
+    comp.optionValue = { body: 'items.value', option: 'id' };
+    comp.body.set({ value: null });
+    comp.signal = signal<any>({ items: { notAnArray: true } });
+
+    mockUtilsService.getNestedProperty.mockImplementation((obj: any, path: string) => {
+      if (path === 'items.value') {
+        return 'FROM-NESTED';
+      }
+      return null;
+    });
+    mockUtilsService.setNestedPropertyWithReduce.mockImplementation((obj: any, _p: string, v: any) => {
+      obj.value = v;
+    });
+
+    mockCacheService.currentResultIsLoading.set(false);
+    fixture.detectChanges();
+
+    expect(comp.body().value).toBe('FROM-NESTED');
+  });
+
+  it('loadData should catch when service.main rejects', async () => {
+    const failingService = {
+      ...mockService,
+      main: jest.fn().mockRejectedValue(new Error('network'))
+    };
+    mockServiceLocator.getService.mockReturnValue(failingService);
+
+    const fixture = TestBed.createComponent(SelectComponent);
+    const comp = fixture.componentInstance;
+    comp.serviceName = 'getCountries';
+    comp.ngOnInit();
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(failingService.main).toHaveBeenCalled();
+  });
 });

--- a/research-indicators/src/app/shared/components/navigation-buttons/navigation-buttons.component.spec.ts
+++ b/research-indicators/src/app/shared/components/navigation-buttons/navigation-buttons.component.spec.ts
@@ -12,7 +12,7 @@ describe('NavigationButtonsComponent', () => {
   let isSidebarCollapsedSignal: ReturnType<typeof signal<boolean>>;
 
   const RESULT_SIDEBAR_WIDTH = 322;
-  const CONTENT_RIGHT_OFFSET = 12;
+  const CONTENT_RIGHT_OFFSET = 0;
 
   beforeEach(async () => {
     hasSmallScreenSignal = signal(false);

--- a/research-indicators/src/app/shared/components/navigation-buttons/navigation-buttons.component.ts
+++ b/research-indicators/src/app/shared/components/navigation-buttons/navigation-buttons.component.ts
@@ -4,7 +4,7 @@ import { SubmissionService } from '@shared/services/submission.service';
 import { ButtonModule } from 'primeng/button';
 
 const RESULT_SIDEBAR_WIDTH_PX = 322;
-const CONTENT_RIGHT_OFFSET_PX = 12;
+const CONTENT_RIGHT_OFFSET_PX = 0;
 
 @Component({
   selector: 'app-navigation-buttons',
@@ -22,7 +22,6 @@ export class NavigationButtonsComponent {
   submission = inject(SubmissionService);
   cache = inject(CacheService);
 
-  /** Left offset so the bar aligns with result-content (platform padding + result sidebar). */
   navLeft = computed(() => {
     const hss = this.cache.hasSmallScreen();
     const collapsed = this.cache.isSidebarCollapsed();

--- a/research-indicators/src/app/shared/interfaces/impact-area.interface.ts
+++ b/research-indicators/src/app/shared/interfaces/impact-area.interface.ts
@@ -14,11 +14,14 @@ export interface ImpactAreaGlobalTarget {
   value: number | null;
 }
 
+export interface ResultImpactAreaGlobalTargetRef {
+  global_target_id: number;
+}
 
 export interface ResultImpactArea {
   impact_area_id: number;
   impact_area_score_id: number | undefined;
-  global_target_id: number | undefined;
+  result_impact_area_global_targets?: ResultImpactAreaGlobalTargetRef[];
 }
 
 export interface ImpactAreasBody {

--- a/research-indicators/src/app/shared/interfaces/lever-sdg-target.interface.ts
+++ b/research-indicators/src/app/shared/interfaces/lever-sdg-target.interface.ts
@@ -1,0 +1,14 @@
+export interface LeverSdgTargetApi {
+  id: number;
+  sdg_target: string;
+  sdg_target_code: string;
+}
+
+export interface LeverSdgTargetOption extends LeverSdgTargetApi {
+  sdg_target_id: number;
+  select_label: string;
+}
+
+export interface ResultLeverSdgTargetPayload {
+  sdg_target_id: number;
+}

--- a/research-indicators/src/app/shared/interfaces/lever-sdg-target.interface.ts
+++ b/research-indicators/src/app/shared/interfaces/lever-sdg-target.interface.ts
@@ -1,7 +1,17 @@
+export interface ClarisaSdg {
+  id: number;
+  short_name?: string;
+  full_name?: string;
+  icon?: string;
+  color?: string;
+  description?: string;
+}
+
 export interface LeverSdgTargetApi {
   id: number;
   sdg_target: string;
   sdg_target_code: string;
+  clarisa_sdg?: ClarisaSdg;
 }
 
 export interface LeverSdgTargetOption extends LeverSdgTargetApi {

--- a/research-indicators/src/app/shared/interfaces/link-results.interface.ts
+++ b/research-indicators/src/app/shared/interfaces/link-results.interface.ts
@@ -1,8 +1,52 @@
+import { ResultStatus, StatusConfig } from './result-config.interface';
+
 export interface LinkResultsResponse {
   link_results: LinkResultItem[];
 }
 
-export interface LinkResultItem {
-  other_result_id: number;
+export interface IndicatorLinkPayload {
+  indicator_id?: number;
+  name?: string;
+  icon_src?: string;
 }
 
+export interface OtherResultLinkPayload {
+  result_id: number;
+  result_official_code: number | string;
+  title?: string;
+  description?: string | null;
+  indicator_id?: number;
+  indicator?: IndicatorLinkPayload;
+  indicator_name?: string;
+  indicator_icon_src?: string;
+  platform_code?: string;
+  external_link?: string | null;
+  public_link?: string | null;
+  report_year_id?: number;
+  result_status_id?: number;
+  result_status?: ResultStatus;
+  status_name?: string;
+  status_description?: string;
+  status_config?: StatusConfig;
+  is_active?: boolean;
+  result_contracts?: LinkResultContractRow[];
+}
+
+export interface LinkResultContractRow {
+  contract_id: string;
+  result_id?: number;
+  is_active?: number;
+  is_primary?: number;
+  agresso_contract?: {
+    description?: string;
+    short_title?: string;
+  };
+}
+
+export interface LinkResultItem {
+  other_result_id: number;
+  link_result_id?: number;
+  result_id?: number;
+  link_result_role_id?: number;
+  other_result?: OtherResultLinkPayload;
+}

--- a/research-indicators/src/app/shared/interfaces/oicr-creation.interface.ts
+++ b/research-indicators/src/app/shared/interfaces/oicr-creation.interface.ts
@@ -1,5 +1,6 @@
 import { Country, Region } from './get-geo-location.interface';
 import { ResultImpactArea } from './impact-area.interface';
+import { GetSdgs } from './get-sdgs.interface';
 
 export interface OicrCreation {
   step_one: StepOne;
@@ -47,7 +48,7 @@ export interface Lever {
   lever_role_id: number;
   is_primary: boolean;
   result_lever_strategic_outcomes?: LeverStrategicOutcome[];
-  // Optional display fields when coming from control-list selections
+  result_lever_sdgs?: GetSdgs[];
   icon?: string;
   short_name?: string;
   other_names?: string;
@@ -100,8 +101,8 @@ export interface PatchOicr {
   extrapolate_estimates?: QuantificationPayload[];
   notable_references?: NotableReferencePayload[];
   result_impact_areas?: ResultImpactArea[];
-  for_external_use: boolean
-  for_external_use_description: string
+  for_external_use: boolean;
+  for_external_use_description: string;
 }
 
 export interface QuantificationPayload {

--- a/research-indicators/src/app/shared/interfaces/oicr-creation.interface.ts
+++ b/research-indicators/src/app/shared/interfaces/oicr-creation.interface.ts
@@ -1,6 +1,7 @@
 import { Country, Region } from './get-geo-location.interface';
 import { ResultImpactArea } from './impact-area.interface';
 import { GetSdgs } from './get-sdgs.interface';
+import { ResultLeverSdgTargetPayload } from './lever-sdg-target.interface';
 
 export interface OicrCreation {
   step_one: StepOne;
@@ -49,12 +50,17 @@ export interface Lever {
   is_primary: boolean;
   result_lever_strategic_outcomes?: LeverStrategicOutcome[];
   result_lever_sdgs?: GetSdgs[];
+  /** Primary levers: PATCH uses this list (not result_lever_sdgs). */
+  result_lever_sdg_targets?: ResultLeverSdgTargetPayload[];
   icon?: string;
   short_name?: string;
   other_names?: string;
 }
+/** Saved on result; list rows from GET lever-strategic-outcome/by-lever/:lever_id also include id + strategic_outcome. */
 export interface LeverStrategicOutcome {
   lever_strategic_outcome_id: number;
+  id?: number;
+  strategic_outcome?: string;
 }
 export interface StepTwo {
   primary_lever: Lever[];

--- a/research-indicators/src/app/shared/interfaces/result/map-v2-result-list-item.spec.ts
+++ b/research-indicators/src/app/shared/interfaces/result/map-v2-result-list-item.spec.ts
@@ -122,4 +122,10 @@ describe('mapV2ResultListItemToResult', () => {
     expect(r.result_official_code).toBe('');
     expect(r.indicator_id).toBe(0);
   });
+
+  it('maps public_link from v2 list row', () => {
+    const url = 'https://sharepoint.example.com/doc';
+    const r = mapV2ResultListItemToResult({ ...minimal, public_link: url });
+    expect(r.public_link).toBe(url);
+  });
 });

--- a/research-indicators/src/app/shared/interfaces/result/map-v2-result-list-item.spec.ts
+++ b/research-indicators/src/app/shared/interfaces/result/map-v2-result-list-item.spec.ts
@@ -1,0 +1,125 @@
+import { mapV2ResultListItemToResult, V2ResultListItem } from './map-v2-result-list-item';
+
+describe('mapV2ResultListItemToResult', () => {
+  const minimal: V2ResultListItem = {
+    result_id: 1,
+    result_official_code: 'R1',
+    platform_code: 'STAR',
+    title: 'T',
+    indicator_id: 2
+  };
+
+  it('maps a minimal row with defaults', () => {
+    const r = mapV2ResultListItemToResult(minimal);
+    expect(r.result_official_code).toBe('R1');
+    expect(r.is_active).toBe(false);
+    expect(r.snapshot_years).toEqual([]);
+    expect(r.result_status).toBeUndefined();
+    expect(r.result_contracts).toBeUndefined();
+    expect(r.created_by_user).toBeUndefined();
+    expect(r.result_levers).toBeUndefined();
+  });
+
+  it('normalizes snapshot_years when not an array', () => {
+    const r = mapV2ResultListItemToResult({ ...minimal, snapshot_years: null as unknown as number[] });
+    expect(r.snapshot_years).toEqual([]);
+  });
+
+  it('keeps snapshot_years when array', () => {
+    const r = mapV2ResultListItemToResult({ ...minimal, snapshot_years: [2023, 2024] });
+    expect(r.snapshot_years).toEqual([2023, 2024]);
+  });
+
+  it('sets is_active true for boolean true or numeric 1', () => {
+    expect(mapV2ResultListItemToResult({ ...minimal, is_active: true }).is_active).toBe(true);
+    expect(mapV2ResultListItemToResult({ ...minimal, is_active: 1 }).is_active).toBe(true);
+    expect(mapV2ResultListItemToResult({ ...minimal, is_active: false }).is_active).toBe(false);
+  });
+
+  it('maps status when status_id is set', () => {
+    const r = mapV2ResultListItemToResult({
+      ...minimal,
+      status_id: 9,
+      status_name: 'S',
+      status_description: 'D',
+      status_config: { color: 'blue' } as any
+    });
+    expect(r.result_status).toEqual({
+      result_status_id: 9,
+      name: 'S',
+      description: 'D',
+      config: { color: 'blue' }
+    });
+  });
+
+  it('maps indicators when indicator_name is set', () => {
+    const r = mapV2ResultListItemToResult({ ...minimal, indicator_name: 'Ind' });
+    expect(r.indicators).toEqual({ name: 'Ind', icon_src: '' });
+  });
+
+  it('maps contract when contract_id is set', () => {
+    const r = mapV2ResultListItemToResult({ ...minimal, contract_id: 'C1' });
+    expect(r.result_contracts).toEqual({ contract_id: 'C1', is_primary: 1 });
+  });
+
+  it('maps created_by_user when first or last name is non-empty', () => {
+    expect(
+      mapV2ResultListItemToResult({ ...minimal, create_user_first_name: ' A ' }).created_by_user
+    ).toEqual({ first_name: 'A', last_name: '' });
+    expect(
+      mapV2ResultListItemToResult({ ...minimal, create_user_last_name: ' B ' }).created_by_user
+    ).toEqual({ first_name: '', last_name: 'B' });
+  });
+
+  it('omits created_by_user when names are blank or null', () => {
+    expect(
+      mapV2ResultListItemToResult({ ...minimal, create_user_first_name: '   ', create_user_last_name: null }).created_by_user
+    ).toBeUndefined();
+    expect(mapV2ResultListItemToResult({ ...minimal, create_user_first_name: null, create_user_last_name: null }).created_by_user).toBeUndefined();
+  });
+
+  it('maps lever_name to result_levers', () => {
+    const r = mapV2ResultListItemToResult({ ...minimal, lever_name: 'L1' });
+    expect(r.result_levers).toEqual([{ is_primary: 1, lever: { short_name: 'L1' } }]);
+  });
+
+  it('coerces result_official_code to string', () => {
+    expect(mapV2ResultListItemToResult({ ...minimal, result_official_code: 99 }).result_official_code).toBe('99');
+  });
+
+  it('defaults result_id to 0 when missing', () => {
+    const { result_id: _, ...rest } = minimal;
+    const r = mapV2ResultListItemToResult(rest as V2ResultListItem);
+    expect(r.result_id).toBe(0);
+  });
+
+  it('maps status when status_id is 0', () => {
+    const r = mapV2ResultListItemToResult({ ...minimal, status_id: 0, status_name: 'Zero' });
+    expect(r.result_status?.result_status_id).toBe(0);
+  });
+
+  it('does not map contract when contract_id is empty string', () => {
+    const r = mapV2ResultListItemToResult({ ...minimal, contract_id: '' });
+    expect(r.result_contracts).toBeUndefined();
+  });
+
+  it('does not add levers when lever_name is empty string', () => {
+    const r = mapV2ResultListItemToResult({ ...minimal, lever_name: '' });
+    expect((r as any).result_levers).toBeUndefined();
+  });
+
+  it('normalizes snapshot_years when value is a non-array object', () => {
+    const r = mapV2ResultListItemToResult({ ...minimal, snapshot_years: {} as unknown as number[] });
+    expect(r.snapshot_years).toEqual([]);
+  });
+
+  it('applies nullish defaults when platform, title, code, result_id, and indicator_id are missing', () => {
+    const r = mapV2ResultListItemToResult({} as V2ResultListItem);
+    expect(r.result_id).toBe(0);
+    expect(r.result_platform).toBe('');
+    expect(r.platform_code).toBe('');
+    expect(r.title).toBe('');
+    expect(r.result_official_code).toBe('');
+    expect(r.indicator_id).toBe(0);
+  });
+});

--- a/research-indicators/src/app/shared/interfaces/result/map-v2-result-list-item.ts
+++ b/research-indicators/src/app/shared/interfaces/result/map-v2-result-list-item.ts
@@ -1,0 +1,72 @@
+import { StatusConfig } from '../result-config.interface';
+import { Result } from './result.interface';
+
+export interface V2ResultListItem {
+  created_at?: string;
+  updated_at?: string;
+  created_by?: number;
+  updated_by?: number;
+  is_active?: number | boolean;
+  result_id?: number;
+  result_official_code?: number | string;
+  platform_code?: string;
+  report_year_id?: number;
+  title?: string;
+  indicator_id?: number;
+  indicator_name?: string;
+  status_id?: number;
+  status_name?: string;
+  status_config?: StatusConfig;
+  status_description?: string;
+  snapshot_years?: number[] | null;
+  contract_id?: string | null;
+  lever_name?: string | null;
+  create_user_id?: number;
+  create_user_first_name?: string;
+  create_user_last_name?: string;
+  external_link?: string;
+}
+
+export function mapV2ResultListItemToResult(row: V2ResultListItem): Result {
+  const snapshotYears = row.snapshot_years;
+  const normalizedSnapshots = Array.isArray(snapshotYears) ? snapshotYears : [];
+
+  const hasCreator =
+    (row.create_user_first_name != null && String(row.create_user_first_name).trim() !== '') ||
+    (row.create_user_last_name != null && String(row.create_user_last_name).trim() !== '');
+
+  return {
+    is_active: row.is_active === true || row.is_active === 1,
+    result_id: row.result_id ?? 0,
+    result_platform: row.platform_code ?? '',
+    result_official_code: String(row.result_official_code ?? ''),
+    version_id: null,
+    title: row.title ?? '',
+    platform_code: row.platform_code ?? '',
+    external_link: row.external_link,
+    description: null,
+    indicator_id: row.indicator_id ?? 0,
+    geo_scope_id: null,
+    indicators: row.indicator_name ? { name: row.indicator_name, icon_src: '' } : undefined,
+    result_status:
+      row.status_id != null
+        ? {
+            result_status_id: row.status_id,
+            name: row.status_name,
+            description: row.status_description,
+            config: row.status_config
+          }
+        : undefined,
+    result_contracts: row.contract_id ? { contract_id: row.contract_id, is_primary: 1 } : undefined,
+    report_year_id: row.report_year_id,
+    created_by_user: hasCreator
+      ? {
+          first_name: (row.create_user_first_name ?? '').trim(),
+          last_name: (row.create_user_last_name ?? '').trim()
+        }
+      : undefined,
+    created_at: row.created_at,
+    snapshot_years: normalizedSnapshots,
+    ...(row.lever_name ? { result_levers: [{ is_primary: 1, lever: { short_name: row.lever_name } }] as unknown as Result['result_levers'] } : {})
+  } as Result;
+}

--- a/research-indicators/src/app/shared/interfaces/result/map-v2-result-list-item.ts
+++ b/research-indicators/src/app/shared/interfaces/result/map-v2-result-list-item.ts
@@ -25,6 +25,7 @@ export interface V2ResultListItem {
   create_user_first_name?: string;
   create_user_last_name?: string;
   external_link?: string;
+  public_link?: string;
 }
 
 export function mapV2ResultListItemToResult(row: V2ResultListItem): Result {
@@ -44,6 +45,7 @@ export function mapV2ResultListItemToResult(row: V2ResultListItem): Result {
     title: row.title ?? '',
     platform_code: row.platform_code ?? '',
     external_link: row.external_link,
+    public_link: row.public_link,
     description: null,
     indicator_id: row.indicator_id ?? 0,
     geo_scope_id: null,

--- a/research-indicators/src/app/shared/interfaces/result/result.interface.ts
+++ b/research-indicators/src/app/shared/interfaces/result/result.interface.ts
@@ -43,6 +43,30 @@ export interface ResultFilter {
   years?: number[];
 }
 
+export interface GetResultsPaginationOptions {
+  page?: number;
+  limit?: number;
+  sortField?: string;
+  sortOrder?: 'ASC' | 'DESC';
+  search?: string;
+}
+
+export interface V2ResultsPaginationMeta {
+  total: number;
+  page: number;
+  limit: number;
+  pageSize?: number;
+  totalPages: number;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+}
+
+export interface GetResultsResponseData {
+  results: Result[];
+  total: number;
+  pagination?: V2ResultsPaginationMeta;
+}
+
 export interface ResultConfig {
   indicators?: boolean;
   'result-status'?: boolean;

--- a/research-indicators/src/app/shared/interfaces/services.interface.ts
+++ b/research-indicators/src/app/shared/interfaces/services.interface.ts
@@ -50,6 +50,7 @@ export type ControlListServices =
   | 'applicationOptions'
   | 'levers'
   | 'leverStrategicOutcomes'
+  | 'leverSdgTargets'
   | 'projectStatus'
   | 'initiatives'
   | 'tags'

--- a/research-indicators/src/app/shared/services/api.service.spec.ts
+++ b/research-indicators/src/app/shared/services/api.service.spec.ts
@@ -1434,6 +1434,68 @@ describe('ApiService', () => {
       );
     });
 
+    it('should use indicator-codes when tabs and filter are empty', async () => {
+      const resultFilter = { 'indicator-codes': [7, 8] };
+      (mockToPromiseService.get as jest.Mock).mockResolvedValue({ data: { data: [], total: 0 } });
+
+      await service.GET_Results(resultFilter);
+
+      expect(mockToPromiseService.get).toHaveBeenCalledWith(`${v2Base}&indicators=7%2C8${ownFalse}`, {});
+    });
+
+    it('should set total from rows length when envelope has no total or pagination.total', async () => {
+      const row = {
+        result_id: 2,
+        result_official_code: 200,
+        platform_code: 'PRMS',
+        title: 'Row',
+        indicator_id: 1
+      };
+      (mockToPromiseService.get as jest.Mock).mockResolvedValue({
+        data: {
+          data: [row]
+        }
+      });
+
+      const out = await service.GET_Results({});
+
+      expect(out.data?.total).toBe(1);
+      expect(out.data?.results?.length).toBe(1);
+      expect(out.data?.pagination).toBeUndefined();
+    });
+
+    it('should use envelope total when data is not an array', async () => {
+      (mockToPromiseService.get as jest.Mock).mockResolvedValue({
+        data: {
+          data: { notAnArray: true } as unknown as [],
+          total: 42
+        }
+      });
+
+      const out = await service.GET_Results({});
+
+      expect(out.data?.total).toBe(42);
+      expect(out.data?.results?.length).toBe(0);
+    });
+
+    it('should unwrap when raw.data is a row array', async () => {
+      const row = {
+        result_id: 3,
+        result_official_code: 300,
+        platform_code: 'STAR',
+        title: 'Arr',
+        indicator_id: 1
+      };
+      (mockToPromiseService.get as jest.Mock).mockResolvedValue({
+        data: [row]
+      });
+
+      const out = await service.GET_Results({});
+
+      expect(out.data?.total).toBe(1);
+      expect(out.data?.results?.length).toBe(1);
+    });
+
     it('should unwrap v2 envelope with nested pagination.total for table totalRecords', async () => {
       const row = {
         result_id: 1,

--- a/research-indicators/src/app/shared/services/api.service.spec.ts
+++ b/research-indicators/src/app/shared/services/api.service.spec.ts
@@ -1600,6 +1600,24 @@ describe('ApiService', () => {
       expect(mockToPromiseService.get).toHaveBeenCalledWith('lever-strategic-outcome/by-lever/5', {});
     });
 
+    it('should call GET_LeverSdgTargets with only_sdg_targets query when second arg true (default)', () => {
+      (mockToPromiseService.get as jest.Mock).mockResolvedValue({ data: [] });
+      service.GET_LeverSdgTargets(3, true);
+      expect(mockToPromiseService.get).toHaveBeenCalledWith('lever-sdg-targets/by-lever/3?only_sdg_targets=true', {});
+    });
+
+    it('should call GET_LeverSdgTargets with default onlySdgTargets when second arg omitted', () => {
+      (mockToPromiseService.get as jest.Mock).mockResolvedValue({ data: [] });
+      service.GET_LeverSdgTargets(4);
+      expect(mockToPromiseService.get).toHaveBeenCalledWith('lever-sdg-targets/by-lever/4?only_sdg_targets=true', {});
+    });
+
+    it('should call GET_LeverSdgTargets without query when onlySdgTargets is false', () => {
+      (mockToPromiseService.get as jest.Mock).mockResolvedValue({ data: [] });
+      service.GET_LeverSdgTargets(3, false);
+      expect(mockToPromiseService.get).toHaveBeenCalledWith('lever-sdg-targets/by-lever/3', {});
+    });
+
     it('should call GET_AutorContact with resultCode', () => {
       (mockToPromiseService.get as jest.Mock).mockResolvedValue({ data: {} });
       service.GET_AutorContact(12345);

--- a/research-indicators/src/app/shared/services/api.service.spec.ts
+++ b/research-indicators/src/app/shared/services/api.service.spec.ts
@@ -1337,72 +1337,135 @@ describe('ApiService', () => {
   });
 
   describe('GET_Results method', () => {
-    it('should call GET_Results with basic filter', () => {
+    const v2Base = 'v2/results?page=1&limit=10000&sort-order=DESC&sort-field=code';
+    const ownFalse = '&only-own-results=false';
+
+    it('should call GET_Results with basic filter', async () => {
       const resultFilter = { 'indicator-codes-tabs': [101, 102] };
-      (mockToPromiseService.get as jest.Mock).mockResolvedValue({ data: [] });
+      (mockToPromiseService.get as jest.Mock).mockResolvedValue({ data: { data: [], total: 0 } });
 
-      service.GET_Results(resultFilter);
+      await service.GET_Results(resultFilter);
 
-      expect(mockToPromiseService.get).toHaveBeenCalledWith('results?sort-order=DESC&indicator-codes=101,102', {});
+      expect(mockToPromiseService.get).toHaveBeenCalledWith(`${v2Base}&indicators=101%2C102${ownFalse}`, {});
     });
 
-    it('should call GET_Results with indicator-codes-filter', () => {
+    it('should call GET_Results with indicator-codes-filter', async () => {
       const resultFilter = { 'indicator-codes-filter': [101, 102] };
-      (mockToPromiseService.get as jest.Mock).mockResolvedValue({ data: [] });
+      (mockToPromiseService.get as jest.Mock).mockResolvedValue({ data: { data: [], total: 0 } });
 
-      service.GET_Results(resultFilter);
+      await service.GET_Results(resultFilter);
 
-      expect(mockToPromiseService.get).toHaveBeenCalledWith('results?sort-order=DESC&indicator-codes=101,102', {});
+      expect(mockToPromiseService.get).toHaveBeenCalledWith(`${v2Base}&indicators=101%2C102${ownFalse}`, {});
     });
 
-    it('should call GET_Results with resultConfig', () => {
+    it('should call GET_Results with resultConfig (ignored in v2 query string)', async () => {
       const resultFilter = {};
       const resultConfig: import('../interfaces/result/result.interface').ResultConfig = { 'audit-data': true, 'result-status': false };
-      (mockToPromiseService.get as jest.Mock).mockResolvedValue({ data: [] });
+      (mockToPromiseService.get as jest.Mock).mockResolvedValue({ data: { data: [], total: 0 } });
 
-      service.GET_Results(resultFilter, resultConfig);
+      await service.GET_Results(resultFilter, resultConfig);
 
-      expect(mockToPromiseService.get).toHaveBeenCalledWith('results?sort-order=DESC&audit-data=true', {});
+      expect(mockToPromiseService.get).toHaveBeenCalledWith(`${v2Base}${ownFalse}`, {});
     });
 
-    it('should call GET_Results with complex filters', () => {
+    it('should call GET_Results with complex filters', async () => {
       const resultFilter: import('../interfaces/result/result.interface').ResultFilter = {
         'indicator-codes-tabs': [101],
         'status-codes': [1, 2],
         years: [2024]
       };
       const resultConfig: import('../interfaces/result/result.interface').ResultConfig = { 'audit-data': true };
-      (mockToPromiseService.get as jest.Mock).mockResolvedValue({ data: [] });
+      (mockToPromiseService.get as jest.Mock).mockResolvedValue({ data: { data: [], total: 0 } });
 
-      service.GET_Results(resultFilter, resultConfig);
+      await service.GET_Results(resultFilter, resultConfig);
 
       expect(mockToPromiseService.get).toHaveBeenCalledWith(
-        'results?sort-order=DESC&indicator-codes=101&audit-data=true&status-codes=1,2&years=2024',
+        `${v2Base}&indicators=101&status-codes=1%2C2&years=2024${ownFalse}`,
         {}
       );
     });
 
-    it('should call GET_Results with empty arrays', () => {
+    it('should call GET_Results with empty arrays', async () => {
       const resultFilter = {
         'indicator-codes-tabs': [],
         status: ['active']
       };
-      (mockToPromiseService.get as jest.Mock).mockResolvedValue({ data: [] });
+      (mockToPromiseService.get as jest.Mock).mockResolvedValue({ data: { data: [], total: 0 } });
 
-      service.GET_Results(resultFilter);
+      await service.GET_Results(resultFilter as import('../interfaces/result/result.interface').ResultFilter);
 
-      expect(mockToPromiseService.get).toHaveBeenCalledWith('results?sort-order=DESC&status=active', {});
+      expect(mockToPromiseService.get).toHaveBeenCalledWith(`${v2Base}&status=active${ownFalse}`, {});
     });
 
-    it('should call GET_Results with no parameters', () => {
+    it('should call GET_Results with no parameters', async () => {
       const resultFilter = {};
-      (mockToPromiseService.get as jest.Mock).mockResolvedValue({ data: [] });
+      (mockToPromiseService.get as jest.Mock).mockResolvedValue({ data: { data: [], total: 0 } });
 
-      service.GET_Results(resultFilter);
+      await service.GET_Results(resultFilter);
 
-      expect(mockToPromiseService.get).toHaveBeenCalledWith('results?sort-order=DESC', {});
+      expect(mockToPromiseService.get).toHaveBeenCalledWith(`${v2Base}${ownFalse}`, {});
     });
 
+    it('should map pagination and search query params', async () => {
+      (mockToPromiseService.get as jest.Mock).mockResolvedValue({ data: { data: [], total: 0 } });
+
+      await service.GET_Results({}, undefined, {
+        page: 2,
+        limit: 25,
+        sortField: 'result-title',
+        sortOrder: 'ASC',
+        search: 'hello world'
+      });
+
+      expect(mockToPromiseService.get).toHaveBeenCalledWith(
+        'v2/results?page=2&limit=25&sort-order=ASC&sort-field=result-title&search=hello%20world&only-own-results=false',
+        {}
+      );
+    });
+
+    it('should send only-own-results true when create-user-codes filter is set', async () => {
+      (mockToPromiseService.get as jest.Mock).mockResolvedValue({ data: { data: [], total: 0 } });
+
+      await service.GET_Results({ 'create-user-codes': ['356'] } as import('../interfaces/result/result.interface').ResultFilter);
+
+      expect(mockToPromiseService.get).toHaveBeenCalledWith(
+        'v2/results?page=1&limit=10000&sort-order=DESC&sort-field=code&only-own-results=true',
+        {}
+      );
+    });
+
+    it('should unwrap v2 envelope with nested pagination.total for table totalRecords', async () => {
+      const row = {
+        result_id: 1,
+        result_official_code: 100,
+        platform_code: 'PRMS',
+        title: 'T',
+        indicator_id: 1,
+        status_id: 4,
+        status_name: 'Draft'
+      };
+      (mockToPromiseService.get as jest.Mock).mockResolvedValue({
+        data: {
+          data: [row],
+          pagination: {
+            total: 3472,
+            page: 1,
+            limit: 25,
+            pageSize: 25,
+            totalPages: 139,
+            hasNextPage: true,
+            hasPreviousPage: false
+          }
+        }
+      });
+
+      const out = await service.GET_Results({}, undefined, { page: 1, limit: 25 });
+
+      expect(out.data?.total).toBe(3472);
+      expect(out.data?.results?.length).toBe(1);
+      expect(out.data?.pagination?.total).toBe(3472);
+      expect(out.data?.pagination?.hasNextPage).toBe(true);
+    });
   });
 
   describe('Additional GET methods', () => {

--- a/research-indicators/src/app/shared/services/api.service.ts
+++ b/research-indicators/src/app/shared/services/api.service.ts
@@ -3,7 +3,15 @@ import { ToPromiseService } from './to-promise.service';
 import { LoginRes, MainResponse } from '../interfaces/responses.interface';
 import { GetViewComponents, Indicator, IndicatorTypes } from '../interfaces/api.interface';
 import { GeneralInformation } from '@interfaces/result/general-information.interface';
-import { Result, ResultConfig, ResultFilter } from '../interfaces/result/result.interface';
+import {
+  GetResultsPaginationOptions,
+  GetResultsResponseData,
+  Result,
+  ResultConfig,
+  ResultFilter,
+  V2ResultsPaginationMeta
+} from '../interfaces/result/result.interface';
+import { mapV2ResultListItemToResult, V2ResultListItem } from '../interfaces/result/map-v2-result-list-item';
 import { ResultStatus } from '../interfaces/result-config.interface';
 import { GetInstitution } from '../interfaces/get-institutions.interface';
 import { PatchResultEvidences } from '../interfaces/patch-result-evidences.interface';
@@ -169,36 +177,83 @@ export class ApiService {
     return this.TP.get(url(), {});
   };
 
-  GET_Results = (resultFilter: ResultFilter, resultConfig?: ResultConfig): Promise<MainResponse<Result[]>> => {
-    const queryParams: string[] = ['sort-order=DESC'];
+  GET_Results = async (
+    resultFilter: ResultFilter,
+    _resultConfig?: ResultConfig,
+    pagination?: GetResultsPaginationOptions
+  ): Promise<MainResponse<GetResultsResponseData>> => {
+    const pairs: [string, string][] = [];
+
+    const page = Math.max(1, pagination?.page ?? 1);
+    const limit = Math.min(10_000, Math.max(1, pagination?.limit ?? 10_000));
+    pairs.push(['page', String(page)]);
+    pairs.push(['limit', String(limit)]);
+
+    const sortOrder = pagination?.sortOrder === 'ASC' ? 'ASC' : 'DESC';
+    pairs.push(['sort-order', sortOrder]);
+    pairs.push(['sort-field', pagination?.sortField?.trim() || 'code']);
+
+    const search = pagination?.search?.trim();
+    if (search) {
+      pairs.push(['search', search]);
+    }
 
     const indicatorKeysHandled = new Set(['indicator-codes', 'indicator-codes-tabs', 'indicator-codes-filter']);
 
     if (resultFilter['indicator-codes-tabs']?.length) {
-      queryParams.push(`indicator-codes=${resultFilter['indicator-codes-tabs'].join(',')}`);
+      pairs.push(['indicators', resultFilter['indicator-codes-tabs'].join(',')]);
     } else if (resultFilter['indicator-codes-filter']?.length) {
-      queryParams.push(`indicator-codes=${resultFilter['indicator-codes-filter'].join(',')}`);
-    }
-
-    if (resultConfig) {
-      Object.entries(resultConfig).forEach(([key, value]) => {
-        if (value) {
-          queryParams.push(`${key}=true`);
-        }
-      });
+      pairs.push(['indicators', resultFilter['indicator-codes-filter'].join(',')]);
+    } else if (resultFilter['indicator-codes']?.length) {
+      pairs.push(['indicators', resultFilter['indicator-codes'].join(',')]);
     }
 
     if (resultFilter) {
       Object.entries(resultFilter).forEach(([key, value]) => {
         if (indicatorKeysHandled.has(key)) return;
+        if (key === 'create-user-codes') return;
         if (Array.isArray(value) && value.length) {
-          queryParams.push(`${key}=${value.join(',')}`);
+          pairs.push([key, value.join(',')]);
         }
       });
     }
 
-    const url = () => `results?${queryParams.join('&')}`;
-    return this.TP.get(url(), {});
+    const onlyOwnResults =
+      Array.isArray(resultFilter?.['create-user-codes']) && resultFilter['create-user-codes'].length > 0;
+    pairs.push(['only-own-results', onlyOwnResults ? 'true' : 'false']);
+
+    const qs = pairs.map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`).join('&');
+    const raw = await this.TP.get(`v2/results?${qs}`, {});
+    return this.unwrapV2ResultsResponse(raw);
+  };
+
+  private unwrapV2ResultsResponse(raw: MainResponse<unknown>): MainResponse<GetResultsResponseData> {
+    const payload = raw?.data;
+    let rows: V2ResultListItem[] = [];
+    let total = 0;
+    let pagination: V2ResultsPaginationMeta | undefined;
+
+    if (payload != null && typeof payload === 'object' && !Array.isArray(payload) && 'data' in payload) {
+      const envelope = payload as { data?: unknown; total?: number; pagination?: V2ResultsPaginationMeta };
+      rows = Array.isArray(envelope.data) ? (envelope.data as V2ResultListItem[]) : [];
+      if (typeof envelope.pagination?.total === 'number') {
+        total = envelope.pagination.total;
+        pagination = envelope.pagination;
+      } else if (typeof envelope.total === 'number') {
+        total = envelope.total;
+      } else {
+        total = rows.length;
+      }
+    } else if (Array.isArray(payload)) {
+      rows = payload as V2ResultListItem[];
+      total = rows.length;
+    }
+
+    const results = rows.map(row => mapV2ResultListItemToResult(row));
+    return {
+      ...raw,
+      data: pagination ? { results, total, pagination } : { results, total }
+    };
   };
 
   GET_ValidateTitle = (title: string): Promise<MainResponse<{ isValid: boolean; result_official_code?: number; platform_code?: string }>> => {

--- a/research-indicators/src/app/shared/services/api.service.ts
+++ b/research-indicators/src/app/shared/services/api.service.ts
@@ -77,6 +77,7 @@ import { DateFormatApiResponse } from '@shared/interfaces/date-format-config.int
 import { GetTags } from '@shared/interfaces/get-tags.interface';
 import { GetOICRDetails } from '@shared/interfaces/gets/get-oicr-details.interface';
 import { LeverStrategicOutcome, Oicr, OicrCreation, PatchOicr } from '@shared/interfaces/oicr-creation.interface';
+import { LeverSdgTargetApi } from '@shared/interfaces/lever-sdg-target.interface';
 import { MaturityLevel } from '@shared/interfaces/maturity-level.interface';
 import { InteractionFeedbackPayload } from '@shared/interfaces/feedback-interaction.interface';
 import { ImpactArea } from '@shared/interfaces/impact-area.interface';
@@ -881,6 +882,13 @@ export class ApiService {
 
   GET_LeverStrategicOutcomes = (leverId: number): Promise<MainResponse<LeverStrategicOutcome[]>> => {
     const url = () => `lever-strategic-outcome/by-lever/${leverId}`;
+    return this.TP.get(url(), {});
+  };
+
+  /** SDG targets available for a lever (use with onlySdgTargets=true for target list only). */
+  GET_LeverSdgTargets = (leverId: number, onlySdgTargets = true): Promise<MainResponse<LeverSdgTargetApi[]>> => {
+    const q = onlySdgTargets ? '?only_sdg_targets=true' : '';
+    const url = () => `lever-sdg-targets/by-lever/${leverId}${q}`;
     return this.TP.get(url(), {});
   };
 

--- a/research-indicators/src/app/shared/services/control-list/get-innovation-dev-output.service.spec.ts
+++ b/research-indicators/src/app/shared/services/control-list/get-innovation-dev-output.service.spec.ts
@@ -50,7 +50,7 @@ describe('GetInnoDevOutputService', () => {
     service.list.set([]);
     apiService.GET_Results.mockResolvedValueOnce(Promise.resolve(mockResults));
     await service.main();
-    expect(service.list()).toEqual(mockResults.data);
+    expect(service.list()).toEqual(mockResults.data.results);
   });
 
   it('should set list to [] if response.data is falsy', async () => {

--- a/research-indicators/src/app/shared/services/control-list/get-innovation-dev-output.service.ts
+++ b/research-indicators/src/app/shared/services/control-list/get-innovation-dev-output.service.ts
@@ -24,7 +24,7 @@ export class GetInnoDevOutputService {
     const response = await this.api.GET_Results({
       'indicator-codes': [2]
     });
-    this.list.set(Array.isArray(response?.data) ? response.data : []);
+    this.list.set(response?.data?.results ?? []);
 
     this.loading.set(false);
   }

--- a/research-indicators/src/app/shared/services/control-list/get-innovation-use-output.service.spec.ts
+++ b/research-indicators/src/app/shared/services/control-list/get-innovation-use-output.service.spec.ts
@@ -50,7 +50,7 @@ describe('GetInnoUseOutputService', () => {
     service.list.set([]);
     apiService.GET_Results.mockResolvedValueOnce(Promise.resolve(mockResults));
     await service.main();
-    expect(service.list()).toEqual(mockResults.data);
+    expect(service.list()).toEqual(mockResults.data.results);
   });
 
   it('should set list to empty array when response has no data', async () => {

--- a/research-indicators/src/app/shared/services/control-list/get-innovation-use-output.service.ts
+++ b/research-indicators/src/app/shared/services/control-list/get-innovation-use-output.service.ts
@@ -24,7 +24,7 @@ export class GetInnoUseOutputService {
       'indicator-codes': [6]
     });
 
-    this.list.set(Array.isArray(response?.data) ? response.data : []);
+    this.list.set(response?.data?.results ?? []);
 
     this.loading.set(false);
   }

--- a/research-indicators/src/app/shared/services/control-list/get-lever-sdg-targets.service.spec.ts
+++ b/research-indicators/src/app/shared/services/control-list/get-lever-sdg-targets.service.spec.ts
@@ -1,0 +1,113 @@
+import { TestBed } from '@angular/core/testing';
+import { GetLeverSdgTargetsService } from './get-lever-sdg-targets.service';
+import { ApiService } from '../api.service';
+
+describe('GetLeverSdgTargetsService', () => {
+  let service: GetLeverSdgTargetsService;
+  let apiMock: { GET_LeverSdgTargets: jest.Mock };
+
+  beforeEach(() => {
+    apiMock = {
+      GET_LeverSdgTargets: jest.fn()
+    };
+
+    TestBed.configureTestingModule({
+      providers: [GetLeverSdgTargetsService, { provide: ApiService, useValue: apiMock }]
+    });
+
+    service = TestBed.inject(GetLeverSdgTargetsService);
+  });
+
+  it('should be created with default signals', () => {
+    expect(service).toBeTruthy();
+    expect(service.loading()).toBe(false);
+    expect(service.list()).toEqual([]);
+  });
+
+  it('isOpenSearch should be false', () => {
+    expect(service.isOpenSearch()).toBe(false);
+  });
+
+  it('getList/getLoading without lever_id should return default signals', () => {
+    expect(service.getList()).toBe(service.list);
+    expect(service.getLoading()).toBe(service.loading);
+  });
+
+  it('getList/getLoading with lever_id should return distinct per-id signals', () => {
+    const l1 = service.getList(1);
+    const l2 = service.getList(2);
+    expect(l1).not.toBe(l2);
+    expect(service.getLoading(1)).not.toBe(service.getLoading(2));
+  });
+
+  it('main without valid lever_id should clear default list and toggle default loading', async () => {
+    const spySet = jest.spyOn(service.list, 'set');
+    const spyLoadSet = jest.spyOn(service.loading, 'set');
+    await service.main();
+    expect(spyLoadSet).toHaveBeenNthCalledWith(1, true);
+    expect(spySet).toHaveBeenCalledWith([]);
+    expect(spyLoadSet).toHaveBeenLastCalledWith(false);
+  });
+
+  it('main with string lever id should call API and map rows with select_label', async () => {
+    apiMock.GET_LeverSdgTargets.mockResolvedValue({
+      data: [
+        { id: 1, sdg_target_code: '2.1', sdg_target: 'End hunger' },
+        { id: 2, sdg_target_code: '', sdg_target: 'Only label' }
+      ]
+    });
+    await service.main('10');
+    expect(apiMock.GET_LeverSdgTargets).toHaveBeenCalledWith(10, true);
+    const listSig = service.getList(10);
+    expect(listSig()).toEqual([
+      {
+        id: 1,
+        sdg_target_code: '2.1',
+        sdg_target: 'End hunger',
+        sdg_target_id: 1,
+        select_label: '2.1 — End hunger'
+      },
+      {
+        id: 2,
+        sdg_target_code: '',
+        sdg_target: 'Only label',
+        sdg_target_id: 2,
+        select_label: 'Only label'
+      }
+    ]);
+  });
+
+  it('main with lever_id should set empty list when API returns non-array data', async () => {
+    apiMock.GET_LeverSdgTargets.mockResolvedValue({ data: null });
+    const listSig = service.getList(4);
+    const spy = jest.spyOn(listSig, 'set');
+    await service.main(4);
+    expect(spy).toHaveBeenCalledWith([]);
+  });
+
+  it('main with lever_id should handle API error and set empty list', async () => {
+    apiMock.GET_LeverSdgTargets.mockRejectedValue(new Error('network'));
+    const listSig = service.getList(8);
+    const loadSig = service.getLoading(8);
+    await service.main(8);
+    expect(listSig()).toEqual([]);
+    expect(loadSig()).toBe(false);
+  });
+
+  it('main with non-finite string lever id should use default list path', async () => {
+    const spy = jest.spyOn(service.list, 'set');
+    await service.main('not-a-number');
+    expect(apiMock.GET_LeverSdgTargets).not.toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledWith([]);
+  });
+
+  it('mapRows returns empty array for null/undefined data', () => {
+    expect((service as any).mapRows(null)).toEqual([]);
+    expect((service as any).mapRows(undefined)).toEqual([]);
+  });
+
+  it('mapRows builds empty select_label when both code and title are blank', () => {
+    const rows = (service as any).mapRows([{ id: 9, sdg_target_code: '', sdg_target: '' }]);
+    expect(rows[0].select_label).toBe('');
+  });
+});

--- a/research-indicators/src/app/shared/services/control-list/get-lever-sdg-targets.service.ts
+++ b/research-indicators/src/app/shared/services/control-list/get-lever-sdg-targets.service.ts
@@ -1,15 +1,15 @@
 import { Injectable, inject, signal } from '@angular/core';
 import { ApiService } from '../api.service';
-import { LeverStrategicOutcome } from '@shared/interfaces/oicr-creation.interface';
+import { LeverSdgTargetApi, LeverSdgTargetOption } from '@shared/interfaces/lever-sdg-target.interface';
 
 @Injectable({ providedIn: 'root' })
-export class GetLeverStrategicOutcomesService {
+export class GetLeverSdgTargetsService {
   private readonly api = inject(ApiService);
   private readonly loadingStore = new Map<number, ReturnType<typeof signal<boolean>>>();
-  private readonly listStore = new Map<number, ReturnType<typeof signal<LeverStrategicOutcome[]>>>();
+  private readonly listStore = new Map<number, ReturnType<typeof signal<LeverSdgTargetOption[]>>>();
 
   loading = signal(false);
-  list = signal<LeverStrategicOutcome[]>([]);
+  list = signal<LeverSdgTargetOption[]>([]);
 
   isOpenSearch(): boolean {
     return false;
@@ -24,7 +24,7 @@ export class GetLeverStrategicOutcomesService {
   getList(lever_id?: number | string) {
     const id = this.coerceLeverId(lever_id);
     if (id === undefined) return this.list;
-    if (!this.listStore.has(id)) this.listStore.set(id, signal<LeverStrategicOutcome[]>([]));
+    if (!this.listStore.has(id)) this.listStore.set(id, signal<LeverSdgTargetOption[]>([]));
     return this.listStore.get(id)!;
   }
 
@@ -35,7 +35,14 @@ export class GetLeverStrategicOutcomesService {
     return this.loadingStore.get(id)!;
   }
 
-  /** Loads GET lever-strategic-outcome/by-lever/{lever_id} (see ApiService.GET_LeverStrategicOutcomes). */
+  private mapRows(data: LeverSdgTargetApi[]): LeverSdgTargetOption[] {
+    return (data ?? []).map(row => ({
+      ...row,
+      sdg_target_id: row.id,
+      select_label: [row.sdg_target_code, row.sdg_target].filter(Boolean).join(' — ')
+    }));
+  }
+
   async main(lever_id?: number | string) {
     const numericId = this.coerceLeverId(lever_id);
     if (numericId === undefined) {
@@ -51,8 +58,9 @@ export class GetLeverStrategicOutcomesService {
     const listSig = this.getList(numericId);
     loadingSig.set(true);
     try {
-      const res = await this.api.GET_LeverStrategicOutcomes(numericId);
-      listSig.set(Array.isArray(res?.data) ? res.data : []);
+      const res = await this.api.GET_LeverSdgTargets(numericId, true);
+      const rows = Array.isArray(res?.data) ? (res.data as LeverSdgTargetApi[]) : [];
+      listSig.set(this.mapRows(rows));
     } catch {
       listSig.set([]);
     } finally {
@@ -60,5 +68,3 @@ export class GetLeverStrategicOutcomesService {
     }
   }
 }
-
-

--- a/research-indicators/src/app/shared/services/control-list/get-lever-sdg-targets.service.ts
+++ b/research-indicators/src/app/shared/services/control-list/get-lever-sdg-targets.service.ts
@@ -59,7 +59,7 @@ export class GetLeverSdgTargetsService {
     loadingSig.set(true);
     try {
       const res = await this.api.GET_LeverSdgTargets(numericId, true);
-      const rows = Array.isArray(res?.data) ? (res.data as LeverSdgTargetApi[]) : [];
+      const rows = Array.isArray(res?.data) ? res.data : [];
       listSig.set(this.mapRows(rows));
     } catch {
       listSig.set([]);

--- a/research-indicators/src/app/shared/services/control-list/get-lever-strategic-outcomes.service.spec.ts
+++ b/research-indicators/src/app/shared/services/control-list/get-lever-strategic-outcomes.service.spec.ts
@@ -55,7 +55,7 @@ describe('GetLeverStrategicOutcomesService', () => {
   it('main without lever_id should set default list empty and toggle default loading', async () => {
     const spySet = jest.spyOn(service.list, 'set');
     const spyLoadSet = jest.spyOn(service.loading, 'set');
-    await service.main(undefined);
+    await service.main();
     expect(spyLoadSet).toHaveBeenNthCalledWith(1, true);
     expect(spySet).toHaveBeenCalledWith([]);
     expect(spyLoadSet).toHaveBeenLastCalledWith(false);
@@ -91,6 +91,20 @@ describe('GetLeverStrategicOutcomesService', () => {
     await service.main(9);
     expect(spyList).toHaveBeenCalledWith([]);
     expect(spyLoad).toHaveBeenLastCalledWith(false);
+  });
+
+  it('main with numeric string lever_id should coerce and call API', async () => {
+    apiMock.GET_LeverStrategicOutcomes.mockResolvedValue({ data: [{ id: 1 }] });
+    await service.main('11');
+    expect(apiMock.GET_LeverStrategicOutcomes).toHaveBeenCalledWith(11);
+    expect(service.getList(11)()).toEqual([{ id: 1 }]);
+  });
+
+  it('main with non-numeric string lever_id should clear default list without API call', async () => {
+    const spy = jest.spyOn(service.list, 'set');
+    await service.main('xyz');
+    expect(apiMock.GET_LeverStrategicOutcomes).not.toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledWith([]);
   });
 });
 

--- a/research-indicators/src/app/shared/services/control-list/get-results.service.spec.ts
+++ b/research-indicators/src/app/shared/services/control-list/get-results.service.spec.ts
@@ -5,7 +5,7 @@ import { ApiService } from '@services/api.service';
 
 describe('GetResultsService', () => {
   let service: GetResultsService;
-  let apiService: any;
+  let apiService: { GET_Results: jest.Mock };
 
   const mockData = [
     { id: 1, name: 'Result 1' },
@@ -13,7 +13,7 @@ describe('GetResultsService', () => {
   ];
 
   const mockResponse = {
-    data: mockData
+    data: { results: mockData, total: 2 }
   };
 
   beforeEach(() => {
@@ -40,13 +40,13 @@ describe('GetResultsService', () => {
 
   it('updateList sets loading and results correctly', async () => {
     await service.updateList();
-    expect(apiService.GET_Results).toHaveBeenCalledWith({});
+    expect(apiService.GET_Results).toHaveBeenCalledWith({}, undefined, { page: 1, limit: 10_000 });
     expect(service.results()).toEqual(mockData);
     expect(service.loading()).toBe(false);
   });
 
   it('updateList handles empty response', async () => {
-    apiService.GET_Results.mockResolvedValueOnce({ data: [] });
+    apiService.GET_Results.mockResolvedValueOnce({ data: { results: [], total: 0 } });
     await service.updateList();
     expect(service.results()).toEqual([]);
     expect(service.loading()).toBe(false);
@@ -73,87 +73,11 @@ describe('GetResultsService', () => {
     expect(service.loading()).toBe(false);
   });
 
-  it('updateList handles response with data not an array', async () => {
-    apiService.GET_Results.mockResolvedValueOnce({ data: 'not an array' });
+  it('updateList handles missing results array', async () => {
+    apiService.GET_Results.mockResolvedValueOnce({ data: { total: 0 } });
     await service.updateList();
     expect(service.results()).toEqual([]);
     expect(service.loading()).toBe(false);
-  });
-
-  it('updateList handles response with data as an object', async () => {
-    apiService.GET_Results.mockResolvedValueOnce({ data: { id: 1 } });
-    await service.updateList();
-    expect(service.results()).toEqual([]);
-    expect(service.loading()).toBe(false);
-  });
-
-  it('getInstance returns a signal with the data', async () => {
-    const filter: ResultFilter = {} as any;
-    const config: ResultConfig = {} as any;
-    apiService.GET_Results.mockResolvedValueOnce({ data: [{ id: 99 }] });
-
-    const result = await service.getInstance(filter, config);
-
-    expect(apiService.GET_Results).toHaveBeenCalledWith(filter, config);
-    expect(result()).toEqual([{ id: 99 }]);
-  });
-
-  it('getInstance without resultConfig', async () => {
-    const filter: ResultFilter = {} as any;
-    apiService.GET_Results.mockResolvedValueOnce({ data: [{ id: 77 }] });
-
-    const result = await service.getInstance(filter);
-
-    expect(apiService.GET_Results).toHaveBeenCalledWith(filter, undefined);
-    expect(result()).toEqual([{ id: 77 }]);
-  });
-
-  it('getInstance handles empty response', async () => {
-    apiService.GET_Results.mockResolvedValueOnce({ data: [] });
-
-    const result = await service.getInstance({} as any);
-
-    expect(result()).toEqual([]);
-  });
-
-  it('getInstance handles response null', async () => {
-    apiService.GET_Results.mockResolvedValueOnce({ data: null });
-
-    const result = await service.getInstance({} as any);
-
-    expect(result()).toEqual([]);
-  });
-
-  it('getInstance handles response undefined', async () => {
-    apiService.GET_Results.mockResolvedValueOnce(undefined);
-
-    const result = await service.getInstance({} as any);
-
-    expect(result()).toEqual([]);
-  });
-
-  it('getInstance handles response without data', async () => {
-    apiService.GET_Results.mockResolvedValueOnce({ status: 200 });
-
-    const result = await service.getInstance({} as any);
-
-    expect(result()).toEqual([]);
-  });
-
-  it('getInstance handles response with data not an array', async () => {
-    apiService.GET_Results.mockResolvedValueOnce({ data: 'not an array' });
-
-    const result = await service.getInstance({} as any);
-
-    expect(result()).toEqual([]);
-  });
-
-  it('getInstance handles response with data as an object', async () => {
-    apiService.GET_Results.mockResolvedValueOnce({ data: { id: 1 } });
-
-    const result = await service.getInstance({} as any);
-
-    expect(result()).toEqual([]);
   });
 
   it('updateList handles API error', async () => {
@@ -165,11 +89,42 @@ describe('GetResultsService', () => {
     expect(service.results()).toEqual([]);
   });
 
-  it('getInstance handles API error', async () => {
+  it('fetchPaginated returns results and total', async () => {
+    const filter: ResultFilter = {} as ResultFilter;
+    const config: ResultConfig = {} as ResultConfig;
+    const pagination = { page: 1, limit: 10, sortField: 'code' as const, sortOrder: 'DESC' as const };
+    apiService.GET_Results.mockResolvedValueOnce({ data: { results: [{ id: 99 }], total: 1 } });
+
+    const result = await service.fetchPaginated(filter, pagination, config);
+
+    expect(apiService.GET_Results).toHaveBeenCalledWith(filter, config, pagination);
+    expect(result).toEqual({ results: [{ id: 99 }], total: 1 });
+  });
+
+  it('fetchPaginated without resultConfig', async () => {
+    const filter: ResultFilter = {} as ResultFilter;
+    const pagination = { page: 2, limit: 5 };
+    apiService.GET_Results.mockResolvedValueOnce({ data: { results: [{ id: 77 }], total: 10 } });
+
+    const result = await service.fetchPaginated(filter, pagination, undefined);
+
+    expect(apiService.GET_Results).toHaveBeenCalledWith(filter, undefined, pagination);
+    expect(result).toEqual({ results: [{ id: 77 }], total: 10 });
+  });
+
+  it('fetchPaginated handles empty envelope', async () => {
+    apiService.GET_Results.mockResolvedValueOnce({ data: { results: [], total: 0 } });
+
+    const result = await service.fetchPaginated({} as ResultFilter, { page: 1, limit: 10 });
+
+    expect(result).toEqual({ results: [], total: 0 });
+  });
+
+  it('fetchPaginated handles API error', async () => {
     apiService.GET_Results.mockRejectedValueOnce(new Error('API Error'));
 
-    const result = await service.getInstance({} as any);
+    const result = await service.fetchPaginated({} as ResultFilter, { page: 1, limit: 10 });
 
-    expect(result()).toEqual([]);
+    expect(result).toEqual({ results: [], total: 0 });
   });
 });

--- a/research-indicators/src/app/shared/services/control-list/get-results.service.spec.ts
+++ b/research-indicators/src/app/shared/services/control-list/get-results.service.spec.ts
@@ -106,7 +106,7 @@ describe('GetResultsService', () => {
     const pagination = { page: 2, limit: 5 };
     apiService.GET_Results.mockResolvedValueOnce({ data: { results: [{ id: 77 }], total: 10 } });
 
-    const result = await service.fetchPaginated(filter, pagination, undefined);
+    const result = await service.fetchPaginated(filter, pagination);
 
     expect(apiService.GET_Results).toHaveBeenCalledWith(filter, undefined, pagination);
     expect(result).toEqual({ results: [{ id: 77 }], total: 10 });
@@ -126,5 +126,23 @@ describe('GetResultsService', () => {
     const result = await service.fetchPaginated({} as ResultFilter, { page: 1, limit: 10 });
 
     expect(result).toEqual({ results: [], total: 0 });
+  });
+
+  it('fetchPaginated defaults total to 0 when response.data.total is missing', async () => {
+    apiService.GET_Results.mockResolvedValueOnce({ data: { results: [{ id: 1 } as any] } });
+
+    const result = await service.fetchPaginated({} as ResultFilter, { page: 1, limit: 10 });
+
+    expect(result.results).toEqual([{ id: 1 }]);
+    expect(result.total).toBe(0);
+  });
+
+  it('fetchPaginated defaults results to [] when response.data.results is missing', async () => {
+    apiService.GET_Results.mockResolvedValueOnce({ data: { total: 5 } as any });
+
+    const result = await service.fetchPaginated({} as ResultFilter, { page: 1, limit: 10 });
+
+    expect(result.results).toEqual([]);
+    expect(result.total).toBe(5);
   });
 });

--- a/research-indicators/src/app/shared/services/control-list/get-results.service.ts
+++ b/research-indicators/src/app/shared/services/control-list/get-results.service.ts
@@ -1,6 +1,7 @@
 import { inject, Injectable, signal, WritableSignal } from '@angular/core';
 import { ApiService } from '@services/api.service';
-import { Result, ResultConfig, ResultFilter } from '@interfaces/result/result.interface';
+import { GetResultsPaginationOptions, Result, ResultConfig, ResultFilter } from '@interfaces/result/result.interface';
+
 @Injectable({
   providedIn: 'root'
 })
@@ -16,8 +17,8 @@ export class GetResultsService {
   updateList = async () => {
     this.loading.set(true);
     try {
-      const response = await this.api.GET_Results({});
-      this.results.set(Array.isArray(response?.data) ? response.data : []);
+      const response = await this.api.GET_Results({}, undefined, { page: 1, limit: 10_000 });
+      this.results.set(response?.data?.results ?? []);
     } catch {
       this.results.set([]);
     } finally {
@@ -25,14 +26,19 @@ export class GetResultsService {
     }
   };
 
-  getInstance = async (resultFilter: ResultFilter, resultConfig?: ResultConfig): Promise<WritableSignal<Result[]>> => {
-    const newSignal = signal<Result[]>([]);
+  fetchPaginated = async (
+    resultFilter: ResultFilter,
+    pagination: GetResultsPaginationOptions,
+    resultConfig?: ResultConfig
+  ): Promise<{ results: Result[]; total: number }> => {
     try {
-      const response = await this.api.GET_Results(resultFilter, resultConfig);
-      newSignal.set(Array.isArray(response?.data) ? response.data : []);
+      const response = await this.api.GET_Results(resultFilter, resultConfig, pagination);
+      return {
+        results: response?.data?.results ?? [],
+        total: response?.data?.total ?? 0
+      };
     } catch {
-      newSignal.set([]);
+      return { results: [], total: 0 };
     }
-    return newSignal;
   };
 }

--- a/research-indicators/src/app/shared/services/my-projects.service.spec.ts
+++ b/research-indicators/src/app/shared/services/my-projects.service.spec.ts
@@ -1522,6 +1522,7 @@ describe('MyProjectsService', () => {
 
   describe('onActiveItemChange', () => {
     it('should change filter item and reset filters', () => {
+      jest.clearAllMocks();
       const newItem: MenuItem = { id: 'my', label: 'My Projects' };
 
       service.onActiveItemChange(newItem);
@@ -1530,14 +1531,7 @@ describe('MyProjectsService', () => {
       expect(service.tableFilters()).toEqual(new MyProjectsFilters());
       expect(service.appliedFilters()).toEqual(new MyProjectsFilters());
       expect(service.searchInput()).toBe('');
-      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(
-        expect.objectContaining({
-          'current-user': true,
-          'with-indicators': false,
-          'order-field': 'contract-code',
-          direction: 'DESC'
-        })
-      );
+      expect(mockApiService.GET_FindContracts).not.toHaveBeenCalled();
     });
   });
 
@@ -1608,24 +1602,26 @@ describe('MyProjectsService', () => {
   });
 
   describe('clearAllFilters', () => {
-    it('should clear all filters and refresh', () => {
+    it('should clear all filters without fetching (caller reloads)', () => {
+      jest.clearAllMocks();
       service.clearAllFilters();
 
       expect(service.tableFilters()).toEqual(new MyProjectsFilters());
       expect(service.appliedFilters()).toEqual(new MyProjectsFilters());
       expect(service.searchInput()).toBe('');
-      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(expect.objectContaining({ 'current-user': false, page: 1, limit: 10 }));
+      expect(mockApiService.GET_FindContracts).not.toHaveBeenCalled();
     });
   });
 
   describe('clearFilters', () => {
-    it('should clear filters and refresh', () => {
+    it('should clear filters without fetching (caller reloads)', () => {
+      jest.clearAllMocks();
       service.clearFilters();
 
       expect(service.tableFilters()).toEqual(new MyProjectsFilters());
       expect(service.appliedFilters()).toEqual(new MyProjectsFilters());
       expect(service.searchInput()).toBe('');
-      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(expect.objectContaining({ 'current-user': false, page: 1, limit: 10 }));
+      expect(mockApiService.GET_FindContracts).not.toHaveBeenCalled();
     });
   });
 

--- a/research-indicators/src/app/shared/services/my-projects.service.spec.ts
+++ b/research-indicators/src/app/shared/services/my-projects.service.spec.ts
@@ -911,46 +911,50 @@ describe('MyProjectsService', () => {
     it('should set direction to DESC when direction is null', async () => {
       await service.main({ 'current-user': true, direction: null });
 
-      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(
-        expect.objectContaining({ direction: 'DESC', 'order-field': 'contract-code' })
-      );
+      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(expect.objectContaining({ direction: 'DESC', 'order-field': 'contract-code' }));
     });
 
     it('should set direction to DESC when direction is empty string', async () => {
       await service.main({ 'current-user': true, direction: '' });
 
-      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(
-        expect.objectContaining({ direction: 'DESC', 'order-field': 'contract-code' })
-      );
+      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(expect.objectContaining({ direction: 'DESC', 'order-field': 'contract-code' }));
     });
 
     it('should default order-field to contract-code when missing', async () => {
       await service.main({ 'current-user': false, page: 1, limit: 10 });
 
-      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(
-        expect.objectContaining({ 'order-field': 'contract-code', direction: 'DESC' })
-      );
+      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(expect.objectContaining({ 'order-field': 'contract-code', direction: 'DESC' }));
     });
 
     it('should keep explicit order-field when provided', async () => {
       await service.main({ 'current-user': false, 'order-field': 'project-name', direction: 'ASC' });
 
-      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(
-        expect.objectContaining({ 'order-field': 'project-name', direction: 'ASC' })
-      );
+      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(expect.objectContaining({ 'order-field': 'project-name', direction: 'ASC' }));
     });
 
     it('should not update list when tab changes during request', async () => {
       let resolveApi!: (value: any) => void;
       mockApiService.GET_FindContracts.mockImplementationOnce(
-        () => new Promise(resolve => { resolveApi = resolve; })
+        () =>
+          new Promise(resolve => {
+            resolveApi = resolve;
+          })
       );
 
       const mainPromise = service.main();
       service.myProjectsFilterItem.set({ id: 'different-tab', label: 'Other' });
       resolveApi({
         data: {
-          data: [{ agreement_id: 'X', projectDescription: 'P', description: 'D', project_lead_description: 'L', principal_investigator: 'PI', lever_name: 'Lv' }]
+          data: [
+            {
+              agreement_id: 'X',
+              projectDescription: 'P',
+              description: 'D',
+              project_lead_description: 'L',
+              principal_investigator: 'PI',
+              lever_name: 'Lv'
+            }
+          ]
         }
       });
       await mainPromise;

--- a/research-indicators/src/app/shared/services/my-projects.service.spec.ts
+++ b/research-indicators/src/app/shared/services/my-projects.service.spec.ts
@@ -240,7 +240,13 @@ describe('MyProjectsService', () => {
     it('should fetch and process data successfully', async () => {
       await service.main();
 
-      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith({ 'with-indicators': false });
+      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(
+        expect.objectContaining({
+          'with-indicators': false,
+          'order-field': 'contract-code',
+          direction: 'DESC'
+        })
+      );
       expect(service.loading()).toBe(false);
       expect(service.list()).toHaveLength(2);
 
@@ -557,14 +563,18 @@ describe('MyProjectsService', () => {
       consoleSpy.mockRestore();
     });
 
-    it('should call API with custom params', async () => {
+    it('should call API with custom params and default sort', async () => {
       const customParams = { 'test-param': 'test-value' };
       await service.main(customParams);
 
-      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith({
-        ...customParams,
-        'with-indicators': false
-      });
+      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ...customParams,
+          'with-indicators': false,
+          'order-field': 'contract-code',
+          direction: 'DESC'
+        })
+      );
     });
 
     it('should handle item with no principal_investigator and no project_lead_description', async () => {
@@ -898,19 +908,35 @@ describe('MyProjectsService', () => {
   });
 
   describe('main method - direction and tab-change branches', () => {
-    it('should set direction to DESC when current-user is true and direction is null', async () => {
+    it('should set direction to DESC when direction is null', async () => {
       await service.main({ 'current-user': true, direction: null });
 
       expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(
-        expect.objectContaining({ direction: 'DESC' })
+        expect.objectContaining({ direction: 'DESC', 'order-field': 'contract-code' })
       );
     });
 
-    it('should set direction to DESC when current-user is true and direction is empty string', async () => {
+    it('should set direction to DESC when direction is empty string', async () => {
       await service.main({ 'current-user': true, direction: '' });
 
       expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(
-        expect.objectContaining({ direction: 'DESC' })
+        expect.objectContaining({ direction: 'DESC', 'order-field': 'contract-code' })
+      );
+    });
+
+    it('should default order-field to contract-code when missing', async () => {
+      await service.main({ 'current-user': false, page: 1, limit: 10 });
+
+      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(
+        expect.objectContaining({ 'order-field': 'contract-code', direction: 'DESC' })
+      );
+    });
+
+    it('should keep explicit order-field when provided', async () => {
+      await service.main({ 'current-user': false, 'order-field': 'project-name', direction: 'ASC' });
+
+      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(
+        expect.objectContaining({ 'order-field': 'project-name', direction: 'ASC' })
       );
     });
 
@@ -1504,11 +1530,14 @@ describe('MyProjectsService', () => {
       expect(service.tableFilters()).toEqual(new MyProjectsFilters());
       expect(service.appliedFilters()).toEqual(new MyProjectsFilters());
       expect(service.searchInput()).toBe('');
-      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith({
-        'current-user': true,
-        'with-indicators': false,
-        direction: 'DESC'
-      });
+      expect(mockApiService.GET_FindContracts).toHaveBeenCalledWith(
+        expect.objectContaining({
+          'current-user': true,
+          'with-indicators': false,
+          'order-field': 'contract-code',
+          direction: 'DESC'
+        })
+      );
     });
   });
 

--- a/research-indicators/src/app/shared/services/my-projects.service.ts
+++ b/research-indicators/src/app/shared/services/my-projects.service.ts
@@ -126,10 +126,13 @@ export class MyProjectsService {
         ...(params ?? {})
       };
 
-      if (finalParams['current-user'] === true) {
-        if (!('direction' in finalParams) || finalParams['direction'] == null || finalParams['direction'] === '') {
-          finalParams['direction'] = 'DESC';
-        }
+      const orderFieldRaw = finalParams['order-field'];
+      if (orderFieldRaw == null || orderFieldRaw === '') {
+        finalParams['order-field'] = 'contract-code';
+      }
+
+      if (finalParams['direction'] == null || finalParams['direction'] === '') {
+        finalParams['direction'] = 'DESC';
       }
 
       const response = await this.api.GET_FindContracts(finalParams);
@@ -216,11 +219,10 @@ export class MyProjectsService {
       params['end-date'] = endDate.toISOString().slice(0, 23);
     }
 
-    // Add sort parameters
-    if (pagination?.sortField) {
-      params['order-field'] = pagination.sortField;
-      params['direction'] = pagination.sortOrder === 1 ? 'ASC' : 'DESC';
-    }
+    const sortField = pagination?.sortField;
+    params['order-field'] =
+      sortField != null && String(sortField).trim() !== '' ? sortField : 'contract-code';
+    params['direction'] = pagination?.sortOrder === 1 ? 'ASC' : 'DESC';
 
     this.appliedFilters.set({ ...filters });
 

--- a/research-indicators/src/app/shared/services/my-projects.service.ts
+++ b/research-indicators/src/app/shared/services/my-projects.service.ts
@@ -345,7 +345,6 @@ export class MyProjectsService {
   onActiveItemChange = (event: MenuItem): void => {
     this.myProjectsFilterItem.set(event);
     this.resetFilters();
-    this.main(this.getBaseParams());
   };
 
   showFilterSidebar(): void {
@@ -369,12 +368,10 @@ export class MyProjectsService {
 
   clearAllFilters() {
     this.resetFilters();
-    this.main({ ...this.getBaseParams(), page: 1, limit: 10 });
   }
 
   clearFilters() {
     this.resetFilters();
-    this.main({ ...this.getBaseParams(), page: 1, limit: 10 });
   }
 
   refresh() {

--- a/research-indicators/src/app/shared/services/my-projects.service.ts
+++ b/research-indicators/src/app/shared/services/my-projects.service.ts
@@ -220,8 +220,7 @@ export class MyProjectsService {
     }
 
     const sortField = pagination?.sortField;
-    params['order-field'] =
-      sortField != null && String(sortField).trim() !== '' ? sortField : 'contract-code';
+    params['order-field'] = sortField != null && String(sortField).trim() !== '' ? sortField : 'contract-code';
     params['direction'] = pagination?.sortOrder === 1 ? 'ASC' : 'DESC';
 
     this.appliedFilters.set({ ...filters });
@@ -339,7 +338,6 @@ export class MyProjectsService {
         // do nothing
       }
     }
-
   }
 
   onActiveItemChange = (event: MenuItem): void => {

--- a/research-indicators/src/app/shared/services/service-locator.service.spec.ts
+++ b/research-indicators/src/app/shared/services/service-locator.service.spec.ts
@@ -496,6 +496,18 @@ describe('ServiceLocatorService', () => {
       expect(result).toBe(serviceMock);
     });
 
+    it('returns leverSdgTargets service', () => {
+      const result = (service as any).getOtherServices('leverSdgTargets');
+      expect(injectorMock.get).toHaveBeenCalled();
+      expect(result).toBe(serviceMock);
+    });
+
+    it('returns sourceFilterOptions service', () => {
+      const result = (service as any).getOtherServices('sourceFilterOptions');
+      expect(injectorMock.get).toHaveBeenCalled();
+      expect(result).toBe(serviceMock);
+    });
+
     it('returns projectStatus service', () => {
       const result = (service as any).getOtherServices('projectStatus');
       expect(injectorMock.get).toHaveBeenCalled();

--- a/research-indicators/src/app/shared/services/service-locator.service.ts
+++ b/research-indicators/src/app/shared/services/service-locator.service.ts
@@ -53,6 +53,7 @@ import { OicrResultsService } from './short-control-list/oicr-results.service';
 import { GetMaturityLevelsService } from './control-list/get-maturity-levels.service';
 import { GetAllianceStaffByGroupService } from './control-list/get-alliance-staff-by-group.service';
 import { GetLeverStrategicOutcomesService } from './control-list/get-lever-strategic-outcomes.service';
+import { GetLeverSdgTargetsService } from './control-list/get-lever-sdg-targets.service';
 import { NotableReferenceTypesService } from './short-control-list/notable-reference-types.service';
 import { InformativeRolesService } from './short-control-list/informative-roles.service';
 import { GlobalTargetsService } from './short-control-list/global-targets.service';
@@ -240,6 +241,8 @@ export class ServiceLocatorService {
         return this.injector.get(GetLeversService);
       case 'leverStrategicOutcomes':
         return this.injector.get(GetLeverStrategicOutcomesService);
+      case 'leverSdgTargets':
+        return this.injector.get(GetLeverSdgTargetsService);
       case 'projectStatus':
         return this.injector.get(GetProjectStatusService);
       case 'allianceStaffByGroup':

--- a/research-indicators/src/app/shared/services/short-control-list/base-results.service.ts
+++ b/research-indicators/src/app/shared/services/short-control-list/base-results.service.ts
@@ -39,8 +39,8 @@ export abstract class BaseResultsService {
   async main() {
     this.loading.set(true);
     try {
-      const response = await this.apiService.GET_Results(this.resultsFilter, this.resultsConfig);
-      const data = Array.isArray(response?.data) ? response.data : [];
+      const response = await this.apiService.GET_Results(this.resultsFilter, this.resultsConfig, { page: 1, limit: 10_000 });
+      const data = response?.data?.results ?? [];
       const dataWithLabel = data.map((item: Result) => ({
         ...item,
         select_label: `${item.result_official_code || ''} - ${item.title || ''}`.trim()

--- a/research-indicators/src/app/shared/services/short-control-list/inn-results.service.spec.ts
+++ b/research-indicators/src/app/shared/services/short-control-list/inn-results.service.spec.ts
@@ -27,7 +27,7 @@ describe('InnResultsService', () => {
     await Promise.resolve();
   };
 
-  const wrapResponse = (data: any[]) => ({ data });
+  const wrapResponse = (data: any[]) => ({ data: { results: data, total: data.length } });
 
   it('should create', async () => {
     await setup(wrapResponse([]));
@@ -40,7 +40,7 @@ describe('InnResultsService', () => {
       { id: 2, result_official_code: 'R-002', title: 'Result B' }
     ];
     await setup(wrapResponse(data));
-    expect(apiMock.GET_Results).toHaveBeenCalledWith(defaultFilter, defaultConfig);
+    expect(apiMock.GET_Results).toHaveBeenCalledWith(defaultFilter, defaultConfig, { page: 1, limit: 10000 });
     expect(service.list().length).toBe(2);
     expect((service.list()[0] as any).select_label).toBe('R-001 - Result A');
     expect(service.loading()).toBe(false);
@@ -88,7 +88,7 @@ describe('InnResultsService', () => {
 
     apiMock.GET_Results.mockResolvedValueOnce(wrapResponse([]));
     await service.main();
-    expect(apiMock.GET_Results).toHaveBeenCalledWith(defaultFilter, defaultConfig);
+    expect(apiMock.GET_Results).toHaveBeenCalledWith(defaultFilter, defaultConfig, { page: 1, limit: 10000 });
     expect(service.loading()).toBe(false);
   });
 });

--- a/research-indicators/src/app/shared/utils/map-link-other-result-to-result.spec.ts
+++ b/research-indicators/src/app/shared/utils/map-link-other-result-to-result.spec.ts
@@ -1,0 +1,191 @@
+import { mapOtherResultLinkPayloadToResult } from './map-link-other-result-to-result';
+import { OtherResultLinkPayload } from '@interfaces/link-results.interface';
+
+describe('mapOtherResultLinkPayloadToResult', () => {
+  const base: OtherResultLinkPayload = {
+    result_id: 1,
+    result_official_code: 'R-1',
+    platform_code: 'STAR',
+    title: 'Title'
+  };
+
+  it('maps minimal payload', () => {
+    const r = mapOtherResultLinkPayloadToResult(base);
+    expect(r.result_id).toBe(1);
+    expect(r.result_official_code).toBe('R-1');
+    expect(r.is_active).toBe(true);
+    expect(r.result_status).toBeUndefined();
+    expect(r.indicators).toBeUndefined();
+    expect(r.result_contracts).toBeUndefined();
+  });
+
+  it('defaults platform and title when missing and normalizes optional links', () => {
+    const r = mapOtherResultLinkPayloadToResult({
+      result_id: 2,
+      result_official_code: 9,
+      external_link: null,
+      public_link: null,
+      description: undefined
+    } as OtherResultLinkPayload);
+    expect(r.result_platform).toBe('');
+    expect(r.platform_code).toBe('');
+    expect(r.title).toBe('');
+    expect(r.external_link).toBeUndefined();
+    expect(r.public_link).toBeUndefined();
+    expect(r.description).toBeNull();
+  });
+
+  it('stringifies undefined result_official_code as empty', () => {
+    const r = mapOtherResultLinkPayloadToResult({
+      result_id: 1,
+      result_official_code: undefined as unknown as string
+    } as OtherResultLinkPayload);
+    expect(r.result_official_code).toBe('');
+  });
+
+  it('uses result_status object when present', () => {
+    const r = mapOtherResultLinkPayloadToResult({
+      ...base,
+      result_status: {
+        result_status_id: 5,
+        name: 'N',
+        description: 'D',
+        action_description: 'A',
+        editable_roles: undefined,
+        config: undefined
+      }
+    });
+    expect(r.result_status?.result_status_id).toBe(5);
+    expect(r.result_status?.name).toBe('N');
+    expect(r.result_status?.editable_roles).toBeUndefined();
+  });
+
+  it('builds result_status from result_status_id when object absent', () => {
+    const r = mapOtherResultLinkPayloadToResult({
+      ...base,
+      result_status_id: 3,
+      status_name: 'Sn',
+      status_description: 'Sd',
+      status_config: { color: 'x' } as any
+    });
+    expect(r.result_status).toEqual({
+      result_status_id: 3,
+      name: 'Sn',
+      description: 'Sd',
+      config: { color: 'x' }
+    });
+  });
+
+  it('uses indicator object when present', () => {
+    const r = mapOtherResultLinkPayloadToResult({
+      ...base,
+      indicator: { indicator_id: 9, name: 'IN', icon_src: '/i.png' }
+    });
+    expect(r.indicators).toEqual({ name: 'IN', icon_src: '/i.png' });
+    expect(r.indicator_id).toBe(9);
+  });
+
+  it('uses indicator defaults when indicator has missing fields', () => {
+    const r = mapOtherResultLinkPayloadToResult({
+      ...base,
+      indicator: {}
+    });
+    expect(r.indicators).toEqual({ name: '', icon_src: '' });
+  });
+
+  it('uses indicator_name when indicator object absent', () => {
+    const r = mapOtherResultLinkPayloadToResult({
+      ...base,
+      indicator_name: 'ByName',
+      indicator_icon_src: '/z.svg'
+    });
+    expect(r.indicators).toEqual({ name: 'ByName', icon_src: '/z.svg' });
+  });
+
+  it('uses empty icon_src when indicator_name path has no icon', () => {
+    const r = mapOtherResultLinkPayloadToResult({
+      ...base,
+      indicator_name: 'OnlyName'
+    });
+    expect(r.indicators).toEqual({ name: 'OnlyName', icon_src: '' });
+  });
+
+  it('picks primary contract when is_primary is 1', () => {
+    const r = mapOtherResultLinkPayloadToResult({
+      ...base,
+      result_contracts: [
+        { contract_id: 'A', is_primary: 0, agresso_contract: { description: 'Long' } },
+        { contract_id: 'B', is_primary: 1, agresso_contract: { short_title: 'Short' } }
+      ]
+    });
+    expect(r.result_contracts?.contract_id).toBe('B');
+    expect((r.result_contracts as any)?.contract?.description).toBe('Short');
+  });
+
+  it('falls back to first contract when no primary', () => {
+    const r = mapOtherResultLinkPayloadToResult({
+      ...base,
+      result_contracts: [{ contract_id: 'Only', is_primary: 0, agresso_contract: { description: 'D1' } }]
+    });
+    expect(r.result_contracts?.contract_id).toBe('Only');
+    expect((r.result_contracts as any)?.contract?.description).toBe('D1');
+  });
+
+  it('prefers agresso description over short_title for project label', () => {
+    const r = mapOtherResultLinkPayloadToResult({
+      ...base,
+      result_contracts: [
+        {
+          contract_id: 'C',
+          is_primary: 1,
+          agresso_contract: { description: 'Full', short_title: 'Short' }
+        }
+      ]
+    });
+    expect((r.result_contracts as any)?.contract?.description).toBe('Full');
+  });
+
+  it('uses short_title when description missing', () => {
+    const r = mapOtherResultLinkPayloadToResult({
+      ...base,
+      result_contracts: [{ contract_id: 'C', is_primary: 1, agresso_contract: { short_title: 'ST' } }]
+    });
+    expect((r.result_contracts as any)?.contract?.description).toBe('ST');
+  });
+
+  it('omits nested contract label when primary has no agresso fields', () => {
+    const r = mapOtherResultLinkPayloadToResult({
+      ...base,
+      result_contracts: [{ contract_id: 'C', is_primary: 1 }]
+    });
+    expect(r.result_contracts?.contract_id).toBe('C');
+    expect((r.result_contracts as any)?.contract).toBeUndefined();
+  });
+
+  it('sets is_active from payload', () => {
+    expect(mapOtherResultLinkPayloadToResult({ ...base, is_active: false }).is_active).toBe(false);
+  });
+
+  it('maps optional links and description', () => {
+    const r = mapOtherResultLinkPayloadToResult({
+      ...base,
+      external_link: 'https://x',
+      public_link: 'https://p',
+      description: 'Desc',
+      report_year_id: 2025
+    });
+    expect(r.external_link).toBe('https://x');
+    expect(r.public_link).toBe('https://p');
+    expect(r.description).toBe('Desc');
+    expect(r.report_year_id).toBe(2025);
+  });
+
+  it('uses indicator_id when indicator object has no id', () => {
+    const r = mapOtherResultLinkPayloadToResult({
+      ...base,
+      indicator_id: 42,
+      indicator: { name: 'N' }
+    });
+    expect(r.indicator_id).toBe(42);
+  });
+});

--- a/research-indicators/src/app/shared/utils/map-link-other-result-to-result.ts
+++ b/research-indicators/src/app/shared/utils/map-link-other-result-to-result.ts
@@ -1,0 +1,69 @@
+import { Result } from '@interfaces/result/result.interface';
+import { OtherResultLinkPayload } from '@interfaces/link-results.interface';
+import { ResultStatus } from '@interfaces/result-config.interface';
+
+function buildResultStatusFromLinkPayload(other: OtherResultLinkPayload): ResultStatus | undefined {
+  if (other.result_status) {
+    return {
+      result_status_id: other.result_status.result_status_id,
+      name: other.result_status.name,
+      description: other.result_status.description,
+      action_description: other.result_status.action_description,
+      editable_roles: other.result_status.editable_roles ?? undefined,
+      config: other.result_status.config
+    };
+  }
+  if (typeof other.result_status_id === 'number') {
+    return {
+      result_status_id: other.result_status_id,
+      name: other.status_name,
+      description: other.status_description,
+      config: other.status_config
+    };
+  }
+  return undefined;
+}
+
+function buildIndicatorsFromLinkPayload(other: OtherResultLinkPayload): Result['indicators'] {
+  if (other.indicator) {
+    return { name: other.indicator.name ?? '', icon_src: other.indicator.icon_src ?? '' };
+  }
+  if (other.indicator_name) {
+    return { name: other.indicator_name, icon_src: other.indicator_icon_src ?? '' };
+  }
+  return undefined;
+}
+
+export function mapOtherResultLinkPayloadToResult(other: OtherResultLinkPayload): Result {
+  const contracts = other.result_contracts;
+  const primary = Array.isArray(contracts) ? (contracts.find(c => Number(c.is_primary) === 1) ?? contracts[0]) : undefined;
+  const projectLabel = primary?.agresso_contract?.description ?? primary?.agresso_contract?.short_title ?? undefined;
+
+  const resultStatus = buildResultStatusFromLinkPayload(other);
+  const indicators = buildIndicatorsFromLinkPayload(other);
+
+  return {
+    is_active: other.is_active ?? true,
+    result_id: other.result_id,
+    result_platform: other.platform_code ?? '',
+    result_official_code: String(other.result_official_code ?? ''),
+    version_id: null,
+    title: other.title ?? '',
+    platform_code: other.platform_code ?? '',
+    external_link: other.external_link ?? undefined,
+    public_link: other.public_link ?? undefined,
+    description: other.description ?? null,
+    indicator_id: other.indicator?.indicator_id ?? other.indicator_id ?? 0,
+    geo_scope_id: null,
+    indicators,
+    result_status: resultStatus,
+    result_contracts: primary?.contract_id
+      ? {
+          contract_id: primary.contract_id,
+          is_primary: Number(primary.is_primary) || 1,
+          contract: projectLabel ? { description: projectLabel } : undefined
+        }
+      : undefined,
+    report_year_id: other.report_year_id
+  };
+}

--- a/research-indicators/src/app/testing/mock-services.mock.spec.ts
+++ b/research-indicators/src/app/testing/mock-services.mock.spec.ts
@@ -382,7 +382,13 @@ describe('mock-services.mock', () => {
       expect(contracts).toEqual({ data: [] });
 
       const results = await apiServiceMock.GET_Results();
-      expect(results).toEqual({ data: [] });
+      expect(results).toEqual({ data: { results: [], total: 0 } });
+
+      const userStaff = await apiServiceMock.GET_UserStaff();
+      expect(userStaff).toEqual({ data: [] });
+
+      const findContracts = await apiServiceMock.GET_FindContracts();
+      expect(findContracts).toEqual({ data: [] });
 
       const institutionsTypesChildless = await apiServiceMock.GET_InstitutionsTypesChildless();
       expect(institutionsTypesChildless).toEqual({ data: [] });

--- a/research-indicators/src/app/testing/mock-services.mock.ts
+++ b/research-indicators/src/app/testing/mock-services.mock.ts
@@ -523,7 +523,7 @@ export const apiServiceMock = {
   GET_IndicatorTypes: jest.fn().mockImplementation(() => Promise.resolve({ data: [] })),
   GET_Years: jest.fn().mockImplementation(() => Promise.resolve({ data: [] })),
   GET_Contracts: jest.fn().mockImplementation(() => Promise.resolve({ data: [] })),
-  GET_Results: jest.fn().mockImplementation(() => Promise.resolve({ data: [] })),
+  GET_Results: jest.fn().mockImplementation(() => Promise.resolve({ data: { results: [], total: 0 } })),
   GET_IpOwners: jest.fn().mockResolvedValue({ data: [] }),
   GET_InstitutionsTypes: jest.fn().mockImplementation(() => Promise.resolve(mockInstitutionsTypes)),
   GET_Languages: jest.fn().mockImplementation(() => Promise.resolve(mockLanguages)),

--- a/research-indicators/src/app/testing/mock-services.mock.ts
+++ b/research-indicators/src/app/testing/mock-services.mock.ts
@@ -360,28 +360,31 @@ export const mockResults = {
     detail: '',
     description: ''
   },
-  data: [
-    {
-      is_active: true,
-      result_id: 1,
-      result_official_code: 'R001',
-      version_id: null,
-      title: 'Innovación 1',
-      description: 'Desc 1',
-      indicator_id: 2,
-      geo_scope_id: null
-    },
-    {
-      is_active: false,
-      result_id: 2,
-      result_official_code: 'R002',
-      version_id: null,
-      title: 'Innovación 2',
-      description: null,
-      indicator_id: 2,
-      geo_scope_id: null
-    }
-  ]
+  data: {
+    results: [
+      {
+        is_active: true,
+        result_id: 1,
+        result_official_code: 'R001',
+        version_id: null,
+        title: 'Innovación 1',
+        description: 'Desc 1',
+        indicator_id: 2,
+        geo_scope_id: null
+      },
+      {
+        is_active: false,
+        result_id: 2,
+        result_official_code: 'R002',
+        version_id: null,
+        title: 'Innovación 2',
+        description: null,
+        indicator_id: 2,
+        geo_scope_id: null
+      }
+    ],
+    total: 2
+  }
 };
 
 export const mockInstitutionsTypes = {

--- a/research-indicators/src/styles/custom-fields.scss
+++ b/research-indicators/src/styles/custom-fields.scss
@@ -51,9 +51,14 @@
   font-family: Barlow, sans-serif !important;
 }
 
-.p-select-option,
-.p-multiselect-option {
+.p-select-option {
   align-items: flex-start !important;
+  white-space: normal !important;
+  overflow: visible !important;
+}
+
+.p-multiselect-option {
+  align-items: center !important;
   white-space: normal !important;
   overflow: visible !important;
 }

--- a/research-indicators/src/styles/custom-fields.scss
+++ b/research-indicators/src/styles/custom-fields.scss
@@ -51,6 +51,21 @@
   font-family: Barlow, sans-serif !important;
 }
 
+.p-select-option,
+.p-multiselect-option {
+  align-items: flex-start !important;
+  white-space: normal !important;
+  overflow: visible !important;
+}
+
+.p-multiselect-option > * {
+  min-width: 0;
+}
+
+.p-multiselect-overlay {
+  overflow-wrap: break-word;
+}
+
 .label,
 body .label,
 .label span,


### PR DESCRIPTION
This pull request improves the Impact Areas → Global Target field on the OICR Details form by aligning its behavior and UX with the rest of the custom field patterns in the app. 

The PrimeNG p-multiSelect now uses appendTo="body" so the options panel is no longer clipped by accordion or card layout (overflow / stacking), while keeping it visually tied to the control: on open we measure the trigger width, apply matching panelStyle width constraints (so long SDG-style labels do not stretch the overlay across the viewport), and call alignOverlay() after change detection so positioning stays correct and the list no longer appears detached or overlapping neighboring fields such as Impact Area Score. 

Validation matches app-multiselect: required state when the score makes global targets mandatory, orange border on error, and the same “This field is required” warning treatment; the required asterisk is rendered flush with the label text like the radio field. The fixed bottom navigation bar is accounted for via overlay base z-index so the dropdown paints above it. 

Unit tests for ImpactAreasComponent were expanded to cover panel styling, overlay open handling, and invalid state logic, bringing impact-areas.component.ts to full Jest coverage.