### PR TITLE
Export button loading state and interaction lock

### DIFF
--- a/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.html
+++ b/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.html
@@ -21,6 +21,7 @@
         }
 
         <app-filters-action-buttons [showExportButton]="true" [exportLabel]="'Export metadata results'"
+          [isExportLoading]="isExporting()"
           [showViewToggleButtons]="false" [showConfigButton]="true" (config)="showConfiguratiosnSidebar()"
           (export)="exportTable()">
         </app-filters-action-buttons>

--- a/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.html
+++ b/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.html
@@ -20,7 +20,7 @@
         </p-button>
         }
 
-        <app-filters-action-buttons [showExportButton]="true" [exportLabel]="'Export Results'"
+        <app-filters-action-buttons [showExportButton]="true" [exportLabel]="'Export metadata results'"
           [showViewToggleButtons]="false" [showConfigButton]="true" (config)="showConfiguratiosnSidebar()"
           (export)="exportTable()">
         </app-filters-action-buttons>

--- a/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.spec.ts
@@ -702,6 +702,15 @@ describe('ResultsCenterTableComponent', () => {
     globalThis.URL = originalURL;
   });
 
+  it('exportTable should return early when an export is already running', async () => {
+    component.isExporting.set(true);
+
+    await component.exportTable();
+
+    expect(mockApiService.GET_ResultCenterXlsx).not.toHaveBeenCalled();
+    expect(component.isExporting()).toBe(true);
+  });
+
   it('exportTable should log error when GET_ResultCenterXlsx rejects', async () => {
     mockApiService.GET_ResultCenterXlsx.mockRejectedValueOnce(new Error('network'));
     await component.exportTable();

--- a/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.ts
+++ b/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.ts
@@ -42,6 +42,7 @@ import { CreateResultManagementService } from '@shared/components/all-modals/mod
 })
 export class ResultsCenterTableComponent implements AfterViewInit, OnDestroy {
   readonly statusTagMaxWidth = '140px';
+  readonly isExporting = signal(false);
 
   resultsCenterService = inject(ResultsCenterService);
   private readonly router = inject(Router);
@@ -150,6 +151,10 @@ export class ResultsCenterTableComponent implements AfterViewInit, OnDestroy {
   }
 
   async exportTable() {
+    if (this.isExporting()) {
+      return;
+    }
+    this.isExporting.set(true);
     try {
       const blob = await this.apiService.GET_ResultCenterXlsx(
         this.resultsCenterService.getExportResultFilter(),
@@ -177,6 +182,8 @@ export class ResultsCenterTableComponent implements AfterViewInit, OnDestroy {
       if (error instanceof Error) {
         console.error('Error details:', error.message, error.stack);
       }
+    } finally {
+      this.isExporting.set(false);
     }
   }
 
@@ -349,7 +356,7 @@ export class ResultsCenterTableComponent implements AfterViewInit, OnDestroy {
     if (!rowEl) return;
 
     const tbody = rowEl.parentElement;
-    if (!tbody || tbody.tagName.toLowerCase() !== 'tbody') return;
+    if (tbody?.tagName.toLowerCase() !== 'tbody') return;
 
     const resultId = rowEl.dataset['resultId'];
     const platformCode = rowEl.dataset['platform'];

--- a/research-indicators/src/app/shared/components/filters-action-buttons/filters-action-buttons.component.html
+++ b/research-indicators/src/app/shared/components/filters-action-buttons/filters-action-buttons.component.html
@@ -2,9 +2,10 @@
 
   @if (showExportButton) {
   <p-button icon="pi pi-file-excel !text-[12px]"
-    styleClass="!rounded-[8px] !text-[12px] !py-1 !max-h-[27px] !bg-white !text-[#035BA9] !border-[#035BA9]"
-    (keydown.enter)="export.emit()" (click)="export.emit()" [label]="exportLabel" class="p-button-outlined"
-    [outlined]="true"></p-button>
+    styleClass="!rounded-[8px] !text-[12px] !py-1 !max-h-[27px] !min-w-[180px] !bg-white !text-[#035BA9] !border-[#035BA9]"
+    (keydown.enter)="!isExportLoading && export.emit()" (click)="!isExportLoading && export.emit()"
+    [label]="isExportLoading ? '' : exportLabel" class="p-button-outlined" [outlined]="true"
+    [disabled]="isExportLoading" [loading]="isExportLoading"></p-button>
   }
   @if (showViewToggleButtons) {
   <p-button styleClass="!rounded-[4px] !text-[12px] !p-0 !max-h-[27px] view-toggle-btn" icon="pi pi-bars" size="small"

--- a/research-indicators/src/app/shared/components/filters-action-buttons/filters-action-buttons.component.ts
+++ b/research-indicators/src/app/shared/components/filters-action-buttons/filters-action-buttons.component.ts
@@ -11,7 +11,7 @@ import { InputTextModule } from 'primeng/inputtext';
 })
 export class FiltersActionButtonsComponent {
   @Input() showExportButton = false;
-  @Input() exportLabel = 'Export Results';
+  @Input() exportLabel = 'Export metadata results';
   @Input() showViewToggleButtons = false;
   @Input() isTableView = false;
 

--- a/research-indicators/src/app/shared/components/filters-action-buttons/filters-action-buttons.component.ts
+++ b/research-indicators/src/app/shared/components/filters-action-buttons/filters-action-buttons.component.ts
@@ -12,6 +12,7 @@ import { InputTextModule } from 'primeng/inputtext';
 export class FiltersActionButtonsComponent {
   @Input() showExportButton = false;
   @Input() exportLabel = 'Export metadata results';
+  @Input() isExportLoading = false;
   @Input() showViewToggleButtons = false;
   @Input() isTableView = false;
 


### PR DESCRIPTION
Disable Export During Request
Prevents duplicate export calls by disabling the export button while the file request is in progress.

Show Export Loading State
Displays a loading indicator on the export button so users get immediate feedback that the export is running.

Block Interaction While Loading
Prevents click and keyboard-triggered export actions when loading is active.

Reset Loading Safely
Ensures the loading state is always cleared in a finally block, even if the export request fails.
