### PR TITLE
OICR entry context, breadcrumbs, and header clarity for Results Center vs project flows

### DIFF
--- a/research-indicators/src/app/pages/platform/pages/result/components/version-selector/version-selector.component.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/components/version-selector/version-selector.component.spec.ts
@@ -249,7 +249,14 @@ describe('VersionSelectorComponent', () => {
     const version = { result_id: 1, report_year_id: 2023 } as any;
     component.liveVersion.set({ result_id: 1 } as any);
     component.selectVersion(version);
-    expect(router.navigate).toHaveBeenCalledWith([], expect.objectContaining({ queryParams: {} }));
+    expect(router.navigate).toHaveBeenCalledWith(
+      [],
+      expect.objectContaining({
+        queryParams: { version: null },
+        queryParamsHandling: 'merge',
+        replaceUrl: true
+      })
+    );
   });
 
   it('should call router.navigate with version param if not selecting liveVersion', () => {
@@ -355,7 +362,11 @@ describe('VersionSelectorComponent', () => {
       liveData: { result_id: 10, result_status_id: 2, report_year_id: 2022, result_official_code: 1 } as any,
       versionsArray: []
     });
-    expect(router.navigate).toHaveBeenCalledWith(['/result', '1', 'general-information'], { replaceUrl: true });
+    expect(router.navigate).toHaveBeenCalledWith(['/result', '1', 'general-information'], {
+      queryParams: { version: null },
+      queryParamsHandling: 'merge',
+      replaceUrl: true
+    });
   });
 
   describe('editInPlatform', () => {

--- a/research-indicators/src/app/pages/platform/pages/result/components/version-selector/version-selector.component.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/components/version-selector/version-selector.component.spec.ts
@@ -81,6 +81,30 @@ describe('VersionSelectorComponent', () => {
     expect(router.navigate).toHaveBeenCalled();
   });
 
+  it('selectVersion should merge from=results-center from route snapshot into queryParams', () => {
+    const route = TestBed.inject(ActivatedRoute);
+    const getSpy = jest.spyOn(route.snapshot.queryParamMap, 'get').mockImplementation((key: string) => {
+      if (key === 'from') return 'results-center';
+      return null;
+    });
+    const router = TestBed.inject(Router);
+    (router.navigate as jest.Mock).mockClear();
+
+    const version = { result_id: 2, report_year_id: 2023 } as any;
+    component.liveVersion.set({ result_id: 1 } as any);
+    component.selectVersion(version);
+
+    expect(router.navigate).toHaveBeenCalledWith(
+      [],
+      expect.objectContaining({
+        queryParams: { version: '2023', from: 'results-center' },
+        queryParamsHandling: 'merge',
+        replaceUrl: true
+      })
+    );
+    getSpy.mockRestore();
+  });
+
   it('should return true for isSelected if ids match', () => {
     const version = { result_id: 5 } as any;
     component.selectedResultId.set(5);

--- a/research-indicators/src/app/pages/platform/pages/result/components/version-selector/version-selector.component.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/components/version-selector/version-selector.component.ts
@@ -10,6 +10,10 @@ import { TooltipModule } from 'primeng/tooltip';
 import { filter, Subscription } from 'rxjs';
 import { environment } from '../../../../../../../environments/environment';
 import { PLATFORM_CODES } from '@shared/constants/platform-codes';
+import {
+  RESULT_ENTRY_SOURCE_QUERY,
+  RESULT_ENTRY_SOURCE_VALUE_RESULTS_CENTER
+} from '@shared/constants/result-entry-source';
 
 @Component({
   selector: 'app-version-selector',
@@ -137,7 +141,11 @@ export class VersionSelectorComponent implements OnDestroy {
         this.selectedResultId.set(liveData.result_id);
       }
       if (currentChild === 'general-information') {
-        this.router.navigate(['/result', currentResultId, currentChild], { replaceUrl: true });
+        this.router.navigate(['/result', currentResultId, currentChild], {
+          queryParams: { ...this.entrySourceQueryParamRecord(), version: null },
+          queryParamsHandling: 'merge',
+          replaceUrl: true
+        });
       }
       return;
     }
@@ -147,7 +155,8 @@ export class VersionSelectorComponent implements OnDestroy {
       this.selectedResultId.set(firstApproved.result_id);
       if (currentChild === 'general-information') {
         this.router.navigate(['/result', currentResultId, currentChild], {
-          queryParams: { version: firstApproved.report_year_id },
+          queryParams: { ...this.entrySourceQueryParamRecord(), version: firstApproved.report_year_id },
+          queryParamsHandling: 'merge',
           replaceUrl: true
         });
         this.hasAutoNavigated = true;
@@ -158,11 +167,12 @@ export class VersionSelectorComponent implements OnDestroy {
   selectVersion(version: TransformResultCodeResponse) {
     this.selectedResultId.set(version.result_id);
     const isLive = this.liveVersion()?.result_id === version.result_id;
-
     this.router.navigate([], {
       relativeTo: this.route,
-      queryParams: isLive ? {} : { version: String(version.report_year_id) },
-      queryParamsHandling: '',
+      queryParams: isLive
+        ? { version: null, ...this.entrySourceQueryParamRecord() }
+        : { version: String(version.report_year_id), ...this.entrySourceQueryParamRecord() },
+      queryParamsHandling: 'merge',
       replaceUrl: true
     });
   }
@@ -209,7 +219,8 @@ export class VersionSelectorComponent implements OnDestroy {
               const currentPath = this.router.url.split('?')[0];
               this.router
                 .navigate([currentPath], {
-                  queryParams: {},
+                  queryParams: { version: null, ...this.entrySourceQueryParamRecord() },
+                  queryParamsHandling: 'merge',
                   replaceUrl: true
                 })
                 .then(() => {
@@ -254,5 +265,12 @@ export class VersionSelectorComponent implements OnDestroy {
   private isResultRouteActive(resultId: string | number): boolean {
     // Verify that the current URL contains /result/{id}
     return this.router.url.startsWith(`/result/${resultId}`);
+  }
+
+  private entrySourceQueryParamRecord(): { [RESULT_ENTRY_SOURCE_QUERY]?: string } {
+    const from = this.route.snapshot.queryParamMap.get(RESULT_ENTRY_SOURCE_QUERY);
+    return from === RESULT_ENTRY_SOURCE_VALUE_RESULTS_CENTER
+      ? { [RESULT_ENTRY_SOURCE_QUERY]: from }
+      : {};
   }
 }

--- a/research-indicators/src/app/pages/platform/pages/result/resolvers/result-exists.resolver.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/resolvers/result-exists.resolver.spec.ts
@@ -24,19 +24,22 @@ describe('resultExistsResolver', () => {
     };
 
     const routerMock = {
-      navigate: jest.fn(),
+      navigate: jest.fn().mockResolvedValue(true),
       url: ''
     };
 
     const routeMock = {
       paramMap: {
         get: jest.fn()
+      },
+      queryParamMap: {
+        get: jest.fn().mockReturnValue(null)
       }
     };
 
     const currentResultServiceMock = {
       validateOpenResult: jest.fn().mockReturnValue(false),
-      openEditRequestdOicrsModal: jest.fn()
+      openEditRequestdOicrsModal: jest.fn().mockResolvedValue(undefined)
     };
 
     const cacheServiceMock = {
@@ -273,7 +276,30 @@ describe('resultExistsResolver', () => {
     expect(currentResultService.validateOpenResult).toHaveBeenCalledWith(1, 2);
     expect(router.navigate).toHaveBeenCalledWith(['/project-detail', 456]);
     expect(cacheService.projectResultsSearchValue.set).toHaveBeenCalledWith('Test Project');
-    expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(1, 2, 3);
+    expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(1, 2, 3, 'project');
+    expect(result).toBe(false);
+  });
+
+  it('should navigate to results-center and open OICR with results-center entry when query has from=results-center', async () => {
+    const id = 123;
+    route.paramMap.get = jest.fn().mockReturnValue(id.toString());
+    route.queryParamMap.get = jest.fn((key: string) => (key === 'from' ? 'results-center' : null));
+    metadataService.update = jest.fn().mockResolvedValue({
+      canOpen: true,
+      indicator_id: 1,
+      status_id: 2,
+      result_official_code: 3,
+      result_contract_id: 456,
+      result_title: 'Test Project'
+    });
+    currentResultService.validateOpenResult = jest.fn().mockReturnValue(true);
+    router.url = '/some-other-path';
+
+    const result = await runInInjectionContext(injector, () => resultExistsResolver(route, { url: '', root: {} as any }));
+
+    expect(router.navigate).toHaveBeenCalledWith(['/results-center']);
+    expect(cacheService.projectResultsSearchValue.set).not.toHaveBeenCalled();
+    expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(1, 2, 3, 'results-center');
     expect(result).toBe(false);
   });
 
@@ -300,7 +326,7 @@ describe('resultExistsResolver', () => {
     expect(currentResultService.validateOpenResult).toHaveBeenCalledWith(1, 2);
     expect(router.navigate).toHaveBeenCalledWith(['/project-detail', 456]);
     expect(cacheService.projectResultsSearchValue.set).not.toHaveBeenCalled();
-    expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(1, 2, 3);
+    expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(1, 2, 3, 'project');
     expect(result).toBe(false);
   });
 
@@ -401,7 +427,7 @@ describe('resultExistsResolver', () => {
     expect(currentResultService.validateOpenResult).toHaveBeenCalledWith(1, 2);
     expect(router.navigate).toHaveBeenCalledWith(['/project-detail', null]);
     expect(cacheService.projectResultsSearchValue.set).toHaveBeenCalledWith('Test Project');
-    expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(1, 2, 3);
+    expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(1, 2, 3, 'project');
     expect(result).toBe(false);
   });
 
@@ -428,7 +454,7 @@ describe('resultExistsResolver', () => {
     expect(currentResultService.validateOpenResult).toHaveBeenCalledWith(1, 2);
     expect(router.navigate).toHaveBeenCalledWith(['/project-detail', undefined]);
     expect(cacheService.projectResultsSearchValue.set).toHaveBeenCalledWith('Test Project');
-    expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(1, 2, 3);
+    expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(1, 2, 3, 'project');
     expect(result).toBe(false);
   });
 
@@ -455,7 +481,7 @@ describe('resultExistsResolver', () => {
     expect(currentResultService.validateOpenResult).toHaveBeenCalledWith(1, 2);
     expect(router.navigate).toHaveBeenCalledWith(['/project-detail', 456]);
     expect(cacheService.projectResultsSearchValue.set).toHaveBeenCalledWith('');
-    expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(1, 2, 3);
+    expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(1, 2, 3, 'project');
     expect(result).toBe(false);
   });
 
@@ -482,7 +508,7 @@ describe('resultExistsResolver', () => {
     expect(currentResultService.validateOpenResult).toHaveBeenCalledWith(1, 2);
     expect(router.navigate).toHaveBeenCalledWith(['/project-detail', 456]);
     expect(cacheService.projectResultsSearchValue.set).toHaveBeenCalledWith('');
-    expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(1, 2, 3);
+    expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(1, 2, 3, 'project');
     expect(result).toBe(false);
   });
 
@@ -509,7 +535,7 @@ describe('resultExistsResolver', () => {
     expect(currentResultService.validateOpenResult).toHaveBeenCalledWith(1, 2);
     expect(router.navigate).toHaveBeenCalledWith(['/project-detail', 456]);
     expect(cacheService.projectResultsSearchValue.set).toHaveBeenCalledWith('Test Project');
-    expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(1, 2, 0);
+    expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(1, 2, 0, 'project');
     expect(result).toBe(false);
   });
 
@@ -536,7 +562,7 @@ describe('resultExistsResolver', () => {
     expect(currentResultService.validateOpenResult).toHaveBeenCalledWith(1, 2);
     expect(router.navigate).toHaveBeenCalledWith(['/project-detail', 456]);
     expect(cacheService.projectResultsSearchValue.set).toHaveBeenCalledWith('Test Project');
-    expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(1, 2, 0);
+    expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(1, 2, 0, 'project');
     expect(result).toBe(false);
   });
 
@@ -563,7 +589,7 @@ describe('resultExistsResolver', () => {
     expect(currentResultService.validateOpenResult).toHaveBeenCalledWith(0, 0);
     expect(router.navigate).toHaveBeenCalledWith(['/project-detail', null]);
     expect(cacheService.projectResultsSearchValue.set).toHaveBeenCalledWith('');
-    expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(0, 0, 0);
+    expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(0, 0, 0, 'project');
     expect(result).toBe(false);
   });
 
@@ -590,7 +616,7 @@ describe('resultExistsResolver', () => {
     expect(currentResultService.validateOpenResult).toHaveBeenCalledWith(0, 0);
     expect(router.navigate).toHaveBeenCalledWith(['/project-detail', undefined]);
     expect(cacheService.projectResultsSearchValue.set).toHaveBeenCalledWith('');
-    expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(0, 0, 0);
+    expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(0, 0, 0, 'project');
     expect(result).toBe(false);
   });
 
@@ -617,7 +643,7 @@ describe('resultExistsResolver', () => {
     expect(currentResultService.validateOpenResult).toHaveBeenCalledWith(1, 4);
     expect(router.navigate).toHaveBeenCalledWith(['/project-detail', 456]);
     expect(cacheService.projectResultsSearchValue.set).toHaveBeenCalledWith('Test Project');
-    expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(1, 4, 3);
+    expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(1, 4, 3, 'project');
     expect(result).toBe(false);
   });
 
@@ -649,7 +675,7 @@ describe('resultExistsResolver', () => {
     expect(currentResultService.validateOpenResult).toHaveBeenCalledWith(1, 14);
     expect(router.navigate).toHaveBeenCalledWith(['/project-detail', 456]);
     expect(cacheService.projectResultsSearchValue.set).toHaveBeenCalledWith('Test Project');
-    expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(1, 14, 3);
+    expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(1, 14, 3, 'project');
     expect(result).toBe(false);
   });
 
@@ -677,7 +703,7 @@ describe('resultExistsResolver', () => {
     expect(currentResultService.validateOpenResult).toHaveBeenCalledWith(1, 12);
     expect(router.navigate).toHaveBeenCalledWith(['/project-detail', 456]);
     expect(cacheService.projectResultsSearchValue.set).toHaveBeenCalledWith('Test Project');
-    expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(1, 12, 3);
+    expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(1, 12, 3, 'project');
     expect(result).toBe(false);
   });
 
@@ -705,7 +731,7 @@ describe('resultExistsResolver', () => {
     expect(currentResultService.validateOpenResult).toHaveBeenCalledWith(1, 13);
     expect(router.navigate).toHaveBeenCalledWith(['/project-detail', 456]);
     expect(cacheService.projectResultsSearchValue.set).toHaveBeenCalledWith('Test Project');
-    expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(1, 13, 3);
+    expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(1, 13, 3, 'project');
     expect(result).toBe(false);
   });
 

--- a/research-indicators/src/app/pages/platform/pages/result/resolvers/result-exists.resolver.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/resolvers/result-exists.resolver.ts
@@ -5,6 +5,10 @@ import { CurrentResultService } from '../../../../../shared/services/cache/curre
 import { CacheService } from '../../../../../shared/services/cache/cache.service';
 import { PLATFORM_CODES } from '@shared/constants/platform-codes';
 import { RolesService } from '@shared/services/cache/roles.service';
+import {
+  RESULT_ENTRY_SOURCE_QUERY,
+  RESULT_ENTRY_SOURCE_VALUE_RESULTS_CENTER
+} from '@shared/constants/result-entry-source';
 
 export const resultExistsResolver: ResolveFn<boolean> = async route => {
   const metadataService = inject(GetMetadataService);
@@ -38,9 +42,20 @@ export const resultExistsResolver: ResolveFn<boolean> = async route => {
   if (currentResultService.validateOpenResult(indicator_id ?? 0, status_id ?? 0)) {
     const isDraft =  (status_id ?? 0) === 10 || (status_id ?? 0) === 12 || (status_id ?? 0) === 13;
     if (!isDraft || (isDraft && !rolesService.isAdmin())) {
-      router.navigate(['/project-detail', result_contract_id]);
-      if (!router.url.includes('/project-detail/')) cacheService.projectResultsSearchValue.set(result_title ?? '');
-      currentResultService.openEditRequestdOicrsModal(indicator_id ?? 0, status_id ?? 0, result_official_code ?? 0);
+      const fromResultsCenter =
+        route.queryParamMap.get(RESULT_ENTRY_SOURCE_QUERY) === RESULT_ENTRY_SOURCE_VALUE_RESULTS_CENTER;
+      if (fromResultsCenter) {
+        await router.navigate(['/results-center']);
+      } else {
+        await router.navigate(['/project-detail', result_contract_id]);
+        if (!router.url.includes('/project-detail/')) cacheService.projectResultsSearchValue.set(result_title ?? '');
+      }
+      await currentResultService.openEditRequestdOicrsModal(
+        indicator_id ?? 0,
+        status_id ?? 0,
+        result_official_code ?? 0,
+        fromResultsCenter ? 'results-center' : 'project'
+      );
       return false;
     }
     return true;

--- a/research-indicators/src/app/pages/platform/pages/result/resolvers/result-exists.resolver.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/resolvers/result-exists.resolver.ts
@@ -1,14 +1,12 @@
 import { inject } from '@angular/core';
-import { ResolveFn, Router } from '@angular/router';
+import { ActivatedRouteSnapshot, ResolveFn, Router } from '@angular/router';
 import { GetMetadataService } from '@shared/services/get-metadata.service';
 import { CurrentResultService } from '../../../../../shared/services/cache/current-result.service';
 import { CacheService } from '../../../../../shared/services/cache/cache.service';
 import { PLATFORM_CODES } from '@shared/constants/platform-codes';
 import { RolesService } from '@shared/services/cache/roles.service';
-import {
-  RESULT_ENTRY_SOURCE_QUERY,
-  RESULT_ENTRY_SOURCE_VALUE_RESULTS_CENTER
-} from '@shared/constants/result-entry-source';
+import { RESULT_ENTRY_SOURCE_QUERY, RESULT_ENTRY_SOURCE_VALUE_RESULTS_CENTER } from '@shared/constants/result-entry-source';
+import { OicrResolverMetadata } from '@shared/interfaces/oicr-resolver-metadata.interface';
 
 export const resultExistsResolver: ResolveFn<boolean> = async route => {
   const metadataService = inject(GetMetadataService);
@@ -39,27 +37,50 @@ export const resultExistsResolver: ResolveFn<boolean> = async route => {
     return false;
   }
 
-  if (currentResultService.validateOpenResult(indicator_id ?? 0, status_id ?? 0)) {
-    const isDraft =  (status_id ?? 0) === 10 || (status_id ?? 0) === 12 || (status_id ?? 0) === 13;
-    if (!isDraft || (isDraft && !rolesService.isAdmin())) {
-      const fromResultsCenter =
-        route.queryParamMap.get(RESULT_ENTRY_SOURCE_QUERY) === RESULT_ENTRY_SOURCE_VALUE_RESULTS_CENTER;
-      if (fromResultsCenter) {
-        await router.navigate(['/results-center']);
-      } else {
-        await router.navigate(['/project-detail', result_contract_id]);
-        if (!router.url.includes('/project-detail/')) cacheService.projectResultsSearchValue.set(result_title ?? '');
-      }
-      await currentResultService.openEditRequestdOicrsModal(
-        indicator_id ?? 0,
-        status_id ?? 0,
-        result_official_code ?? 0,
-        fromResultsCenter ? 'results-center' : 'project'
-      );
-      return false;
-    }
-    return true;
+  const oicrResolveOutcome = await tryOpenOicrEditorFromResolver(route, router, cacheService, currentResultService, rolesService, {
+    indicator_id,
+    status_id,
+    result_official_code,
+    result_contract_id,
+    result_title
+  });
+  if (oicrResolveOutcome !== undefined) {
+    return oicrResolveOutcome;
   }
 
   return true;
 };
+
+async function tryOpenOicrEditorFromResolver(
+  route: ActivatedRouteSnapshot,
+  router: Router,
+  cacheService: CacheService,
+  currentResultService: CurrentResultService,
+  rolesService: RolesService,
+  meta: OicrResolverMetadata
+): Promise<boolean | undefined> {
+  const { indicator_id, status_id, result_official_code, result_contract_id, result_title } = meta;
+
+  if (!currentResultService.validateOpenResult(indicator_id ?? 0, status_id ?? 0)) {
+    return undefined;
+  }
+
+  const isDraft = (status_id ?? 0) === 10 || (status_id ?? 0) === 12 || (status_id ?? 0) === 13;
+  if (!isDraft || (isDraft && !rolesService.isAdmin())) {
+    const fromResultsCenter = route.queryParamMap.get(RESULT_ENTRY_SOURCE_QUERY) === RESULT_ENTRY_SOURCE_VALUE_RESULTS_CENTER;
+    if (fromResultsCenter) {
+      await router.navigate(['/results-center']);
+    } else {
+      await router.navigate(['/project-detail', result_contract_id]);
+      if (!router.url.includes('/project-detail/')) cacheService.projectResultsSearchValue.set(result_title ?? '');
+    }
+    await currentResultService.openEditRequestdOicrsModal(
+      indicator_id ?? 0,
+      status_id ?? 0,
+      result_official_code ?? 0,
+      fromResultsCenter ? 'results-center' : 'project'
+    );
+    return false;
+  }
+  return true;
+}

--- a/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.html
+++ b/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.html
@@ -138,7 +138,8 @@
           @if (primaryContractId) {
           <a (keydown.enter)="$event.stopPropagation()"
             class="project-link cursor-pointer hover:text-blue-800 hover:underline transition-colors duration-200"
-            [routerLink]="['/project-detail', primaryContractId, 'project-results']" (click)="$event.stopPropagation()">
+            [routerLink]="['/project-detail', primaryContractId, 'project-results']"
+            [queryParams]="resultEntryQueryParamsForNavigation()" (click)="$event.stopPropagation()">
             {{ primaryContractId }}
           </a>
           } @else {

--- a/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.spec.ts
@@ -8,6 +8,23 @@ import { computed, signal } from '@angular/core';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ApiService } from '../../../../../../shared/services/api.service';
 import { CreateResultManagementService } from '../../../../../../shared/components/all-modals/modals-content/create-result-modal/services/create-result-management.service';
+import { getResultEntrySourceFromSearch, isResultsCenterEntryFromUrl } from '@shared/constants/result-entry-source';
+
+describe('result-entry-source helpers', () => {
+  it('getResultEntrySourceFromSearch returns null for empty and parses query shapes', () => {
+    expect(getResultEntrySourceFromSearch('')).toBeNull();
+    expect(getResultEntrySourceFromSearch('?from=results-center')).toBe('results-center');
+    expect(getResultEntrySourceFromSearch('from=results-center')).toBe('results-center');
+    expect(getResultEntrySourceFromSearch('x=1&from=results-center')).toBe('results-center');
+    expect(getResultEntrySourceFromSearch('?from=other')).toBe('other');
+  });
+
+  it('isResultsCenterEntryFromUrl detects results-center entry from URL query', () => {
+    expect(isResultsCenterEntryFromUrl('/result/STAR-1')).toBe(false);
+    expect(isResultsCenterEntryFromUrl('/result/STAR-1?from=results-center')).toBe(true);
+    expect(isResultsCenterEntryFromUrl('/result/STAR-1?from=projects')).toBe(false);
+  });
+});
 
 describe('ResultsCenterTableComponent', () => {
   let component: ResultsCenterTableComponent;
@@ -48,6 +65,7 @@ describe('ResultsCenterTableComponent', () => {
   }
 
   beforeEach(async () => {
+    TestBed.resetTestingModule();
     jest.spyOn(console, 'error').mockImplementation(() => {});
 
     const listSig = signal([mockResult]);
@@ -203,6 +221,14 @@ describe('ResultsCenterTableComponent', () => {
     expect(mockRouter.navigate).not.toHaveBeenCalled();
   });
 
+  it('openResult PRMS should set result information entry context to results-center when in results-center context', () => {
+    fixture.componentRef.setInput('resultEntryContext', 'results-center');
+    const prms = { ...mockResult, platform_code: 'PRMS' };
+    mockModals.setResultInformationEntryContext.mockClear();
+    component.openResult(prms);
+    expect(mockModals.setResultInformationEntryContext).toHaveBeenCalledWith('results-center');
+  });
+
   it('openCreateResultForProject should open create modal when primaryContractId is set', () => {
     (mockService.primaryContractId as jest.Mock).mockReturnValue('CONTRACT-123');
     component.openCreateResultForProject();
@@ -210,6 +236,13 @@ describe('ResultsCenterTableComponent', () => {
     expect(mockCreateResultManagementService.setPresetFromProjectResultsTable).toHaveBeenCalledWith(true);
     expect(mockCreateResultManagementService.setResultCreationEntryContext).toHaveBeenCalledWith('project');
     expect(mockModals.openModal).toHaveBeenCalledWith('createResult');
+  });
+
+  it('openCreateResultForProject should set results-center creation context when table is in results-center context', () => {
+    (mockService.primaryContractId as jest.Mock).mockReturnValue('CONTRACT-123');
+    fixture.componentRef.setInput('resultEntryContext', 'results-center');
+    component.openCreateResultForProject();
+    expect(mockCreateResultManagementService.setResultCreationEntryContext).toHaveBeenCalledWith('results-center');
   });
 
   it('openCreateResultForProject should do nothing when primaryContractId is null', () => {
@@ -288,6 +321,12 @@ describe('ResultsCenterTableComponent', () => {
   it('getResultQueryParams should return empty object when not approved-with-versions', () => {
     const r = { ...mockResult, result_status: { name: 'SUBMITTED', result_status_id: 1 }, snapshot_years: [] };
     expect(component.getResultQueryParams(r as any)).toEqual({});
+  });
+
+  it('getResultQueryParams should include from=results-center when entry context is results-center', () => {
+    fixture.componentRef.setInput('resultEntryContext', 'results-center');
+    const r = { ...mockResult, result_status: { name: 'SUBMITTED', result_status_id: 1 }, snapshot_years: [] };
+    expect(component.getResultQueryParams(r as any)).toEqual({ from: 'results-center' });
   });
 
   it.each([
@@ -392,6 +431,22 @@ describe('ResultsCenterTableComponent', () => {
     // call the remover
     (component as any).removeDocumentClickListener?.();
     expect(removeSpy).toHaveBeenCalledWith('click', expect.any(Function), { capture: true } as unknown as boolean);
+  });
+
+  it('ngOnDestroy should remove document click listener when registered', () => {
+    const removeSpy = jest.spyOn(document, 'removeEventListener');
+    component.ngAfterViewInit();
+    component.ngOnDestroy();
+    expect(removeSpy).toHaveBeenCalledWith('click', expect.any(Function), { capture: true } as unknown as boolean);
+    removeSpy.mockRestore();
+  });
+
+  it('dt2 setter should sync tableRef on ResultsCenterService', () => {
+    const fakeTable = { el: { nativeElement: document.createElement('div') } } as any;
+    component.dt2 = fakeTable;
+    expect(mockService.tableRef()).toBe(fakeTable);
+    component.dt2 = undefined;
+    expect(mockService.tableRef()).toBeUndefined();
   });
 
   it('onDocClickCapture should call processRowClick with target element', () => {
@@ -653,6 +708,12 @@ describe('ResultsCenterTableComponent', () => {
     expect(console.error).toHaveBeenCalled();
   });
 
+  it('exportTable should log rejection when error is not an Error instance', async () => {
+    mockApiService.GET_ResultCenterXlsx.mockRejectedValueOnce('network-fail');
+    await component.exportTable();
+    expect(console.error).toHaveBeenCalled();
+  });
+
   it('exportTable should log error when blob is empty', async () => {
     const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     mockApiService.GET_ResultCenterXlsx.mockResolvedValueOnce(new Blob([]));
@@ -760,7 +821,30 @@ describe('ResultsCenterTableComponent', () => {
 
     expect(preventDefaultSpy).toHaveBeenCalled();
     expect(stopPropagationSpy).toHaveBeenCalled();
-    expect(mockRouter.navigate).toHaveBeenCalledWith(['/project-detail', 'C-1', 'project-results']);
+    expect(mockRouter.navigate).toHaveBeenCalledWith(['/project-detail', 'C-1', 'project-results'], { queryParams: {} });
+  });
+
+  it('processRowClick should navigate to project-detail with from query when resultEntryContext is results-center', () => {
+    fixture.componentRef.setInput('resultEntryContext', 'results-center');
+    mockModals.isAnyModalOpen.mockReturnValue(false);
+    const tableElement = document.createElement('table');
+    const tbody = document.createElement('tbody');
+    const row = document.createElement('tr');
+    const cell = document.createElement('td');
+    cell.className = 'project-cell';
+    row.appendChild(cell);
+    tbody.appendChild(row);
+    tableElement.appendChild(tbody);
+    (component as any).dt2 = {
+      el: { nativeElement: tableElement },
+      filteredValue: [{ ...mockResult, result_contracts: { contract_id: 'C-1' } }],
+      first: 0
+    };
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+    (component as any).processRowClick(cell, event);
+    expect(mockRouter.navigate).toHaveBeenCalledWith(['/project-detail', 'C-1', 'project-results'], {
+      queryParams: { from: 'results-center' }
+    });
   });
 
   it('processRowClick should return early for non-PRMS/TIP/AICCRA when clicking routerLink', () => {
@@ -819,5 +903,14 @@ describe('ResultsCenterTableComponent', () => {
     (component as any).closeResultInformationModal();
     expect(mockModals.closeModal).toHaveBeenCalledWith('resultInformation');
     expect(setSelectedSpy).toHaveBeenCalledWith(null);
+  });
+
+  it('closeResultInformationModal should clear entry context when modal is not open', () => {
+    mockModals.isModalOpen.mockReturnValue({ isOpen: false });
+    mockModals.closeModal.mockClear();
+    mockModals.setResultInformationEntryContext.mockClear();
+    (component as any).closeResultInformationModal();
+    expect(mockModals.setResultInformationEntryContext).toHaveBeenCalledWith(null);
+    expect(mockModals.closeModal).not.toHaveBeenCalled();
   });
 });

--- a/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.spec.ts
@@ -93,6 +93,7 @@ describe('ResultsCenterTableComponent', () => {
       closeModal: jest.fn(),
       closeAllModals: jest.fn(),
       isModalOpen: jest.fn(() => ({ isOpen: false })),
+      setResultInformationEntryContext: jest.fn(),
       // New helper used by processRowClick to avoid interfering when a modal is already open
       isAnyModalOpen: jest.fn(() => false)
     };
@@ -108,7 +109,8 @@ describe('ResultsCenterTableComponent', () => {
 
     mockCreateResultManagementService = {
       setContractId: jest.fn(),
-      setPresetFromProjectResultsTable: jest.fn()
+      setPresetFromProjectResultsTable: jest.fn(),
+      setResultCreationEntryContext: jest.fn()
     };
 
     await TestBed.configureTestingModule({
@@ -196,6 +198,7 @@ describe('ResultsCenterTableComponent', () => {
     const prms = { ...mockResult, platform_code: 'PRMS' };
     component.openResult(prms);
     expect(mockModals.selectedResultForInfo()).toEqual(prms);
+    expect(mockModals.setResultInformationEntryContext).toHaveBeenCalledWith(null);
     expect(mockModals.openModal).toHaveBeenCalledWith('resultInformation');
     expect(mockRouter.navigate).not.toHaveBeenCalled();
   });
@@ -205,6 +208,7 @@ describe('ResultsCenterTableComponent', () => {
     component.openCreateResultForProject();
     expect(mockCreateResultManagementService.setContractId).toHaveBeenCalledWith('CONTRACT-123');
     expect(mockCreateResultManagementService.setPresetFromProjectResultsTable).toHaveBeenCalledWith(true);
+    expect(mockCreateResultManagementService.setResultCreationEntryContext).toHaveBeenCalledWith('project');
     expect(mockModals.openModal).toHaveBeenCalledWith('createResult');
   });
 
@@ -220,10 +224,18 @@ describe('ResultsCenterTableComponent', () => {
     expect(mockRouter.navigate).toHaveBeenCalledWith(['/result', 'ROAR-7', 'general-information'], { queryParams: { version: 2024 } });
   });
 
+  it('openResult from results center should add from query for STAR navigation', () => {
+    fixture.componentRef.setInput('resultEntryContext', 'results-center');
+    component.openResult(mockResult);
+    expect(mockRouter.navigate).toHaveBeenCalledWith(['/result', 'ROAR-7', 'general-information'], {
+      queryParams: { version: 2024, from: 'results-center' }
+    });
+  });
+
   it('openResult should navigate without version when condition not met', () => {
     const r = { ...mockResult, result_status: { name: 'SUBMITTED', result_status_id: 1 }, snapshot_years: [] };
     component.openResult(r as any);
-    expect(mockRouter.navigate).toHaveBeenCalledWith(['/result', 'ROAR-7']);
+    expect(mockRouter.navigate).toHaveBeenCalledWith(['/result', 'ROAR-7'], { queryParams: {} });
   });
 
   it('openResultByYear should no-op for PRMS, navigate otherwise', () => {
@@ -248,6 +260,7 @@ describe('ResultsCenterTableComponent', () => {
 
   it('getResultHref should return simple path when no snapshots/version', () => {
     const r = { ...mockResult, result_status: { name: 'SUBMITTED', result_status_id: 1 }, snapshot_years: [] };
+    mockRouter.createUrlTree.mockReturnValueOnce({ toString: () => '/result/ROAR-7' });
     const href = component.getResultHref(r as any);
     expect(href).toBe('/result/ROAR-7');
   });

--- a/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.ts
+++ b/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.ts
@@ -1,4 +1,8 @@
 import { Component, inject, ViewChild, signal, AfterViewInit, OnDestroy, computed, HostListener, Input } from '@angular/core';
+import {
+  RESULT_ENTRY_SOURCE_QUERY,
+  RESULT_ENTRY_SOURCE_VALUE_RESULTS_CENTER
+} from '@shared/constants/result-entry-source';
 import { FormsModule } from '@angular/forms';
 import { Table, TableModule } from 'primeng/table';
 import { ButtonModule } from 'primeng/button';
@@ -48,6 +52,8 @@ export class ResultsCenterTableComponent implements AfterViewInit, OnDestroy {
   private readonly apiService = inject(ApiService);
 
   @Input() showNewProjectResultButton = false;
+  /** Use `results-center` when this table is on the global Results Center page; `project` on project detail. */
+  @Input() resultEntryContext: 'results-center' | 'project' = 'project';
 
   private dt2Table: Table | undefined;
 
@@ -191,6 +197,9 @@ export class ResultsCenterTableComponent implements AfterViewInit, OnDestroy {
     }
     this.createResultManagementService.setContractId(contractId);
     this.createResultManagementService.setPresetFromProjectResultsTable(true);
+    this.createResultManagementService.setResultCreationEntryContext(
+      this.resultEntryContext === 'results-center' ? 'results-center' : 'project'
+    );
     this.allModalsService.openModal('createResult');
   }
 
@@ -210,6 +219,7 @@ export class ResultsCenterTableComponent implements AfterViewInit, OnDestroy {
       result.platform_code === PLATFORM_CODES.AICCRA
     ) {
       this.allModalsService.selectedResultForInfo.set(result);
+      this.applyResultInformationModalContext();
       this.allModalsService.openModal('resultInformation');
       return;
     }
@@ -217,9 +227,11 @@ export class ResultsCenterTableComponent implements AfterViewInit, OnDestroy {
     const resultCode = `${result.platform_code}-${result.result_official_code}`;
     if (result.result_status?.result_status_id === 6 && Array.isArray(result.snapshot_years) && result.snapshot_years.length > 0) {
       const latestYear = Math.max(...result.snapshot_years);
-      this.router.navigate(['/result', resultCode, 'general-information'], { queryParams: { version: latestYear } });
+      this.router.navigate(['/result', resultCode, 'general-information'], {
+        queryParams: this.resultEntryQueryParamsForNavigation({ version: latestYear })
+      });
     } else {
-      this.router.navigate(['/result', resultCode]);
+      this.router.navigate(['/result', resultCode], { queryParams: this.resultEntryQueryParamsForNavigation() });
     }
   }
 
@@ -230,7 +242,7 @@ export class ResultsCenterTableComponent implements AfterViewInit, OnDestroy {
     this.closeResultInformationModal();
     const resultCode = `${platformCode}-${result}`;
     this.router.navigate(['/result', resultCode], {
-      queryParams: { version: year }
+      queryParams: this.resultEntryQueryParamsForNavigation({ version: year })
     });
   }
 
@@ -248,11 +260,11 @@ export class ResultsCenterTableComponent implements AfterViewInit, OnDestroy {
       const latestYear = Math.max(...result.snapshot_years);
       return this.router
         .createUrlTree(['/result', resultCode, 'general-information'], {
-          queryParams: { version: latestYear }
+          queryParams: this.resultEntryQueryParamsForNavigation({ version: latestYear })
         })
         .toString();
     }
-    return `/result/${resultCode}`;
+    return this.router.createUrlTree(['/result', resultCode], { queryParams: this.resultEntryQueryParamsForNavigation() }).toString();
   }
 
   getResultRouteArray(result: Result): string | string[] {
@@ -276,12 +288,12 @@ export class ResultsCenterTableComponent implements AfterViewInit, OnDestroy {
     this.processRowClick(target, event);
   }
 
-  getResultQueryParams(result: Result): { version?: number } {
+  getResultQueryParams(result: Result): Record<string, string | number> {
     if (result.result_status?.result_status_id === 6 && Array.isArray(result.snapshot_years) && result.snapshot_years.length > 0) {
       const latestYear = Math.max(...result.snapshot_years);
-      return { version: latestYear };
+      return this.resultEntryQueryParamsForNavigation({ version: latestYear });
     }
-    return {};
+    return this.resultEntryQueryParamsForNavigation();
   }
 
   onResultLinkClick(result: Result): void {
@@ -291,6 +303,7 @@ export class ResultsCenterTableComponent implements AfterViewInit, OnDestroy {
       result.platform_code === PLATFORM_CODES.AICCRA
     ) {
       this.allModalsService.selectedResultForInfo.set(result);
+      this.applyResultInformationModalContext();
       this.allModalsService.openModal('resultInformation');
     }
   }
@@ -404,13 +417,30 @@ export class ResultsCenterTableComponent implements AfterViewInit, OnDestroy {
       event.preventDefault();
       event.stopPropagation();
       this.allModalsService.selectedResultForInfo.set(result);
+      this.applyResultInformationModalContext();
       this.allModalsService.openModal('resultInformation');
     }
+  }
+
+  private resultEntryQueryParamsForNavigation(extra: Record<string, string | number> = {}): Record<string, string | number> {
+    const q: Record<string, string | number> = { ...extra };
+    if (this.resultEntryContext === 'results-center') {
+      q[RESULT_ENTRY_SOURCE_QUERY] = RESULT_ENTRY_SOURCE_VALUE_RESULTS_CENTER;
+    }
+    return q;
+  }
+
+  private applyResultInformationModalContext(): void {
+    this.allModalsService.setResultInformationEntryContext(
+      this.resultEntryContext === 'results-center' ? 'results-center' : null
+    );
   }
 
   private closeResultInformationModal(): void {
     if (this.allModalsService.isModalOpen('resultInformation').isOpen) {
       this.allModalsService.closeModal('resultInformation');
+    } else {
+      this.allModalsService.setResultInformationEntryContext(null);
     }
     this.allModalsService.selectedResultForInfo.set(null);
   }

--- a/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.ts
+++ b/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.ts
@@ -1,8 +1,5 @@
 import { Component, inject, ViewChild, signal, AfterViewInit, OnDestroy, computed, HostListener, Input } from '@angular/core';
-import {
-  RESULT_ENTRY_SOURCE_QUERY,
-  RESULT_ENTRY_SOURCE_VALUE_RESULTS_CENTER
-} from '@shared/constants/result-entry-source';
+import { RESULT_ENTRY_SOURCE_QUERY, RESULT_ENTRY_SOURCE_VALUE_RESULTS_CENTER } from '@shared/constants/result-entry-source';
 import { FormsModule } from '@angular/forms';
 import { Table, TableModule } from 'primeng/table';
 import { ButtonModule } from 'primeng/button';
@@ -52,7 +49,6 @@ export class ResultsCenterTableComponent implements AfterViewInit, OnDestroy {
   private readonly apiService = inject(ApiService);
 
   @Input() showNewProjectResultButton = false;
-  /** Use `results-center` when this table is on the global Results Center page; `project` on project detail. */
   @Input() resultEntryContext: 'results-center' | 'project' = 'project';
 
   private dt2Table: Table | undefined;
@@ -197,9 +193,7 @@ export class ResultsCenterTableComponent implements AfterViewInit, OnDestroy {
     }
     this.createResultManagementService.setContractId(contractId);
     this.createResultManagementService.setPresetFromProjectResultsTable(true);
-    this.createResultManagementService.setResultCreationEntryContext(
-      this.resultEntryContext === 'results-center' ? 'results-center' : 'project'
-    );
+    this.createResultManagementService.setResultCreationEntryContext(this.resultEntryContext === 'results-center' ? 'results-center' : 'project');
     this.allModalsService.openModal('createResult');
   }
 
@@ -395,7 +389,9 @@ export class ResultsCenterTableComponent implements AfterViewInit, OnDestroy {
       if (result.result_contracts?.contract_id) {
         event.preventDefault();
         event.stopPropagation();
-        this.router.navigate(['/project-detail', result.result_contracts.contract_id, 'project-results']);
+        this.router.navigate(['/project-detail', result.result_contracts.contract_id, 'project-results'], {
+          queryParams: this.resultEntryQueryParamsForNavigation()
+        });
       }
       return;
     }
@@ -422,7 +418,8 @@ export class ResultsCenterTableComponent implements AfterViewInit, OnDestroy {
     }
   }
 
-  private resultEntryQueryParamsForNavigation(extra: Record<string, string | number> = {}): Record<string, string | number> {
+  /** Used by the template for project-detail links when the table is embedded in Results Center vs project context. */
+  resultEntryQueryParamsForNavigation(extra: Record<string, string | number> = {}): Record<string, string | number> {
     const q: Record<string, string | number> = { ...extra };
     if (this.resultEntryContext === 'results-center') {
       q[RESULT_ENTRY_SOURCE_QUERY] = RESULT_ENTRY_SOURCE_VALUE_RESULTS_CENTER;
@@ -431,9 +428,7 @@ export class ResultsCenterTableComponent implements AfterViewInit, OnDestroy {
   }
 
   private applyResultInformationModalContext(): void {
-    this.allModalsService.setResultInformationEntryContext(
-      this.resultEntryContext === 'results-center' ? 'results-center' : null
-    );
+    this.allModalsService.setResultInformationEntryContext(this.resultEntryContext === 'results-center' ? 'results-center' : null);
   }
 
   private closeResultInformationModal(): void {

--- a/research-indicators/src/app/pages/platform/pages/results-center/results-center.component.html
+++ b/research-indicators/src/app/pages/platform/pages/results-center/results-center.component.html
@@ -30,7 +30,7 @@
       </div>
     </div>
     <!-- Results Table -->
-    <app-results-center-table></app-results-center-table>
+    <app-results-center-table resultEntryContext="results-center"></app-results-center-table>
   </div>
 </div>
 

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.html
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.html
@@ -65,6 +65,7 @@
   @if (currentContract()) {
   <app-oicr-header [data]="{
       title: createResultManagementService.resultTitle() || '',
+      result_official_code: createResultManagementService.currentRequestedResultCode() ?? cache.currentMetadata()?.result_official_code,
       agreement_id: currentContract()?.agreement_id,
       description: currentContract()?.description,
       project_lead_description: currentContract()?.project_lead_description,

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.spec.ts
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.spec.ts
@@ -157,7 +157,7 @@ describe('CreateOicrFormComponent', () => {
 
     const mockCurrentResultService = {
       currentResult: signal(null),
-      openEditRequestdOicrsModal: jest.fn()
+      openEditRequestdOicrsModal: jest.fn().mockResolvedValue(undefined)
     };
 
     await TestBed.configureTestingModule({
@@ -892,11 +892,14 @@ describe('CreateOicrFormComponent', () => {
   it('should handle handleSubmitBack method', async () => {
     // Mock the cache service methods
     const mockCacheService = TestBed.inject(CacheService);
+    const mockCurrentResultService = TestBed.inject(CurrentResultService) as any;
     mockCacheService.currentMetadata = jest.fn(() => ({ indicator_id: 1, status_id: 2 }));
     mockCacheService.getCurrentNumericResultId = jest.fn(() => 123);
-    
+    component.router.url = '/result/STAR-123';
+
     await component.handleSubmitBack();
-    
+
+    expect(mockCurrentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(1, 2, 123, 'project');
     expect(mockAllModalsService.setSubmitResultOrigin).toHaveBeenCalledWith(null);
     expect(mockAllModalsService.setSubmitHeader).toHaveBeenCalledWith(null);
     expect(mockAllModalsService.setSubmitBackStep).toHaveBeenCalledWith(null);
@@ -904,6 +907,18 @@ describe('CreateOicrFormComponent', () => {
     expect(mockAllModalsService.createResultManagementService.resetModal).toHaveBeenCalled();
     expect(mockAllModalsService.closeModal).toHaveBeenCalledWith('submitResult');
     // This test covers the handleSubmitBack method logic
+  });
+
+  it('should pass results-center context on handleSubmitBack when URL has from=results-center', async () => {
+    const mockCacheService = TestBed.inject(CacheService);
+    const mockCurrentResultService = TestBed.inject(CurrentResultService) as any;
+    mockCacheService.currentMetadata = jest.fn(() => ({ indicator_id: 1, status_id: 2 }));
+    mockCacheService.getCurrentNumericResultId = jest.fn(() => 123);
+    component.router.url = '/result/STAR-123?from=results-center';
+
+    await component.handleSubmitBack();
+
+    expect(mockCurrentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(1, 2, 123, 'results-center');
   });
 
   it('should handle handleSubmitBack with no metadata', async () => {
@@ -1389,6 +1404,92 @@ describe('CreateOicrFormComponent', () => {
     // navigate() body should have run: closeModal, updateList, etc.
     expect(mockAllModalsService.closeModal).toHaveBeenCalledWith('createResult');
     expect(mockGetResultsService.updateList).toHaveBeenCalled();
+  });
+
+  it('should navigate to results-center on Done when OICR success and entry context is results-center', async () => {
+    const mockResponse = {
+      status: 200,
+      data: { result_official_code: 'TEST-001' }
+    };
+    mockApiService.POST_CreateOicr = jest.fn().mockResolvedValue(mockResponse);
+    mockCreateResultManagementService.createOicrBody.set({
+      ...mockCreateResultManagementService.createOicrBody(),
+      base_information: {
+        indicator_id: 5,
+        contract_id: '123',
+        title: 'Test Title'
+      }
+    });
+    mockCreateResultManagementService.resultCreationEntryContext.set('results-center');
+
+    const mockRouter = TestBed.inject(Router);
+    mockRouter.navigate = jest.fn().mockResolvedValue(true);
+    mockRouter.url = '/results-center';
+
+    const mockActionsService = TestBed.inject(ActionsService);
+    let capturedCallback: (() => void) | undefined;
+    mockActionsService.showGlobalAlert = jest.fn().mockImplementation(config => {
+      capturedCallback = config.confirmCallback?.event;
+    });
+
+    const mockGetResultsService = TestBed.inject(GetResultsService);
+    mockGetResultsService.updateList = jest.fn();
+
+    const mockCacheService = TestBed.inject(CacheService);
+    mockCacheService.projectResultsSearchValue = signal('');
+
+    await component.createResult();
+    expect(mockActionsService.showGlobalAlert).toHaveBeenCalled();
+    capturedCallback?.();
+
+    expect(mockRouter.navigate).toHaveBeenCalledWith(['/results-center'], {
+      replaceUrl: true,
+      onSameUrlNavigation: 'reload'
+    });
+    expect(mockAllModalsService.closeModal).toHaveBeenCalledWith('createResult');
+    expect(mockGetResultsService.updateList).toHaveBeenCalled();
+
+    mockCreateResultManagementService.resultCreationEntryContext.set(null);
+  });
+
+  it('should navigate to project-detail/ with empty contract segment when contract_id is missing on OICR Done', async () => {
+    const mockResponse = {
+      status: 200,
+      data: { result_official_code: 'TEST-001' }
+    };
+    mockApiService.POST_CreateOicr = jest.fn().mockResolvedValue(mockResponse);
+    mockCreateResultManagementService.createOicrBody.set({
+      ...mockCreateResultManagementService.createOicrBody(),
+      base_information: {
+        indicator_id: 5,
+        title: 'Test Title'
+      } as any
+    });
+    mockCreateResultManagementService.resultCreationEntryContext.set(null);
+
+    const mockRouter = TestBed.inject(Router);
+    mockRouter.navigate = jest.fn().mockResolvedValue(true);
+    mockRouter.url = '/other-path';
+
+    const mockActionsService = TestBed.inject(ActionsService);
+    let capturedCallback: (() => void) | undefined;
+    mockActionsService.showGlobalAlert = jest.fn().mockImplementation(config => {
+      capturedCallback = config.confirmCallback?.event;
+    });
+
+    const mockGetResultsService = TestBed.inject(GetResultsService);
+    mockGetResultsService.updateList = jest.fn();
+
+    const mockCacheService = TestBed.inject(CacheService);
+    mockCacheService.projectResultsSearchValue = signal('');
+
+    await component.createResult();
+    capturedCallback?.();
+
+    expect(mockRouter.navigate).toHaveBeenCalledWith(
+      ['project-detail/', ''],
+      { replaceUrl: true, onSameUrlNavigation: 'reload' }
+    );
   });
 
   it('should handle createResult with success response and indicator_id not 5 - direct navigation', async () => {

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.spec.ts
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.spec.ts
@@ -74,6 +74,8 @@ describe('CreateOicrFormComponent', () => {
       oicrPrimaryOptionsDisabled: signal([]),
       resultTitle: signal(''),
       statusId: signal(9),
+      resultCreationEntryContext: signal<'results-center' | 'project' | null>(null),
+      setResultCreationEntryContext: jest.fn(),
       setModalTitle: jest.fn(),
       setStatusId: jest.fn(),
       clearOicrBody: jest.fn(),

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.ts
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.ts
@@ -454,10 +454,19 @@ export class CreateOicrFormComponent implements OnInit {
           label: 'Done',
           event: () => {
             // Modern Angular approach - Navigate with reload
-            const targetRoute =
-              this.createResultManagementService.createOicrBody().base_information.indicator_id === 5
-                ? ['project-detail/', this.createResultManagementService.createOicrBody()?.base_information?.contract_id]
-                : ['result', response.data.result_official_code];
+            const isOicr = this.createResultManagementService.createOicrBody().base_information.indicator_id === 5;
+            const fromResultsCenter = this.createResultManagementService.resultCreationEntryContext() === 'results-center';
+            let targetRoute: (string | number)[];
+            if (isOicr) {
+              targetRoute = fromResultsCenter
+                ? ['/results-center']
+                : [
+                    'project-detail/',
+                    this.createResultManagementService.createOicrBody()?.base_information?.contract_id ?? ''
+                  ];
+            } else {
+              targetRoute = ['result', response.data.result_official_code];
+            }
 
             // Navigate to results-center first to ensure component refresh
             const navigate = () => {

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.ts
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.ts
@@ -54,6 +54,7 @@ import { RolesService } from '@shared/services/cache/roles.service';
 import { ProjectResultsTableService } from '@shared/components/project-results-table/project-results-table.service';
 import { OicrHeaderComponent } from '@shared/components/oicr-header/oicr-header.component';
 import { CurrentResultService } from '@shared/services/cache/current-result.service';
+import { isResultsCenterEntryFromUrl } from '@shared/constants/result-entry-source';
 import { FindContracts } from '@shared/interfaces/find-contracts.interface';
 import { AccordionModule } from 'primeng/accordion';
 import { SubmissionService } from '@shared/services/submission.service';
@@ -626,10 +627,12 @@ export class CreateOicrFormComponent implements OnInit {
     const currentMetadata = this.cache.currentMetadata();
     if (currentMetadata?.indicator_id && currentMetadata?.status_id) {
       const resultCode = this.cache.getCurrentNumericResultId();
+      const fromResultsCenter = isResultsCenterEntryFromUrl(this.router.url);
       await this.currentResultService.openEditRequestdOicrsModal(
         currentMetadata.indicator_id,
         currentMetadata.status_id,
-        resultCode
+        resultCode,
+        fromResultsCenter ? 'results-center' : 'project'
       );
     }
   }

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/services/create-result-management.service.spec.ts
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/services/create-result-management.service.spec.ts
@@ -144,6 +144,13 @@ describe('CreateResultManagementService', () => {
     expect(service.presetFromProjectResultsTable()).toBe(false);
   });
 
+  it('should set and clear result creation entry context', () => {
+    service.setResultCreationEntryContext('results-center');
+    expect(service.resultCreationEntryContext()).toBe('results-center');
+    service.resetModal();
+    expect(service.resultCreationEntryContext()).toBeNull();
+  });
+
   it('should set status ID', () => {
     service.setStatusId(5);
     expect(service.statusId()).toBe(5);

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/services/create-result-management.service.ts
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/services/create-result-management.service.ts
@@ -12,6 +12,7 @@ export class CreateResultManagementService {
   items = signal<AIAssistantResult[]>([]);
   contractId = signal<string | null>(null);
   presetFromProjectResultsTable = signal<boolean>(false);
+  resultCreationEntryContext = signal<'results-center' | 'project' | null>(null);
   resultTitle = signal<string | null>(null);
   year = signal<number | null>(null);
   modalTitle = signal<string>('Create A Result');
@@ -80,6 +81,7 @@ export class CreateResultManagementService {
     this.items.set([]);
     this.contractId.set(null);
     this.presetFromProjectResultsTable.set(false);
+    this.resultCreationEntryContext.set(null);
     this.resultTitle.set(null);
     this.modalTitle.set('Create A Result');
     this.statusId.set(null);
@@ -91,6 +93,10 @@ export class CreateResultManagementService {
 
   setPresetFromProjectResultsTable(value: boolean) {
     this.presetFromProjectResultsTable.set(value);
+  }
+
+  setResultCreationEntryContext(value: 'results-center' | 'project' | null) {
+    this.resultCreationEntryContext.set(value);
   }
 
   setStatusId(statusId: number | null) {

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/submit-result-content/submit-result-content.component.spec.ts
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/submit-result-content/submit-result-content.component.spec.ts
@@ -1268,6 +1268,20 @@ describe('SubmitResultContentComponent', () => {
     });
   });
 
+  it('should include result_official_code in headerData when latest origin has code in metadata', () => {
+    const baseHeader = { status_id: '6', indicator_id: 1 };
+    mockAllModalsService.submitResultOrigin.set('latest');
+    mockAllModalsService.submitHeader.set(baseHeader);
+    mockCacheService.currentMetadata.set({ status_id: 5, result_official_code: 12345 });
+
+    const result = component.headerData();
+
+    expect(result).toEqual({
+      ...baseHeader,
+      result_official_code: 12345
+    });
+  });
+
   it('should not select option when disabled', () => {
     const disabledOption = { statusId: 5, key: 'revise', disabled: true };
     const setSpy = jest.spyOn(mockSubmissionService.statusSelected, 'set');

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/submit-result-content/submit-result-content.component.ts
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/submit-result-content/submit-result-content.component.ts
@@ -50,14 +50,21 @@ export class SubmitResultContentComponent {
       const currentMetadata = this.cache.currentMetadata();
       const currentStatusId = currentMetadata?.status_id;
       const resultStatus = currentMetadata?.result_status;
+      const resultOfficialCode = currentMetadata?.result_official_code;
+      const headerWithCode =
+        resultOfficialCode !== null && resultOfficialCode !== undefined
+          ? { ...base, result_official_code: resultOfficialCode }
+          : base;
       
       if (currentStatusId != null && resultStatus) {
         return {
-          ...base,
+          ...headerWithCode,
           status_id: String(currentStatusId),
           status_config: resultStatus
         };
       }
+
+      return headerWithCode;
     }
 
     return base;

--- a/research-indicators/src/app/shared/components/filters-action-buttons/filters-action-buttons.component.html
+++ b/research-indicators/src/app/shared/components/filters-action-buttons/filters-action-buttons.component.html
@@ -2,7 +2,7 @@
 
   @if (showExportButton) {
   <p-button icon="pi pi-file-excel !text-[12px]"
-    styleClass="!rounded-[8px] !text-[12px] !py-1 !max-h-[27px] !bg-white !text-[#035BA9] !border-[#035BA9]"
+    styleClass="!rounded-[8px] !text-[12px] !py-1 !max-h-[27px] !bg-white !text-[#035BA9] !border-[#035BA9] !hidden"
     (keydown.enter)="export.emit()" (click)="export.emit()" [label]="exportLabel" class="p-button-outlined"
     [outlined]="true"></p-button>
   }

--- a/research-indicators/src/app/shared/components/filters-action-buttons/filters-action-buttons.component.html
+++ b/research-indicators/src/app/shared/components/filters-action-buttons/filters-action-buttons.component.html
@@ -2,7 +2,7 @@
 
   @if (showExportButton) {
   <p-button icon="pi pi-file-excel !text-[12px]"
-    styleClass="!rounded-[8px] !text-[12px] !py-1 !max-h-[27px] !hidden !bg-white !text-[#035BA9] !border-[#035BA9]"
+    styleClass="!rounded-[8px] !text-[12px] !py-1 !max-h-[27px] !bg-white !text-[#035BA9] !border-[#035BA9]"
     (keydown.enter)="export.emit()" (click)="export.emit()" [label]="exportLabel" class="p-button-outlined"
     [outlined]="true"></p-button>
   }

--- a/research-indicators/src/app/shared/components/oicr-header/oicr-header.component.html
+++ b/research-indicators/src/app/shared/components/oicr-header/oicr-header.component.html
@@ -1,15 +1,22 @@
 <div class="flex justify-between items-center bg-[#f4f7f9] border-y border-[#E8EBED] px-15 pb-7 pt-6">
   <div class="flex-col flex w-full">
     <div class="flex items-center {{ showTag && !shouldShowWorkflow() ? 'pb-1' : 'pb-0' }}">
-      @if (showTag && shouldShowWorkflow()) {
-      <app-oicr-workflow-status [currentStatusId]="data?.['status_id'] ?? null"
-        [statusDescription]="data?.['status_config']?.description ?? ''"
-        [iconName]="data?.['status_config']?.config?.icon?.name ?? ''"
-        [iconColor]="data?.['status_config']?.config?.icon?.color ?? ''"></app-oicr-workflow-status>
-      } @else if (showTag) {
+      @if (showTag) {
       <div class="flex items-center gap-2">
-        <i class="pi pi-chart-pie !text-[12px] text-[#F58220]"></i>
-        <span class="text-[11px] text-[#8D9299] font-[400] !font-[Space_Grotesk]">OICR</span>
+        <i class="pi pi-chart-pie !text-[12px] text-[#F58220] pt-0.5"></i>
+        <span class="text-[12px] text-[#8D9299] font-[400] !font-[Space_Grotesk] pr-1 pt-0.5">OICR
+          @if (data?.['result_official_code'] !== null && data?.['result_official_code'] !== undefined) {
+          <span class="text-[12px] text-[#8D9299] font-[400] !font-[Space_Grotesk]">
+            {{ data?.['result_official_code'] }}
+          </span>
+          }
+        </span>
+        @if (shouldShowWorkflow()) {
+        <app-oicr-workflow-status [currentStatusId]="data?.['status_id'] ?? null"
+          [statusDescription]="data?.['status_config']?.description ?? ''"
+          [iconName]="data?.['status_config']?.config?.icon?.name ?? ''"
+          [iconColor]="data?.['status_config']?.config?.icon?.color ?? ''"></app-oicr-workflow-status>
+        } @else {
         <app-custom-tag [statusId]="data?.['status_id'] ?? 9" [statusName]="data?.['status_config']?.name ?? ''"
           [statusColor]="data?.['status_config']?.config?.color?.text ?? ''"
           [statusBackground]="data?.['status_config']?.config?.color?.background ?? ''"
@@ -17,6 +24,7 @@
           [iconName]="data?.['status_config']?.config?.icon?.name ?? ''"
           [iconColor]="data?.['status_config']?.config?.icon?.color ?? ''"
           [tooltip]="data?.['status_config']?.description ?? ''" class="pb-1"></app-custom-tag>
+        }
       </div>
       } @else {
       <div class="flex items-center gap-2">

--- a/research-indicators/src/app/shared/components/project-results-table/project-results-table.component.spec.ts
+++ b/research-indicators/src/app/shared/components/project-results-table/project-results-table.component.spec.ts
@@ -34,7 +34,8 @@ describe('ProjectResultsTableComponent', () => {
 
     createResultManagementService = {
       setContractId: jest.fn(),
-      setPresetFromProjectResultsTable: jest.fn()
+      setPresetFromProjectResultsTable: jest.fn(),
+      setResultCreationEntryContext: jest.fn()
     };
 
     projectResultsTableService = {
@@ -98,6 +99,7 @@ describe('ProjectResultsTableComponent', () => {
 
     expect(createResultManagementService.setContractId).toHaveBeenCalledWith('A123');
     expect(createResultManagementService.setPresetFromProjectResultsTable).toHaveBeenCalledWith(true);
+    expect(createResultManagementService.setResultCreationEntryContext).toHaveBeenCalledWith('project');
     expect(allModalsService.openModal).toHaveBeenCalledWith('createResult');
   });
 
@@ -106,6 +108,7 @@ describe('ProjectResultsTableComponent', () => {
 
     expect(createResultManagementService.setContractId).toHaveBeenCalledWith(null);
     expect(createResultManagementService.setPresetFromProjectResultsTable).toHaveBeenCalledWith(false);
+    expect(createResultManagementService.setResultCreationEntryContext).toHaveBeenCalledWith(null);
   });
 
   it('should return danger severity for EDITING status', () => {

--- a/research-indicators/src/app/shared/components/project-results-table/project-results-table.component.ts
+++ b/research-indicators/src/app/shared/components/project-results-table/project-results-table.component.ts
@@ -71,12 +71,14 @@ export class ProjectResultsTableComponent implements OnInit, OnDestroy {
   openCreateResultForProject() {
     this.createResultManagementService.setContractId(this.contractId);
     this.createResultManagementService.setPresetFromProjectResultsTable(true);
+    this.createResultManagementService.setResultCreationEntryContext('project');
     this.allModalsService.openModal('createResult');
   }
 
   ngOnDestroy() {
     this.createResultManagementService.setContractId(null);
     this.createResultManagementService.setPresetFromProjectResultsTable(false);
+    this.createResultManagementService.setResultCreationEntryContext(null);
   }
 
   getSeverity(status: string) {

--- a/research-indicators/src/app/shared/components/result-sidebar/result-sidebar.component.html
+++ b/research-indicators/src/app/shared/components/result-sidebar/result-sidebar.component.html
@@ -43,7 +43,7 @@
     @if (!option.hide) {
     <div class="options" [class.disabled]="option.disabled" (click)="navigateTo(option, $event)"
       (keydown.enter)="navigateTo(option, $event)" [routerLink]="option.disabled ? null : option.path"
-      routerLinkActive="active">
+      [queryParams]="getResultChildQueryParams()" queryParamsHandling="merge" routerLinkActive="active">
       <div class="w-4 h-4 rounded-full flex items-center justify-center greenCheckBorder {{ option.greenCheck && 'greenCheckActive' }} {{
               option.greenCheck ? 'bg-[#509c55]' : 'bg-[#A2A9AF]'
             }}">

--- a/research-indicators/src/app/shared/components/result-sidebar/result-sidebar.component.spec.ts
+++ b/research-indicators/src/app/shared/components/result-sidebar/result-sidebar.component.spec.ts
@@ -435,6 +435,59 @@ describe('ResultSidebarComponent', () => {
         replaceUrl: false
       });
     });
+
+    it('should preserve from=results-center in queryParams when navigating sidebar', () => {
+      const getMock = route.snapshot.queryParamMap.get as jest.Mock;
+      getMock.mockImplementation((key: string) => {
+        if (key === 'version') return '2021';
+        if (key === 'from') return 'results-center';
+        return '123';
+      });
+
+      const mockEvent = { preventDefault: jest.fn() } as any;
+      const enabledOption = {
+        label: 'Section',
+        path: 'alignment',
+        disabled: false,
+        greenCheckKey: 'alignment'
+      };
+
+      component.navigateTo(enabledOption, mockEvent);
+
+      expect(router.navigate).toHaveBeenCalledWith(['/result', '123', 'alignment'], {
+        queryParams: { version: '2021', from: 'results-center' },
+        replaceUrl: false
+      });
+
+      getMock.mockReset();
+      getMock.mockReturnValue('123');
+    });
+  });
+
+  describe('getResultChildQueryParams', () => {
+    it('should include version and from when route has from=results-center', () => {
+      const getMock = route.snapshot.queryParamMap.get as jest.Mock;
+      getMock.mockImplementation((key: string) => {
+        if (key === 'version') return '2022';
+        if (key === 'from') return 'results-center';
+        return '123';
+      });
+      expect(component.getResultChildQueryParams()).toEqual({ version: '2022', from: 'results-center' });
+      getMock.mockReset();
+      getMock.mockReturnValue('123');
+    });
+
+    it('should omit from when query from is not results-center', () => {
+      const getMock = route.snapshot.queryParamMap.get as jest.Mock;
+      getMock.mockImplementation((key: string) => {
+        if (key === 'version') return '2022';
+        if (key === 'from') return 'projects';
+        return '123';
+      });
+      expect(component.getResultChildQueryParams()).toEqual({ version: '2022' });
+      getMock.mockReset();
+      getMock.mockReturnValue('123');
+    });
   });
 
   describe('getRouterLink', () => {
@@ -548,7 +601,7 @@ describe('ResultSidebarComponent', () => {
 
       expect(router.navigate).toHaveBeenCalledWith(['/project-detail', 'CONTRACT-1']);
       expect(searchValueSignal()).toBe('My Result Title');
-      expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(1, 6, 999);
+      expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(1, 6, 999, 'project');
     });
 
     it('should not set projectResultsSearchValue when url already includes project-detail', async () => {
@@ -570,7 +623,29 @@ describe('ResultSidebarComponent', () => {
 
       expect(router.navigate).toHaveBeenCalledWith(['/project-detail', 'CONTRACT-1']);
       expect(searchValueSignal()).toBe('');
-      expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(1, 6, 999);
+      expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(1, 6, 999, 'project');
+    });
+
+    it('should navigate to results-center and open OICR with results-center entry when url has from=results-center', async () => {
+      cacheService.currentMetadata?.set({
+        indicator_id: 1,
+        status_id: 6,
+        result_contract_id: 'CONTRACT-1',
+        result_title: 'My Result Title',
+        result_official_code: 999
+      });
+      const searchValueSignal = signal('');
+      (cacheService as any).projectResultsSearchValue = searchValueSignal;
+      (router as any).url = '/result/STAR-1?from=results-center';
+      (apiService.PATCH_SubmitResult as jest.Mock).mockResolvedValue({ successfulRequest: true });
+      (metadataService.update as jest.Mock).mockResolvedValue(undefined);
+      (currentResultService.validateOpenResult as jest.Mock).mockReturnValue(true);
+
+      await (component as any).updateResultStatus(6, '');
+
+      expect(router.navigate).toHaveBeenCalledWith(['/results-center']);
+      expect(searchValueSignal()).toBe('');
+      expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(1, 6, 999, 'results-center');
     });
 
     it('should only show toast when validateOpenResult returns false', async () => {
@@ -741,7 +816,7 @@ describe('ResultSidebarComponent', () => {
 
       expect(router.navigate).toHaveBeenCalledWith(['/project-detail', 'CONTRACT-1']);
       expect(searchValueSignal()).toBe('');
-      expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(1, 6, 999);
+      expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(1, 6, 999, 'project');
     });
 
     it('should call openEditRequestdOicrsModal with 0 for undefined indicator_id, status_id, result_official_code', async () => {
@@ -758,7 +833,7 @@ describe('ResultSidebarComponent', () => {
 
       await (component as any).updateResultStatus(6, '');
 
-      expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(0, 0, 0);
+      expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(0, 0, 0, 'project');
     });
   });
 
@@ -1221,7 +1296,7 @@ describe('ResultSidebarComponent', () => {
 
       await (component as any).handlePostponeOrRejectRedirect();
 
-      expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(0, 11, 12345);
+      expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(0, 11, 12345, 'project');
     });
 
     it('should handle handlePostponeOrRejectRedirect with undefined result_official_code', async () => {
@@ -1236,7 +1311,7 @@ describe('ResultSidebarComponent', () => {
 
       await (component as any).handlePostponeOrRejectRedirect();
 
-      expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(1, 11, 0);
+      expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(1, 11, 0, 'project');
     });
 
     it('should call openEditRequestdOicrsModal', async () => {
@@ -1251,7 +1326,7 @@ describe('ResultSidebarComponent', () => {
 
       await (component as any).handlePostponeOrRejectRedirect();
 
-      expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(1, 11, 12345);
+      expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(1, 11, 12345, 'project');
     });
   });
 });

--- a/research-indicators/src/app/shared/components/result-sidebar/result-sidebar.component.ts
+++ b/research-indicators/src/app/shared/components/result-sidebar/result-sidebar.component.ts
@@ -16,7 +16,11 @@ import { S3ImageUrlPipe } from '@shared/pipes/s3-image-url.pipe';
 import { RolesService } from '@shared/services/cache/roles.service';
 import { GlobalAlert } from '@shared/interfaces/global-alert.interface';
 import { CurrentResultService } from '@shared/services/cache/current-result.service';
-import { RESULT_ENTRY_SOURCE_QUERY, RESULT_ENTRY_SOURCE_VALUE_RESULTS_CENTER } from '@shared/constants/result-entry-source';
+import {
+  isResultsCenterEntryFromUrl,
+  RESULT_ENTRY_SOURCE_QUERY,
+  RESULT_ENTRY_SOURCE_VALUE_RESULTS_CENTER
+} from '@shared/constants/result-entry-source';
 
 interface SubmissionAlertData {
   severity: 'success' | 'warning';
@@ -361,11 +365,13 @@ export class ResultSidebarComponent {
       const isDraft = (status_id ?? 0) === 10 || (status_id ?? 0) === 12 || (status_id ?? 0) === 13;
       if (!isDraft || (isDraft && !this.roles.isAdmin())) {
         if (result_contract_id) {
-          this.router.navigate(['/project-detail', result_contract_id]);
-          if (!this.router.url.includes('/project-detail/')) {
-            this.cache.projectResultsSearchValue.set(result_title ?? '');
-          }
-          await this.currentResultService.openEditRequestdOicrsModal(indicator_id ?? 0, status_id ?? 0, result_official_code ?? 0);
+          await this.openOicrEditModalAfterProjectOrResultsCenterNavigation(
+            String(result_contract_id),
+            result_title,
+            indicator_id ?? 0,
+            status_id ?? 0,
+            result_official_code ?? 0
+          );
           return;
         }
       }
@@ -395,12 +401,36 @@ export class ResultSidebarComponent {
       return;
     }
 
-    this.router.navigate(['/project-detail', result_contract_id]);
+    await this.openOicrEditModalAfterProjectOrResultsCenterNavigation(
+      String(result_contract_id),
+      result_title,
+      indicator_id ?? 0,
+      status_id ?? 0,
+      result_official_code ?? 0
+    );
+  }
 
-    if (!this.router.url.includes('/project-detail/')) {
-      this.cache.projectResultsSearchValue.set(result_title ?? '');
+  private async openOicrEditModalAfterProjectOrResultsCenterNavigation(
+    resultContractId: string,
+    resultTitle: string | undefined | null,
+    indicatorId: number,
+    statusId: number,
+    resultOfficialCode: number
+  ): Promise<void> {
+    const fromResultsCenter = isResultsCenterEntryFromUrl(this.router.url);
+    if (fromResultsCenter) {
+      await this.router.navigate(['/results-center']);
+    } else {
+      await this.router.navigate(['/project-detail', resultContractId]);
+      if (!this.router.url.includes('/project-detail/')) {
+        this.cache.projectResultsSearchValue.set(resultTitle ?? '');
+      }
     }
-
-    await this.currentResultService.openEditRequestdOicrsModal(indicator_id ?? 0, status_id ?? 0, result_official_code ?? 0);
+    await this.currentResultService.openEditRequestdOicrsModal(
+      indicatorId,
+      statusId,
+      resultOfficialCode,
+      fromResultsCenter ? 'results-center' : 'project'
+    );
   }
 }

--- a/research-indicators/src/app/shared/components/result-sidebar/result-sidebar.component.ts
+++ b/research-indicators/src/app/shared/components/result-sidebar/result-sidebar.component.ts
@@ -16,6 +16,7 @@ import { S3ImageUrlPipe } from '@shared/pipes/s3-image-url.pipe';
 import { RolesService } from '@shared/services/cache/roles.service';
 import { GlobalAlert } from '@shared/interfaces/global-alert.interface';
 import { CurrentResultService } from '@shared/services/cache/current-result.service';
+import { RESULT_ENTRY_SOURCE_QUERY, RESULT_ENTRY_SOURCE_VALUE_RESULTS_CENTER } from '@shared/constants/result-entry-source';
 
 interface SubmissionAlertData {
   severity: 'success' | 'warning';
@@ -59,6 +60,16 @@ export class ResultSidebarComponent {
         greenCheck: Boolean(this.cache.greenChecks()[option.greenCheckKey as keyof GreenChecks])
       }));
   });
+
+  getResultChildQueryParams(): Record<string, string> {
+    const m = this.route.snapshot.queryParamMap;
+    const o: Record<string, string> = {};
+    const v = m.get('version');
+    const f = m.get('from');
+    if (v) o['version'] = v;
+    if (f === RESULT_ENTRY_SOURCE_VALUE_RESULTS_CENTER) o[RESULT_ENTRY_SOURCE_QUERY] = f;
+    return o;
+  }
 
   allOptions: WritableSignal<SidebarOption[]> = signal([
     {
@@ -226,10 +237,18 @@ export class ResultSidebarComponent {
     }
 
     const id = this.route.snapshot.paramMap.get('id');
-    const version = this.route.snapshot.queryParamMap.get('version');
+    const m = this.route.snapshot.queryParamMap;
+    const version = m.get('version');
+    const from = m.get('from');
     const commands = ['/result', id, option.path];
 
-    const queryParams = version ? { version } : {};
+    const queryParams: Record<string, string> = {};
+    if (version) {
+      queryParams['version'] = version;
+    }
+    if (from === RESULT_ENTRY_SOURCE_VALUE_RESULTS_CENTER) {
+      queryParams[RESULT_ENTRY_SOURCE_QUERY] = from;
+    }
 
     this.router.navigate(commands, {
       queryParams,

--- a/research-indicators/src/app/shared/components/section-header/section-header.component.spec.ts
+++ b/research-indicators/src/app/shared/components/section-header/section-header.component.spec.ts
@@ -606,6 +606,18 @@ describe('SectionHeaderComponent', () => {
       expect(breadcrumb[2].tooltip).toBe('Test Result');
     });
 
+    it('should return Results Center → Result when result was opened from Results Center (from query)', () => {
+      component['contractId'].set('');
+      component['currentUrl'].set('/result/ROAR-7/general-information?from=results-center');
+      component['resultTitle'].set('OICR title');
+
+      const breadcrumb = component.breadcrumb();
+      expect(breadcrumb).toEqual([
+        { label: 'Results Center', route: '/results-center' },
+        { label: 'Result ROAR-7', tooltip: 'OICR title' }
+      ]);
+    });
+
     it('should handle result page without resultId in URL', () => {
       component['contractId'].set('123');
       component['currentProject'].set({ projectDescription: 'Test Project' });

--- a/research-indicators/src/app/shared/components/section-header/section-header.component.spec.ts
+++ b/research-indicators/src/app/shared/components/section-header/section-header.component.spec.ts
@@ -618,6 +618,14 @@ describe('SectionHeaderComponent', () => {
       ]);
     });
 
+    it('should return empty breadcrumb when Results Center entry has no result id segment', () => {
+      component['contractId'].set('');
+      component['currentUrl'].set('/result/?from=results-center');
+      component['resultTitle'].set('x');
+
+      expect(component.breadcrumb()).toEqual([]);
+    });
+
     it('should handle result page without resultId in URL', () => {
       component['contractId'].set('123');
       component['currentProject'].set({ projectDescription: 'Test Project' });

--- a/research-indicators/src/app/shared/components/section-header/section-header.component.ts
+++ b/research-indicators/src/app/shared/components/section-header/section-header.component.ts
@@ -15,6 +15,7 @@ import { filter } from 'rxjs/operators';
 import { Subscription } from 'rxjs';
 import { DownloadOicrTemplateComponent } from '../download-oicr-template/download-oicr-template.component';
 import { RolesService } from '@shared/services/cache/roles.service';
+import { isResultsCenterEntryFromUrl } from '@shared/constants/result-entry-source';
 
 export interface BreadcrumbItem {
   label: string;
@@ -169,6 +170,19 @@ export class SectionHeaderComponent implements OnDestroy, AfterViewInit, OnInit 
   breadcrumb = computed(() => {
     const project = this.currentProject();
     const contractId = this.contractId();
+    const fullUrl = this.currentUrl();
+
+    if (this.isResultPage() && isResultsCenterEntryFromUrl(fullUrl)) {
+      const pathOnly = fullUrl.split(/[?#]/)[0];
+      const segs = pathOnly.split('/').filter(Boolean);
+      const resultId = segs[0] === 'result' && segs.length >= 2 ? segs[1] : '';
+      if (resultId) {
+        return [
+          { label: 'Results Center', route: '/results-center' },
+          { label: `Result ${resultId}`, tooltip: this.resultTitle() }
+        ] as BreadcrumbItem[];
+      }
+    }
 
     if (!contractId) return [];
 
@@ -184,8 +198,9 @@ export class SectionHeaderComponent implements OnDestroy, AfterViewInit, OnInit 
     ];
 
     if (this.isResultPage()) {
-      const urlParts = this.currentUrl().split('/');
-      const resultId = urlParts[2]; // /result/2243/any-page -> 2243
+      const pathOnly = fullUrl.split(/[?#]/)[0];
+      const segs = pathOnly.split('/').filter(Boolean);
+      const resultId = segs[0] === 'result' && segs.length >= 2 ? segs[1] : '';
 
       if (resultId) {
         baseItems[1].route = `/project-detail/${contractId}`;

--- a/research-indicators/src/app/shared/constants/result-entry-source.ts
+++ b/research-indicators/src/app/shared/constants/result-entry-source.ts
@@ -1,0 +1,14 @@
+export const RESULT_ENTRY_SOURCE_QUERY = 'from';
+export const RESULT_ENTRY_SOURCE_VALUE_RESULTS_CENTER = 'results-center';
+
+export function getResultEntrySourceFromSearch(search: string): string | null {
+  if (!search) return null;
+  const q = search.startsWith('?') ? search.slice(1) : search;
+  return new URLSearchParams(q).get(RESULT_ENTRY_SOURCE_QUERY);
+}
+
+export function isResultsCenterEntryFromUrl(url: string): boolean {
+  const i = url.indexOf('?');
+  if (i < 0) return false;
+  return getResultEntrySourceFromSearch(url.slice(i)) === RESULT_ENTRY_SOURCE_VALUE_RESULTS_CENTER;
+}

--- a/research-indicators/src/app/shared/interfaces/oicr-header-data.interface.ts
+++ b/research-indicators/src/app/shared/interfaces/oicr-header-data.interface.ts
@@ -10,6 +10,7 @@ export interface LeverData {
 
 export interface OicrHeaderData {
   title?: string;
+  result_official_code?: string | number;
   agreement_id?: string;
   description?: string;
   project_lead_description?: string;

--- a/research-indicators/src/app/shared/interfaces/oicr-resolver-metadata.interface.ts
+++ b/research-indicators/src/app/shared/interfaces/oicr-resolver-metadata.interface.ts
@@ -1,0 +1,7 @@
+export interface OicrResolverMetadata {
+  indicator_id: number | null | undefined;
+  status_id: number | null | undefined;
+  result_official_code: number | null | undefined;
+  result_contract_id: string | number | null | undefined;
+  result_title: string | null | undefined;
+}

--- a/research-indicators/src/app/shared/services/cache/all-modals.service.spec.ts
+++ b/research-indicators/src/app/shared/services/cache/all-modals.service.spec.ts
@@ -85,6 +85,20 @@ describe('AllModalsService', () => {
     });
   });
 
+  describe('setResultInformationEntryContext', () => {
+    it('should set results-center title when context is results-center', () => {
+      service.setResultInformationEntryContext('results-center');
+      expect(service.resultInformationEntryContext()).toBe('results-center');
+      expect(service.modalConfig().resultInformation.title).toBe('Result information (Results Center)');
+    });
+
+    it('should set default title when context is null', () => {
+      service.setResultInformationEntryContext(null);
+      expect(service.resultInformationEntryContext()).toBeNull();
+      expect(service.modalConfig().resultInformation.title).toBe('Result Information');
+    });
+  });
+
   describe('Signal setters', () => {
     it('should set partnerRequestSection', () => {
       service.setPartnerRequestSection('test-section');
@@ -300,6 +314,15 @@ describe('AllModalsService', () => {
       const config = service.modalConfig();
       expect(config.createResult.isOpen).toBe(false);
       expect(config.createResult.isWide).toBe(false);
+    });
+
+    it('should reset resultInformation title and entry context when closing resultInformation', () => {
+      service.setResultInformationEntryContext('results-center');
+      service.openModal('resultInformation');
+      service.closeModal('resultInformation');
+
+      expect(service.resultInformationEntryContext()).toBeNull();
+      expect(service.modalConfig().resultInformation.title).toBe('Result Information');
     });
 
     it('should handle submitResult modal close without cleanup', () => {

--- a/research-indicators/src/app/shared/services/cache/all-modals.service.ts
+++ b/research-indicators/src/app/shared/services/cache/all-modals.service.ts
@@ -27,6 +27,7 @@ interface ModalConfig {
 export class AllModalsService {
   partnerRequestSection = signal<string | null>(null);
   selectedResultForInfo = signal<Result | null>(null);
+  resultInformationEntryContext = signal<'results-center' | null>(null);
   submitResultOrigin = signal<'latest' | null>(null);
   submitHeader = signal<OicrHeaderData | null>(null);
   submitBackStep = signal<number | null>(null);
@@ -57,6 +58,17 @@ export class AllModalsService {
   refreshLinkedResults?: () => Promise<void> | void;
   setRefreshLinkedResults = (fn: (() => Promise<void> | void) | undefined) => (this.refreshLinkedResults = fn);
   syncSelectedResults = signal<Result[]>([]);
+
+  setResultInformationEntryContext(context: 'results-center' | null): void {
+    this.resultInformationEntryContext.set(context);
+    this.modalConfig.update(modals => ({
+      ...modals,
+      resultInformation: {
+        ...modals.resultInformation,
+        title: context === 'results-center' ? 'Result information (Results Center)' : 'Result Information'
+      }
+    }));
+  }
 
   setSubmitResultOrigin(origin: 'latest' | null): void {
     this.submitResultOrigin.set(origin);
@@ -190,17 +202,27 @@ export class AllModalsService {
   }
 
   closeModal(modalName: ModalName): void {
-    this.modalConfig.update(modals => ({
-      ...modals,
-      [modalName]: {
-        ...modals[modalName],
-        isOpen: false,
-        isWide: false
+    this.modalConfig.update(modals => {
+      const next = {
+        ...modals,
+        [modalName]: {
+          ...modals[modalName],
+          isOpen: false,
+          isWide: false
+        }
+      };
+      if (modalName === 'resultInformation') {
+        next.resultInformation = { ...next.resultInformation, title: 'Result Information' };
       }
-    }));
+      return next;
+    });
 
     if (modalName === 'createResult') {
       this.createResultManagementService.resetModal();
+    }
+
+    if (modalName === 'resultInformation') {
+      this.resultInformationEntryContext.set(null);
     }
   }
 
@@ -230,7 +252,7 @@ export class AllModalsService {
       requestPartner: { ...this.modalConfig().requestPartner, isOpen: false, isWide: false },
       createOicrResult: { ...this.modalConfig().createOicrResult, isOpen: false, isWide: false },
       askForHelp: { ...this.modalConfig().askForHelp, isOpen: false, isWide: false },
-      resultInformation: { ...this.modalConfig().resultInformation, isOpen: false, isWide: false },
+      resultInformation: { ...this.modalConfig().resultInformation, isOpen: false, isWide: false, title: 'Result Information' },
       addContactPerson: { ...this.modalConfig().addContactPerson, isOpen: false, isWide: false },
       selectLinkedResults: { ...this.modalConfig().selectLinkedResults, isOpen: false, isWide: false }
     });
@@ -238,6 +260,7 @@ export class AllModalsService {
     this.setSubmitResultOrigin(null);
     this.clearSubmissionData();
     this.refreshLinkedResults = undefined;
+    this.resultInformationEntryContext.set(null);
 
     this.createResultManagementService.resetModal();
   }

--- a/research-indicators/src/app/shared/services/cache/current-result.service.spec.ts
+++ b/research-indicators/src/app/shared/services/cache/current-result.service.spec.ts
@@ -37,7 +37,8 @@ describe('CurrentResultService', () => {
       modalTitle: signalMock() as any,
       contractId: signalMock() as any,
       resultTitle: signalMock() as any,
-      statusId: signalMock() as any
+      statusId: signalMock() as any,
+      setResultCreationEntryContext: jest.fn()
     } as any;
 
     TestBed.configureTestingModule({
@@ -106,6 +107,18 @@ describe('CurrentResultService', () => {
       
       expect(result).toBe(false);
       expect(mockApi.GET_OICRModal).not.toHaveBeenCalled();
+    });
+
+    it('should call setResultCreationEntryContext when a creation entry context is provided', async () => {
+      const responseData = {
+        step_three: { comment_geo_scope: 'x' },
+        base_information: { contract_id: 'C-1', title: 'T' }
+      };
+      mockApi.GET_OICRModal.mockResolvedValueOnce({ data: responseData });
+
+      await service.openEditRequestdOicrsModal(5, 1, 456, 'results-center');
+
+      expect(mockCreateResultManagement.setResultCreationEntryContext).toHaveBeenCalledWith('results-center');
     });
 
     it('should successfully open modal when indicatorId is 5', async () => {

--- a/research-indicators/src/app/shared/services/cache/current-result.service.ts
+++ b/research-indicators/src/app/shared/services/cache/current-result.service.ts
@@ -14,8 +14,16 @@ export class CurrentResultService {
   allModalsService = inject(AllModalsService);
   cache = inject(CacheService);
 
-  async openEditRequestdOicrsModal(indicatorId: number, resultStatusId: number, resultCode: number) {
+  async openEditRequestdOicrsModal(
+    indicatorId: number,
+    resultStatusId: number,
+    resultCode: number,
+    creationEntryContext?: 'results-center' | 'project' | null
+  ) {
     if (!this.validateOpenResult(indicatorId, resultStatusId)) return false;
+    if (creationEntryContext !== undefined) {
+      this.createResultManagementService.setResultCreationEntryContext(creationEntryContext);
+    }
     this.createResultManagementService.currentRequestedResultCode.set(resultCode);
     this.createResultManagementService.editingOicr.set(true);
     await this.api.GET_OICRModal(resultCode).then(response => {


### PR DESCRIPTION
Implemented end-to-end alignment for opening and continuing OICR work from either the Results Center or project paths: query-based entry (from=results-center) now drives navigation back to Results Center (instead of always project detail) when reopening or redirecting into the OICR flow, and breadcrumb labels switch to Results Center → Result instead of Projects → Project → Result when that entry applies. Modal behavior was wired so the create/edit OICR and review modals respect the same context (including submit-review header data and post-submit navigation). The OICR header was updated to show Resume Code before status, including in the review modal where it was previously missing.

The changes ensure that users who land on a result from the Results Center see consistent breadcrumbs, URLs, and modal entry context throughout OICR creation, editing, and review—without breaking the existing project-detail experience for users who never used the Results Center entry. Header presentation was improved by surfacing the result / resume code next to the OICR label and status so reviewers and authors can identify the record at a glance in both the main OICR modal and the review flow.