### PR TITLE
📝 docs(sdd): establish SDD constitutional baseline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,109 @@
+# CLAUDE.md — Repository Guide for Claude Code
+
+This is the **constitutional baseline** for the `alliance-research-indicators-client` repository. Read it before making non-trivial changes.
+
+The actual application lives under `research-indicators/` (Angular 19 + PrimeNG 19 SPA). The `docs/` folder is the source of truth for product intent, UX rules, and technical conventions.
+
+---
+
+## Constitutional Documents
+
+All four are living documents. If reality disagrees with them, **fix one or the other** — never let them drift.
+
+| Document | Purpose | Consult before… |
+|----------|---------|-----------------|
+| [`docs/prd.md`](./docs/prd.md) | **PRD** — problem, personas (4), goals & KPIs, scope, non-goals, user stories, acceptance criteria, constraints | Any change that affects what the product *does* for users, or that touches scope / personas / KPIs |
+| [`docs/system-design/design.md`](./docs/system-design/design.md) | **System Design** — UX principles, IA, flows, screen inventory, navigation, tokens, components, responsive, a11y, dark mode, design decisions | Any UI/UX change — new screen, new pattern, new color/spacing, new modal, theme work |
+| [`docs/detailed-design/detailed-design.md`](./docs/detailed-design/detailed-design.md) | **Detailed Design** — system overview, modules, data model, API contracts, state boundaries, integrations, security, errors, testing, constraints | Any technical change — new service, interceptor, route, dependency, integration, or change to state/auth/error patterns |
+| [`docs/specs/general-setup/`](./docs/specs/general-setup/) | **SDD templates** — `requirements.md`, `design.md`, `task.md` formats for module specs | Before running `/sdd-specify` for any new feature/module |
+
+These four documents form the SDD constitutional baseline. Future `/sdd-specify`, `/sdd-execute`, `/sdd-validate`, and `/sdd-test` work depends on them.
+
+### Child guides
+
+Scoped guides for specific subtrees. Read them in addition to the constitutional docs whenever you're working inside their folder.
+
+| Guide | Scope |
+|-------|-------|
+| [`research-indicators/src/CLAUDE.md`](./research-indicators/src/CLAUDE.md) | Day-to-day coding contract for the Angular SPA source — folder layout, path aliases, where new code goes, conventions, tests, commands |
+
+---
+
+## How module specs are organized
+
+Spec taxonomy is **by domain module**, mirroring the page modules in [`docs/detailed-design/detailed-design.md`](./docs/detailed-design/detailed-design.md) §2.
+
+```
+docs/specs/
+├── general-setup/           # methodology templates (this baseline)
+├── results/                 # result lifecycle work
+├── indicators/              # indicator catalog
+├── projects/                # projects & project detail
+├── dashboard/               # analytics & charts
+├── notifications/           # real-time feed
+├── administration/          # center-admin tooling (bulk upload, SDG mgmt)
+├── auth/                    # cognito, JWT, guards
+├── shared/                  # cross-cutting shared components/services
+└── platform/                # shell, navbar, sidebar
+```
+
+Inside each domain, one folder per feature/spec (kebab-case). Each spec folder contains:
+
+- `requirements.md` — what to build (from [`docs/specs/general-setup/requirements.md`](./docs/specs/general-setup/requirements.md))
+- `design.md` — how to build it (from [`docs/specs/general-setup/design.md`](./docs/specs/general-setup/design.md))
+- `task.md` — execution units (from [`docs/specs/general-setup/task.md`](./docs/specs/general-setup/task.md))
+
+Requirement IDs follow `REQ-<DOMAIN>-<NN>` and task IDs follow `T-<DOMAIN>-<NN>` (see the templates). IDs are immutable once published.
+
+---
+
+## Hard rules (from the PRD constraints — C-1 through C-6)
+
+When you change code, these are non-negotiable unless the PRD itself is updated:
+
+- **C-1**: Stack is **Angular 19 + PrimeNG 19**. No framework migration.
+- **C-2**: Auth is **AWS Cognito + JWT**. No alternative IdPs in this client.
+- **C-3**: Controlled vocabularies come from **CLARISA**. No parallel taxonomies for institutions, countries, regions, SDGs, levers, impact areas, etc.
+- **C-4**: Accessibility floor is **WCAG 2.1 AA** on every changed screen.
+- **C-5**: Production bundles must respect `angular.json` budgets (initial ≤ 3 MB error / 2 MB warning; component styles ≤ 8 kB / 4 kB).
+- **C-6**: New features are **lazy-loaded standalone components**. No NgModules.
+
+See [`docs/prd.md`](./docs/prd.md) §8.3 for the full constraint list.
+
+---
+
+## Where things live
+
+- **Angular source**: `research-indicators/src/` — see also the child guide [`research-indicators/src/CLAUDE.md`](./research-indicators/src/CLAUDE.md) for folder layout, aliases, and per-folder conventions.
+- **Routes**: `research-indicators/src/app/app.routes.ts`
+- **Pages**: `research-indicators/src/app/pages/`
+- **Shared (components, services, pipes, utils, interfaces)**: `research-indicators/src/app/shared/`
+- **Theme (PrimeNG Aura preset)**: `research-indicators/src/app/theme/roartheme.ts`
+- **Global SCSS & tokens**: `research-indicators/src/styles/`
+- **Environments**: `research-indicators/src/environments/`
+- **Jest config**: `research-indicators/jest.config.ts`
+- **Color & utility-class reference**: `research-indicators/README.md`
+- **Docker / Nginx**: `research-indicators/Dockerfile`, `research-indicators/nginx.conf`, `research-indicators/docker-compose.yml`
+- **CI**: `.github/workflows/` (unit tests, SonarCloud, Jenkins trigger)
+
+---
+
+## Quick patterns
+
+- **Color/spacing**: use token utility classes (`abc-*`, `atc-*`, `rs-*`, `fs-*`) — never hardcoded hex. See [`docs/system-design/design.md`](./docs/system-design/design.md) §7 and `research-indicators/README.md`.
+- **HTTP**: go through `ApiService` (or a domain service that delegates to it). Always handle `MainResponse<T>`. Surface 409 conflicts via the link-to-existing flow.
+- **State**: signals (`signal`, `computed`, `WritableSignal`) for client state; RxJS for streams; no NgRx. See [`docs/detailed-design/detailed-design.md`](./docs/detailed-design/detailed-design.md) §6.
+- **Auth**: never bypass `jWtInterceptor`. Tokens stay in `localStorage` + cache signals; never logged.
+- **Modals**: use `all-modals` host + `modal` wrapper, not ad-hoc overlays.
+- **Forms**: reactive forms; wrapped PrimeNG inputs from `custom-fields.scss` / `custom-prime-force-styles.scss`.
+- **Testing**: Jest co-located `.spec.ts`. Shared fixtures in `src/app/testing/`. Don't push project coverage below the floors in `jest.config.ts`.
+
+---
+
+## Working with this repo as Claude
+
+1. **Before non-trivial work**, scan the relevant constitutional doc above.
+2. **For new features**, run `/sdd-specify` and follow the templates in [`docs/specs/general-setup/`](./docs/specs/general-setup/).
+3. **For UI work**, reach for shared components and tokens before inventing new ones. If you must introduce a new pattern, record the decision in [`docs/system-design/design.md`](./docs/system-design/design.md) §12 in the same change.
+4. **For technical changes**, if you deviate from the patterns in [`docs/detailed-design/detailed-design.md`](./docs/detailed-design/detailed-design.md), update that doc in the same change.
+5. **Open questions** belong in the relevant doc's "Open Questions" section, not in commit messages.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,181 @@
+# Alliance Research Indicators — Client
+
+Web client for the **Alliance of Bioversity International and CIAT** (and the broader CGIAR ecosystem) — used to report, search, validate, and analyze research results mapped to a standardized indicator framework. It is the user-facing layer of a multi-platform results federation that includes **STAR, TIP, PRMS, and AICCRA**.
+
+The application captures structured evidence of research outcomes (capacity sharing events, innovation development, policy changes, OICRs, IP rights, partners, evidence files, geographic scope) using canonical **CLARISA** controlled vocabularies so results are comparable across platforms and reportable to funders.
+
+> The **constitutional baseline** for this repository lives in [`docs/`](./docs/). Read it before non-trivial changes. The day-to-day coding contract for the Angular SPA lives in [`research-indicators/src/CLAUDE.md`](./research-indicators/src/CLAUDE.md).
+
+---
+
+## Repository layout
+
+```
+alliance-research-indicators-client/
+├── README.md                       ← this file
+├── CLAUDE.md                       ← repo-level guide for Claude Code
+├── LICENSE
+├── docs/                           ← SDD constitutional baseline (read first)
+│   ├── prd.md
+│   ├── system-design/design.md
+│   ├── detailed-design/detailed-design.md
+│   └── specs/
+│       ├── general-setup/          ← methodology templates
+│       │   ├── requirements.md
+│       │   ├── design.md
+│       │   └── task.md
+│       └── <domain>/<feature>/     ← feature specs (created via /sdd-specify)
+└── research-indicators/            ← Angular 19 + PrimeNG 19 SPA
+    ├── README.md                   ← app-level: color tokens, utility classes
+    ├── README.Docker.md            ← Docker usage notes
+    ├── src/
+    │   ├── CLAUDE.md               ← child guide: folder layout, aliases, conventions
+    │   └── ...                     ← Angular source
+    ├── angular.json
+    ├── package.json
+    ├── Dockerfile
+    ├── docker-compose.yml
+    └── nginx.conf
+```
+
+---
+
+## Documentation map
+
+The `docs/` folder is the source of truth for product intent, UX rules, and technical conventions. All four documents are **living** — if reality disagrees with them, fix one or the other.
+
+| Document | What it covers | When to consult |
+|----------|----------------|-----------------|
+| [`docs/prd.md`](./docs/prd.md) | **Product Requirements** — problem, four personas (Researcher, Center Admin, MEL Regional Expert, Cross-Platform Consumer), goals, KPIs (M1–M8), scope, non-goals, user stories (R-1…CP-3, S-1…S-3), acceptance criteria, hard constraints (C-1…C-6), assumptions, open questions | Any change that affects **what** the product does for users, or that touches scope / personas / KPIs |
+| [`docs/system-design/design.md`](./docs/system-design/design.md) | **UI/UX Blueprint** — experience principles, information architecture, 5 primary user flows, 22-screen inventory, navigation model, layout patterns, design tokens, component inventory, responsive behavior, accessibility, dark mode, decision record, open gaps | Any UI/UX change — new screen, pattern, color/spacing, modal, or theme work |
+| [`docs/detailed-design/detailed-design.md`](./docs/detailed-design/detailed-design.md) | **Technical Blueprint** — system overview, domain modules, data model, API contracts (`MainResponse<T>` envelope, 3 services, 3 interceptors), state boundaries (signals + RxJS, no NgRx), integrations (Cognito, CLARISA, file-manager, text-mining, WebSocket, analytics), security/authorization, error handling, testing strategy, constraints | Any technical change — new service, interceptor, route, dependency, integration, or change to state/auth/error patterns |
+| [`docs/specs/general-setup/`](./docs/specs/general-setup/) | **SDD methodology templates** for module specs: [`requirements.md`](./docs/specs/general-setup/requirements.md), [`design.md`](./docs/specs/general-setup/design.md), [`task.md`](./docs/specs/general-setup/task.md) | Before running `/sdd-specify` for any new feature/module |
+
+Together these documents are the foundation for `/sdd-specify`, `/sdd-execute`, `/sdd-validate`, and `/sdd-test`.
+
+### Spec taxonomy
+
+Spec folders under `docs/specs/` are organized **by domain module**, mirroring [`docs/detailed-design/detailed-design.md`](./docs/detailed-design/detailed-design.md) §2:
+
+```
+docs/specs/
+├── general-setup/    ← templates (this baseline)
+├── results/          ← result lifecycle work (11 metadata tabs)
+├── indicators/       ← indicator catalog
+├── projects/         ← projects & project detail
+├── dashboard/        ← analytics & charts
+├── notifications/    ← real-time feed
+├── administration/   ← center-admin tooling (bulk upload, SDG mgmt)
+├── auth/             ← Cognito, JWT, guards
+├── shared/           ← cross-cutting shared components/services
+└── platform/         ← shell, navbar, sidebar
+```
+
+Each feature spec is a slug folder (kebab-case) containing `requirements.md`, `design.md`, and `task.md` derived from the templates. Requirement IDs (`REQ-<DOMAIN>-<NN>`) and task IDs (`T-<DOMAIN>-<NN>`) are **immutable** once published.
+
+---
+
+## Hard constraints (from PRD §8.3)
+
+These bind every change. Updates require updating the PRD itself.
+
+- **C-1** Stack is **Angular 19 + PrimeNG 19**. No framework migration.
+- **C-2** Auth is **AWS Cognito + JWT**. No alternative IdPs.
+- **C-3** Controlled vocabularies come from **CLARISA**. No parallel taxonomies.
+- **C-4** **WCAG 2.1 AA** accessibility floor on every changed screen.
+- **C-5** Production bundles respect `angular.json` budgets (initial ≤ 3 MB error / 2 MB warning; component styles ≤ 8 kB / 4 kB).
+- **C-6** New features are **lazy-loaded standalone components**. No NgModules.
+
+---
+
+## Getting started
+
+All commands run from the `research-indicators/` directory.
+
+### Prerequisites
+
+- **Node.js 20.x** (matches the Dockerfile build stage).
+- **npm 10.x** (ships with Node 20).
+- Access to the backend services configured in `src/environments/environment*.ts`:
+  - `mainApiUrl` — primary REST API
+  - `textMiningUrl` — text-mining / NLP microservice
+  - `fileManagerUrl` — evidence file upload service
+- **AWS Cognito** user-pool credentials (consumed at runtime).
+
+### Install
+
+```bash
+cd research-indicators
+npm install
+```
+
+### Run
+
+| Command | Purpose |
+|---------|---------|
+| `npm start` | Dev server at `http://localhost:4200` (hot reload) |
+| `npm run build` | Production build → `dist/research-indicators/` |
+| `npm run build-dev` | Dev build with sourcemaps |
+| `npm run test` | Jest unit tests |
+| `npm run test:watch` | Jest in watch mode |
+| `npm run test:coverage` | Coverage report (floors: stmts 40% / branches 20% / lines 45% / functions 30%) |
+| `npm run lint` | Angular ESLint (TS + HTML) |
+| `npm run s-lint` | Stylelint (SCSS) |
+| `npm run compose:up:dev` | Docker Compose dev profile |
+| `npm run compose:up:prod` | Docker Compose prod profile |
+
+See [`research-indicators/README.md`](./research-indicators/README.md) for the **color token system** and **responsive utility classes** reference. See [`research-indicators/README.Docker.md`](./research-indicators/README.Docker.md) for Docker-specific usage.
+
+---
+
+## Architecture at a glance
+
+```
+┌────────────────────────────────────────────┐
+│      Browser (Angular 19 SPA, this repo)   │
+│  PrimeNG 19, Signals + RxJS, SCSS tokens   │
+│  Lazy standalone routes • JWT + Cognito    │
+│  WebSocket presence/notifications          │
+└──────┬───────────┬────────────────────┬────┘
+       │ HTTPS REST│ HTTPS REST         │ WSS
+       ▼           ▼                    ▼
+   Main API    Text-Mining          WebSocket
+   (NestJS)    microservice         gateway
+       │
+       ▼
+   CLARISA   ◀── STAR / TIP / PRMS / AICCRA (federation)
+                ▲
+                │
+           AWS Cognito
+```
+
+Full architecture, data model, API contracts, and security model in [`docs/detailed-design/detailed-design.md`](./docs/detailed-design/detailed-design.md).
+
+---
+
+## Build & deploy
+
+- **Multi-stage Dockerfile** at [`research-indicators/Dockerfile`](./research-indicators/Dockerfile) — Node 20-alpine build → Nginx-alpine serving `dist/research-indicators/browser` on port 80.
+- **Nginx** config at [`research-indicators/nginx.conf`](./research-indicators/nginx.conf) — SPA fallback (`try_files $uri $uri/ /index.html`).
+- **Compose** at [`research-indicators/docker-compose.yml`](./research-indicators/docker-compose.yml) — dev profile mounts source for hot reload.
+- **Service worker** at [`research-indicators/ngsw-config.json`](./research-indicators/ngsw-config.json) — registered in production builds only (currently a no-op for offline; see detailed-design §11.4).
+- **CI/CD** workflows in [`.github/workflows/`](./.github/workflows/): `unit-tests.yml`, `sonarcloud-analysis.yml`, `jenkins-trigger.yml`.
+
+---
+
+## Contributing
+
+1. **Read the relevant constitutional doc** before non-trivial work (see [Documentation map](#documentation-map)).
+2. **For new features**, run `/sdd-specify` and follow the templates in [`docs/specs/general-setup/`](./docs/specs/general-setup/). Place the spec under the matching `docs/specs/<domain>/<feature>/` folder.
+3. **For UI work**, reach for shared components and tokens before inventing new ones. New patterns must be recorded in [`docs/system-design/design.md`](./docs/system-design/design.md) §12 in the same change.
+4. **For technical changes**, if you deviate from [`docs/detailed-design/detailed-design.md`](./docs/detailed-design/detailed-design.md), update that doc in the same change.
+5. **Open questions** belong in the relevant doc's "Open Questions" section, not in commit messages.
+6. **Tests** must not push project coverage below the floors enforced by [`research-indicators/jest.config.ts`](./research-indicators/jest.config.ts).
+
+Conventions for branching, PR titles, and execution sequencing are documented in [`docs/specs/general-setup/task.md`](./docs/specs/general-setup/task.md) §6.
+
+---
+
+## License
+
+See [`LICENSE`](./LICENSE).

--- a/docs/detailed-design/detailed-design.md
+++ b/docs/detailed-design/detailed-design.md
@@ -1,0 +1,349 @@
+# Alliance Research Indicators — Detailed Design (Technical Blueprint)
+
+> The implementation blueprint. Companion to [`../prd.md`](../prd.md) (product) and [`../system-design/design.md`](../system-design/design.md) (UI/UX). When the code disagrees with this document, fix one or the other — never let them drift.
+
+---
+
+## 1. System Overview
+
+The repository contains a **single Angular 19 SPA** (under `research-indicators/`) that acts as the client tier of the Alliance Research Indicators platform.
+
+```
+┌────────────────────────────────────────────┐
+│      Browser (Angular 19 SPA, this repo)   │
+│                                            │
+│  - PrimeNG 19 UI, Signals + RxJS, SCSS     │
+│  - Lazy standalone routes                  │
+│  - JWT + Cognito auth                      │
+│  - WebSocket presence/notifications        │
+│  - Analytics: Hotjar, Clarity, GA, BugHerd │
+└──────────┬───────────────┬──────────────┬──┘
+           │ HTTPS / REST  │ HTTPS / REST │ WSS
+           │               │              │
+┌──────────▼──┐   ┌────────▼──────┐  ┌────▼──────────┐
+│  Main API   │   │ Text-Mining   │  │ File Manager  │
+│  (NestJS)   │   │ microservice  │  │ microservice  │
+└─────────────┘   └───────────────┘  └───────────────┘
+           │
+           ▼
+   ┌─────────────┐         ┌───────────────────┐
+   │   CLARISA   │         │ STAR / TIP / PRMS │
+   │ (lists)     │         │ AICCRA (federation)│
+   └─────────────┘         └───────────────────┘
+                      │
+                      ▼
+              ┌───────────────┐
+              │ AWS Cognito   │
+              └───────────────┘
+```
+
+- **Build artifacts** ship as static files behind **Nginx** in an Alpine container.
+- **CI/CD**: GitHub Actions (`unit-tests.yml`, `sonarcloud-analysis.yml`, `jenkins-trigger.yml`).
+- **Versioning**: npm semver scripts (`version:patch|minor|major`); production builds register a service worker (`ngsw-config.json`).
+
+---
+
+## 2. Domain Modules & Responsibilities
+
+The Angular app is organized by **page domain** under `src/app/pages/` with cross-cutting code in `src/app/shared/`. Spec work should follow the same domain split (see [`../specs/general-setup/`](../specs/general-setup/)).
+
+| Module | Path | Responsibility |
+|--------|------|----------------|
+| **Platform shell** | `src/app/pages/platform/` | Authenticated shell — navbar, sidebar, outlet for children |
+| **Home** | `pages/platform/pages/home/` | Logged-in dashboard / entry actions |
+| **Indicator** | `pages/platform/pages/indicator/`, `about-indicators/` | Indicator catalog & detail |
+| **Results** | `pages/platform/pages/result/`, `results-center/`, `search-a-result/`, `load-result/` | Result lifecycle: create, edit (11 tabs), search, hub |
+| **Projects** | `pages/platform/pages/my-projects/`, `project-detail/` | Project portfolio & detail |
+| **Dashboard** | `pages/platform/pages/dashboard/` | Aggregate analytics, Chart.js views |
+| **Notifications** | `pages/platform/pages/notifications/` | Real-time feed |
+| **Profile** | `pages/platform/pages/profile/` | User settings, theme |
+| **About** | `pages/platform/pages/about/` | App info |
+| **Administration / Center Admin** | `pages/platform/pages/administration/center-admin/` | Bulk upload, SDG management |
+| **Auth** | `pages/login/`, `pages/auth/` | Cognito entry & callback |
+| **Landing** | `pages/landing/` | Public surface |
+| **Real-time** | `pages/room/` | WebSocket collaboration |
+| **OICR Download** | `pages/oicr-download/` | Public template download |
+| **Dynamic Fields** | `pages/dynamic-fields/` | Form-field configuration utility |
+| **Shared** | `src/app/shared/` | Components, services, pipes, utilities, interfaces |
+| **Theme** | `src/app/theme/` | PrimeNG Aura preset (`roartheme.ts`) |
+| **Testing** | `src/app/testing/` | Test harness, mocks |
+
+---
+
+## 3. Data Model & Entities
+
+The authoritative source of truth is the backend; this document reflects the **client-side TypeScript shapes** under `src/app/shared/interfaces/`.
+
+### 3.1 Core entities (client view)
+
+- **Result** (`result.interface.ts`) — the central record. Fields span all 11 tabs:
+  - Identity: `id`, `official_code`, `platform_code`, `title`, `description`, `indicator_id`, `version`
+  - Lifecycle: `status_id`, `created_at`, `updated_at`, `submitted_at`, `submitted_by`
+  - General info: `start_date`, `end_date`, `keywords`, `language_id`, `geographic_scope_id`
+  - Sub-entities below
+- **Result sub-entities** (one interface file each):
+  - `general-information`, `links-to-result`, `alliance-alignment`, `partners`, `evidence`, `oicr-details`, `ip-rights`, `capacity-sharing`, `policy-change`, `innovation-details`, `geographic-scope`
+- **Project** — research project metadata; results link to projects.
+- **Indicator** (`api.interface.ts`) — five known indicator types (1–5), each with category metadata and example results.
+- **User** (`get-current-user.interface.ts`) — `user_id`, `role_id`, `sec_role_id`, `focus_id`, `first_name`, `last_name`, `email`, `center`, `platform`.
+- **Cache state** (`cache.interface.ts`) — client UI state: current result, current metadata, theme, modals, role flags.
+- **Controlled-list entities** — institutions, countries, regions, subnational, SDGs, levers, sdg-targets, impact-areas, delivery-modality, languages, session-types, session-purposes, actor-types.
+- **MainResponse<T>** (`responses.interface.ts`) — envelope: `{ successfulRequest, status, data, errorDetail }`.
+- **HttpErrorResponse** (`http-error-response.interface.ts`) + `ErrorDetailLike` — structured error shape.
+
+### 3.2 Versioning
+
+- Results are **versioned** server-side. The client receives a `version` field and supports a `?version=N` query param on `/result/:id`.
+- `VersionWatcherService` polls / observes version transitions and surfaces stale-data prompts.
+
+### 3.3 Federation identity
+
+- Cross-platform identity is the pair (`platform_code`, `official_code`).
+- Duplicate creation returns **HTTP 409** with the existing record reference — the client surfaces a link-to-existing flow.
+
+---
+
+## 4. API Surface & Contracts
+
+Three backend services are consumed; URLs come from `src/environments/environment*.ts`.
+
+### 4.1 Service URLs
+
+| Env var | Purpose | Owner |
+|---------|---------|-------|
+| `environment.mainApiUrl` | Primary REST backend (NestJS-style) | Main API team |
+| `environment.textMiningUrl` | AI/NLP auto-fill & extraction | Text-mining team |
+| `environment.fileManagerUrl` | Evidence file upload/serve | File-manager team |
+
+### 4.2 Response envelope
+
+```ts
+interface MainResponse<T> {
+  successfulRequest: boolean;
+  status: number;
+  data: T;
+  errorDetail?: {
+    status: number;
+    title: string;
+    description?: string;
+    errors?: Array<{ field: string; message: string }>;
+  };
+}
+```
+
+The client should **never** parse a raw `T` — always go through `MainResponse<T>`. Interceptors centralize this.
+
+### 4.3 Representative endpoints (consumed via `ApiService`)
+
+- `POST /authorization/login`
+- `POST /authorization/refresh-token`
+- `GET /indicator-types`, `GET /indicators`
+- `GET /maturity-levels`
+- `GET /tools/clarisa/institutions`, `/sdgs`, `/levers`, `/sdg-targets`, `/impact-areas`, `/countries`, `/languages`, `/delivery-modality`, `/session-types`
+- `GET /results`, `GET /results/search`, `GET /results/:id`
+- `POST /results`, `PATCH /results/:id`, `PATCH /results/:id/submit`, `DELETE /results/:id/:field`
+- `GET /results-center`, `GET /dashboards`
+- `GET /projects`, `GET /contracts`, `GET /metadata`
+
+### 4.4 Client contract rules
+
+- **Always** wrap HTTP calls behind `ApiService` (or domain-specific service that delegates to it). No raw `HttpClient` in components.
+- **Never** swallow `successfulRequest === false`. Pass it through to `ActionsService` so the user sees a toast/alert.
+- **Conflicts (409)**: surface a structured "link to existing" prompt; do not retry blindly.
+- **Auth (401)**: handled by `jWtInterceptor` → refresh → retry once. After a second 401, log the user out.
+- **Validation errors**: render `errorDetail.errors[]` inline next to the offending form field.
+
+---
+
+## 5. Backend Workflows & Business Rules (Client Reflection)
+
+The backend is authoritative; the client must mirror these rules so users don't run into surprises mid-flow:
+
+1. **Result creation** validates uniqueness of (`platform_code`, `official_code`) → 409 if duplicate.
+2. **Tab completion** is independent — saving one tab doesn't require others to be complete.
+3. **Submission** requires required-field validation across tabs; the client should pre-check before calling `PATCH /results/:id/submit`.
+4. **MEL review** transitions are server-driven; the client reads `status_id` and renders permitted actions accordingly.
+5. **Center-admin actions** (bulk upload, SDG management) require `role_id === 9` plus matching `focus_id` / `sec_role_id` checks (mirrored client-side by `RolesService` / `centerAdminGuard`).
+6. **Versioning**: editing a stale version returns 409/410-style errors; client prompts user to reload.
+7. **Evidence files** are uploaded to the file-manager service first, then the resulting URL is attached to the result — never embed raw file bytes in a result POST.
+
+---
+
+## 6. Frontend Architecture & State Boundaries
+
+### 6.1 Component / module style
+
+- **Standalone components only.** No NgModules in new code. Lazy load via `loadComponent: () => import(...)` (see `src/app/app.routes.ts`).
+- **View transitions** enabled at the router (`withViewTransitions()`).
+- **Path aliases** declared in `tsconfig.json` (and mirrored in `jest.config.ts`):
+  - `@platform`, `@landing`, `@pages`, `@shared`, `@services`, `@guards`, `@envs`, `@interfaces`, etc.
+- Prefix for generated selectors is `app` (see `angular.json`).
+
+### 6.2 State boundaries
+
+| Layer | Primary tool | Where it lives |
+|-------|--------------|----------------|
+| Server cache | `ApiService` + per-domain services + `MainResponse<T>` | `src/app/shared/services/` |
+| Client cache (cross-cutting state) | **Angular Signals** (`signal`, `computed`, `WritableSignal<T>`) | `shared/services/cache.service.ts` |
+| Reactive streams (HTTP, WebSocket) | **RxJS** | services + interceptors |
+| Local component state | Signals (preferred) or component fields | inside components |
+| Persisted state | `localStorage` (tokens, theme) via cache services | `cache.service.ts`, `dark-mode.service.ts` |
+| URL state | Angular Router (route params, query params) | `app.routes.ts` |
+
+- **No NgRx.** Service-per-domain + signals is the established pattern.
+- **No two-way binding** for cross-cutting state; use signals + setters.
+
+### 6.3 Interceptors
+
+Three are registered (order matters):
+
+1. `jWtInterceptor` — attaches JWT, proactively refreshes near expiry, retries once on 401.
+2. `httpErrorInterceptor` — central error logging + toast/alert dispatch via `ActionsService`.
+3. `resultInterceptor` — result-domain transformations (e.g., version handling).
+
+### 6.4 Real-time (WebSocket)
+
+- `WebsocketService` connects on app init via `ngx-socket-io`.
+- Emits `config-user` (name, userId, platform) to identify the client.
+- Listens to: `all-connected-users-<platform>`, `notifications`, `alert-<platform>`.
+- Exposes signals (`userList`, `currentRoom`) for components.
+- **Degradation**: when the socket is disconnected, UI must continue to function with REST polling fallbacks where applicable; it must never block on `connected`.
+
+### 6.5 Form handling
+
+- Reactive forms via `@angular/forms`.
+- Each result tab is its own form; `shared-result-form` provides the host pattern.
+- Custom fields (`custom-fields`) and PrimeNG inputs are wrapped via `src/styles/custom-fields.scss` / `custom-prime-force-styles.scss`.
+- Validation: client-side mirrors server-side; server-side wins on conflict.
+
+---
+
+## 7. Integration Points
+
+| Integration | Mechanism | Service / file |
+|-------------|-----------|----------------|
+| **AWS Cognito** | OAuth-style redirect → `/auth` callback → token exchange | `cognito.service.ts`, `login.component`, `auth.component` |
+| **Main API** | REST over HTTPS, `MainResponse<T>` envelope | `api.service.ts`, `to-promise.service.ts` |
+| **Text-mining service** | REST | `text-mining.service.ts` |
+| **File-manager service** | REST multipart upload, returns persistent URL | `file-manager.service.ts` |
+| **WebSocket gateway** | Socket.IO via `ngx-socket-io` | `sockets/websocket.service.ts` |
+| **CLARISA** | Indirect via main API endpoints (`/tools/clarisa/*`) | `get-clarisa-institutions-*.service.ts`, `get-subnational-by-iso-alpha.service.ts` |
+| **Hotjar** | Browser SDK | `hotjar.service.ts`, `tracking-tools.service.ts` |
+| **Microsoft Clarity** | Browser SDK | `clarity.service.ts` |
+| **Google Analytics** | Browser SDK | `google-analytics.service.ts` |
+| **BugHerd** | Browser SDK | `bug-herd.service.ts` |
+| **Service worker** | Angular ngsw, production builds only | `ngsw-config.json`, `app.config.ts` |
+
+Federation with STAR / TIP / PRMS / AICCRA is **read/link-only** from the client — it follows deep-link URLs supplied by the main API.
+
+---
+
+## 8. Security & Authorization Model
+
+### 8.1 Authentication
+
+- **AWS Cognito** + JWT (PRD C-2). No alternative IdPs.
+- Tokens (`access_token`, `refresh_token`, `exp`) stored in `localStorage` and mirrored in cache signals.
+- `jWtInterceptor` performs **proactive expiration checks** before each outbound request and refreshes when within the configured skew.
+- Refresh failure → clear tokens + redirect to `/login`.
+
+### 8.2 Authorization
+
+- Backend is authoritative. The client mirrors role checks for UX (hide actions early).
+- `rolesGuard` — global authenticated/unauthenticated routing decision.
+- `centerAdminGuard` — composite check: `role_id === 1` (Admin) OR (`role_id === 9` AND focus/sec-role match).
+- `RolesService` exposes computed signals for role membership and feature visibility.
+- **Never** trust the client to enforce destructive policies; the backend must reject unauthorized writes regardless of client UI.
+
+### 8.3 Sensitive data handling
+
+- No PII beyond user account fields (name, email, center) is stored client-side.
+- Tokens are never logged or sent to analytics SDKs.
+- Evidence uploads pass through the file-manager service and are never inlined.
+- Service workers (`ngsw-worker.js`) are scoped to production and do not cache authenticated API responses by default.
+
+---
+
+## 9. Error Handling & Observability
+
+### 9.1 Error handling
+
+- **Layered model**:
+  1. `httpErrorInterceptor` — central HTTP error trap.
+  2. `ActionsService` — converts errors into toasts (`global-toast`), alerts (`global-alert`, `alert-tag`), and structured form-field errors.
+  3. Components subscribe to `ActionsService` signals for surface-specific behavior.
+- **User-facing rule**: every error reaches the user as a *human-readable* toast or alert. Never `console.log` and walk away in production paths.
+- **Form-validation errors** are rendered inline using `errorDetail.errors[]` from the response envelope.
+- **409 / conflicts** route to dedicated flows (duplicate-result link prompt; stale-version reload prompt).
+
+### 9.2 Observability
+
+- **Hotjar**, **Microsoft Clarity** — session replay / heatmaps for UX research.
+- **Google Analytics** — page/event analytics.
+- **BugHerd** — in-product feedback / bug reports.
+- **SonarCloud** — static analysis via `.github/workflows/sonarcloud-analysis.yml`.
+- **Version watcher** — `VersionWatcherService` surfaces app-update banners when a new build is deployed.
+
+### 9.3 What is *not* observable today (open gaps)
+
+- No browser-side error reporting service (e.g., Sentry).
+- No structured RUM (real-user-monitoring) for Web Vitals beyond what GA reports.
+
+---
+
+## 10. Testing Strategy
+
+- **Test runner**: Jest via `jest-preset-angular` (`jest.config.ts`).
+- **Test environment**: `jsdom`.
+- **Path aliases** mirrored in `jest.config.ts` (must stay in sync with `tsconfig.json`).
+- **Coverage thresholds** (CI floor): statements 40%, branches 20%, lines 45%, functions 30%.
+- **Excluded from coverage**: `app.config.ts`, `app.routes.ts`, `websocket.service.ts`, `alert.component.ts` (known instability).
+- **No e2e** suite today. Manual smoke testing covers the golden paths in [`../system-design/design.md`](../system-design/design.md) §3.
+
+### 10.1 What to test
+
+- **Services**: HTTP wiring (with `HttpTestingController`), interceptors, role logic, cache mutations.
+- **Components**: rendering, role-conditional visibility, form validity, signal-driven state transitions, error surfaces.
+- **Guards & resolvers**: pass/fail decisions for representative role + token states.
+- **Pipes & utilities**: pure-function coverage at high percentage.
+
+### 10.2 Testing conventions
+
+- Co-locate `.spec.ts` files with their subjects.
+- Use `src/app/testing/` mocks; do not reinvent fixtures per test.
+- Snapshot tests sparingly — they decay quickly on a PrimeNG-heavy UI.
+
+---
+
+## 11. Technical Constraints & Assumptions
+
+### 11.1 Hard constraints (from [`../prd.md`](../prd.md) §8.3)
+
+- **C-1**: Angular 19 + PrimeNG 19 — no framework migration.
+- **C-2**: AWS Cognito + JWT — no alternative IdPs.
+- **C-3**: CLARISA is the controlled-vocabulary source.
+- **C-4**: WCAG 2.1 AA accessibility minimum.
+- **C-5**: Production bundle budgets per `angular.json`: initial ≤ 3 MB error / 2 MB warning; component styles ≤ 8 kB error / 4 kB warning.
+- **C-6**: Standalone components + lazy `loadComponent` routes only.
+
+### 11.2 Operational constraints
+
+- Container build: multi-stage `Dockerfile`, Nginx-Alpine serving `dist/research-indicators/browser` on port 80.
+- Nginx config (`nginx.conf`) does SPA fallback (`try_files $uri $uri/ /index.html`).
+- Service worker registers with `registerWhenStable:30000`, production only.
+- CI workflows: `unit-tests.yml`, `sonarcloud-analysis.yml`, `jenkins-trigger.yml`.
+
+### 11.3 Assumptions
+
+- Backend services maintain the `MainResponse<T>` envelope. A breaking change to that contract is a coordinated cross-team change.
+- CLARISA endpoints stay stable across versions; client-side caching is safe.
+- Cognito region/userpool configuration is supplied via `environment*.ts` at build/deploy time.
+- WebSocket gateway is hosted on the same domain (or a CORS-permitted one) and uses transports compatible with `ngx-socket-io` 4.x.
+
+### 11.4 Known technical debt / future work
+
+- Coverage thresholds are intentionally low; raise them gradually as new tests land.
+- Some `custom-prime-force-styles.scss` rules don't fully account for dark mode (see system-design OG-2).
+- No first-class error-reporting integration (Sentry-like).
+- No e2e suite; consider Playwright if the surface grows.
+- `ngsw-config.json` currently has no asset/data groups defined — service worker is effectively a no-op for offline.

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1,0 +1,213 @@
+# Alliance Research Indicators — Product Requirements Document
+
+> Living document. Update whenever scope, personas, success metrics, or non-goals change. Do not let it drift behind the implementation.
+
+---
+
+## 1. Overview & Purpose
+
+**Alliance Research Indicators** is the web client used by the Alliance of Bioversity International and CIAT (and the broader CGIAR ecosystem) to **report, search, validate, and analyze research results** mapped to a standardized indicator framework. It is the user-facing layer of a multi-platform results federation that includes **STAR, TIP, PRMS, and AICCRA**.
+
+The application's purpose is to let researchers, monitoring & evaluation (MEL) specialists, and center administrators **capture structured evidence of research outcomes** — capacity sharing events, innovation development, policy changes, OICRs (Outcome Impact Case Reports), and related artifacts — using consistent controlled vocabularies (CLARISA institutions, countries, SDGs, levers, impact areas) so that results are **comparable across platforms and reportable to funders and global frameworks**.
+
+This PRD is the canonical "why" of the product. Technical detail belongs in [`detailed-design/detailed-design.md`](./detailed-design/detailed-design.md); UX system rules belong in [`system-design/design.md`](./system-design/design.md).
+
+---
+
+## 2. Problem Statement
+
+Research results inside the Alliance and CGIAR are produced across many platforms, projects, and centers, but historically:
+
+- **Reporting was fragmented.** Each platform stored results in incompatible structures, making cross-platform aggregation expensive and error-prone.
+- **Controlled vocabularies drifted.** Institution names, country codes, SDGs, and lever taxonomies were re-entered manually, producing inconsistent reporting to funders and global frameworks.
+- **Evidence was scattered.** Files, OICR narratives, partner lists, and policy/innovation metadata lived in spreadsheets, emails, and ad-hoc tools.
+- **Auditability was weak.** Centers had limited visibility into who reported what, when, and whether a result had been validated or submitted.
+
+The product solves this by providing **one structured, role-aware, federation-aware interface** to capture, link, search, and analyze results — backed by canonical CLARISA controlled lists and a versioned result lifecycle.
+
+---
+
+## 3. Target Personas
+
+The product is optimized around four primary personas. All four are first-class — UX choices should not regress any of them.
+
+### 3.1 Researcher / Result Reporter
+- **Role**: Project staff or scientist responsible for capturing a research result.
+- **Primary job-to-be-done**: Create a result, fill the tabbed metadata (general information, partners, evidence, OICR details, IP rights, capacity sharing, policy change, innovation details, geographic scope) accurately, attach evidence, and submit for review.
+- **Pain points it must remove**: Re-entering institution / country data, losing form state between tabs, unclear required fields, unclear submission status.
+
+### 3.2 Center Admin
+- **Role**: Institutional administrator for a CGIAR center / Alliance unit.
+- **Primary job-to-be-done**: Bulk-upload capacity-sharing events, manage center-level SDG alignment, oversee the results produced by their center, and unblock reporters.
+- **Pain points it must remove**: No bulk path for high-volume capacity sharing data; no center-scoped overview of in-flight results.
+
+### 3.3 MEL Regional Expert
+- **Role**: Monitoring, Evaluation & Learning specialist with regional scope.
+- **Primary job-to-be-done**: Review, edit, and validate any result in their scope, ensure quality and alignment, and surface aggregate trends.
+- **Pain points it must remove**: Inability to edit results owned by others; lack of trustworthy aggregate views.
+
+### 3.4 Cross-Platform Consumer (STAR / TIP / PRMS / AICCRA)
+- **Role**: Anyone — funder reporting analyst, leadership, partner researcher — who needs to **find** results that already exist across federated platforms.
+- **Primary job-to-be-done**: Search and dashboard a unified view of results, follow links to results in other platforms, export structured metadata for downstream analysis.
+- **Pain points it must remove**: Re-creating results that already exist elsewhere (causing 409-conflict duplication); fragmented dashboards.
+
+> Supporting personas exist (System Admin, anonymous landing-page visitor, IT operator) but are not the focus of product decisions.
+
+---
+
+## 4. Goals & Success Metrics
+
+### 4.1 Product Goals (the "what we want to be true")
+
+1. **One canonical result record.** A research result is captured once, with complete structured metadata, and linkable to its counterparts across STAR / TIP / PRMS / AICCRA.
+2. **Trust the taxonomy.** Every controlled-vocabulary field (institutions, geography, SDGs, levers, impact areas) is sourced from CLARISA — not free text.
+3. **Role-correct access.** Researchers see and edit their own; Center Admins see their center; MEL Regional Experts see their region; cross-platform consumers see public/federated views — without surprises.
+4. **Reportable in minutes, not days.** Aggregate dashboards and structured exports replace ad-hoc spreadsheet work.
+5. **Evidence is permanent and findable.** Attached files (PDFs, images, datasets) are stored via the file-manager service and survive result revisions.
+
+### 4.2 Success Metrics (KPIs)
+
+> These KPIs are the testable bar. Concrete numeric targets are **open questions** below — they need product-owner sign-off before they become commitments.
+
+| # | KPI | Why it matters |
+|---|-----|----------------|
+| M1 | Time-to-submit a complete result (median, by indicator) | Reporting friction is the #1 user complaint |
+| M2 | % of results submitted with **zero free-text overrides** of CLARISA-controlled fields | Measures taxonomy adoption |
+| M3 | % of results that **link to a cross-platform counterpart** when one exists | Measures federation correctness |
+| M4 | Number of 409 duplicate-result conflicts per month | Should trend toward zero as search/linking improves |
+| M5 | Active monthly users by persona (Researcher / Center Admin / MEL / Consumer) | Coverage of the four target personas |
+| M6 | % of bulk-upload jobs (capacity sharing) that complete without manual fixup | Center Admin productivity |
+| M7 | Lighthouse / Web Vitals scores on Home, Results Center, Dashboard | UX quality floor |
+| M8 | WCAG 2.1 AA conformance on changed screens (per release) | Accessibility floor |
+
+---
+
+## 5. Scope
+
+### 5.1 In Scope
+
+- Authenticated, role-aware web client built on **Angular 19 + PrimeNG 19**.
+- Result lifecycle: **create, edit, version, submit, search, link, export**.
+- Result metadata tabs: general information, links to result, alliance alignment, partners, evidence, OICR details, IP rights, capacity sharing, policy change, innovation details, geographic scope.
+- Indicator catalog browser and "About Indicators" educational surface.
+- Results Center hub, dashboard / charts, and full-text search.
+- Project portfolio view ("My Projects") and project detail with linked results.
+- Center Admin tools: capacity-sharing bulk upload, SDG management.
+- Real-time presence / notifications / alerts via WebSocket.
+- Multi-platform federation: cross-platform result linking and duplicate detection (409 handling).
+- Excel export (ExcelJS), PDF preview (pdfjs-dist), OICR download workflows.
+- Light & dark theming via PrimeNG Aura preset and CSS-variable token system.
+- Analytics: Hotjar, Microsoft Clarity, Google Analytics, BugHerd feedback.
+
+### 5.2 Out of Scope (Non-Goals)
+
+- **Backend ownership.** The NestJS-style APIs (`mainApiUrl`, `textMiningUrl`, `fileManagerUrl`) and CLARISA are external systems. This repo consumes them; it does not define their data model.
+- **Identity provider alternatives.** Auth stays on **AWS Cognito + JWT**. No SAML, no enterprise SSO branching in this client.
+- **Framework migration.** No React / Vue / Svelte rewrite. The stack is locked at Angular 19 + PrimeNG 19 for the foreseeable horizon of this document.
+- **Parallel taxonomies.** Institutions, countries, regions, SDGs, levers, impact areas — none are re-implemented locally. They come from CLARISA.
+- **Standalone mobile app.** The web client must be responsive (and is tuned for landscape/height ≤768px) but no native iOS/Android shell is in scope.
+- **Cross-platform write federation.** This client does not write results back into STAR / TIP / PRMS / AICCRA — it only **links** to them.
+- **Custom AuthZ engine.** Authorization is role-based and enforced by the backend; the client mirrors but does not replace those checks.
+
+---
+
+## 6. User Stories
+
+Stories are grouped by persona. They are intentionally outcome-shaped, not implementation-shaped.
+
+### Researcher / Result Reporter
+
+- **R-1**: As a researcher, I can **create a new result** for an indicator and have the system pre-populate my center, contact info, and known project links so I don't re-type them.
+- **R-2**: As a researcher, I can **save partial progress** on any tab and return later without losing data.
+- **R-3**: As a researcher, I can **attach evidence files** (PDFs, images, datasets) to a result, with progress feedback and a permanent reference URL.
+- **R-4**: As a researcher, I am **warned before creating a duplicate** of a result that already exists in another platform (or in this one), and I can choose to link instead.
+- **R-5**: As a researcher, I can **submit a result for MEL review** and see its status (draft / submitted / accepted / returned) at a glance.
+- **R-6**: As a researcher, I can **search by free text, indicator, year, country, partner, or project** and find my own and the Alliance's prior work.
+
+### Center Admin
+
+- **CA-1**: As a Center Admin, I can **bulk-upload capacity-sharing events** for my center from a structured template and see per-row validation errors.
+- **CA-2**: As a Center Admin, I can **see the in-flight results** owned by my center and the bottlenecks in their lifecycle.
+- **CA-3**: As a Center Admin, I can **manage SDG alignment** for my center so reporting rolls up correctly.
+
+### MEL Regional Expert
+
+- **MEL-1**: As a MEL Regional Expert, I can **edit any result in my scope**, leave structured feedback, and accept or return it.
+- **MEL-2**: As a MEL Regional Expert, I can **view aggregate dashboards** filtered by region, indicator, and year.
+- **MEL-3**: As a MEL Regional Expert, I can **export structured metadata** of selected results to Excel for offline analysis.
+
+### Cross-Platform Consumer
+
+- **CP-1**: As a cross-platform consumer, I can **search across STAR / TIP / PRMS / AICCRA** and see results from all of them in one list.
+- **CP-2**: As a cross-platform consumer, I can **follow a deep link** to a result and see its full metadata, evidence, partners, and cross-platform counterparts.
+- **CP-3**: As a cross-platform consumer, I can **download an OICR template / report** when needed.
+
+### System-wide
+
+- **S-1**: As any user, I can **switch between light and dark mode** and have the choice persist.
+- **S-2**: As any user, I receive **real-time notifications and alerts** without refreshing the page.
+- **S-3**: As any user, the app **respects my role** — I never see actions I'm not allowed to perform.
+
+---
+
+## 7. Acceptance Criteria
+
+The following are the **always-on** acceptance bars. Per-feature ACs live in module specs under `docs/specs/<domain>/`.
+
+1. **Auth correctness.** Unauthenticated users only see `landing`, `login`, `auth`. JWT-protected routes are gated by `rolesGuard`. Center-admin routes are gated by `centerAdminGuard`. Expiring tokens are proactively refreshed before request dispatch.
+2. **Role correctness.** Edit/destroy actions are hidden when the backend would reject them. Center Admin and MEL Regional Expert see scopes consistent with their `role_id` (1, 9, 10) and `sec_role_id` / `focus_id` where applicable.
+3. **Controlled-list integrity.** No screen allows free-text entry for a field that maps to a CLARISA list (institutions, countries, regions, subnational, SDGs, levers, languages, delivery modalities, session types).
+4. **Result lifecycle integrity.** A submitted result cannot be silently overwritten. Version transitions are persisted and visible.
+5. **Duplicate detection.** Creating a result that collides with an existing record (same platform_code + official_code) surfaces a 409 conflict and links to the existing result instead of producing a duplicate.
+6. **Evidence durability.** Files uploaded via the file-manager service have a stable URL and survive result edits.
+7. **Real-time integrity.** WebSocket disconnects degrade gracefully; the UI never blocks on a missing socket.
+8. **Theming.** Both light and dark theme render every screen without unreadable contrast or broken layout. Users can toggle and the choice persists.
+9. **Accessibility floor.** Every changed screen meets **WCAG 2.1 AA**: keyboard reachable controls, visible focus, labels on inputs, sufficient color contrast, accessible names for icon-only buttons.
+10. **Performance floor.** Production bundle stays within the budgets declared in `angular.json` (initial ≤ 3 MB, component styles ≤ 8 kB). New lazy routes do not push initial bundle past the warning threshold (2 MB).
+11. **Testing floor.** Unit tests via Jest meet or exceed the project's coverage thresholds (statements 40%, branches 20%, lines 45%, functions 30%) and do not regress on changed files.
+
+---
+
+## 8. Assumptions, Dependencies, & Constraints
+
+### 8.1 Assumptions
+
+- **A-1**: CLARISA controlled lists are authoritative and reasonably stable. Lists are cached client-side (via `control-list-cache.service.ts`, `dropdowns-cache.service.ts`).
+- **A-2**: The backend exposes a consistent `MainResponse<T>` envelope (`successfulRequest`, `status`, `data`, `errorDetail`).
+- **A-3**: Users have modern evergreen browsers (Chromium, Firefox, Safari current — Angular 19 baseline).
+- **A-4**: Federation partners (STAR / TIP / PRMS / AICCRA) provide deep-link-able result URLs that this client can reach.
+
+### 8.2 Dependencies
+
+- **D-1**: **CLARISA** — institutions, countries, regions, subnational, SDGs, levers, impact areas.
+- **D-2**: **Main API** (NestJS-style REST) at `environment.mainApiUrl`.
+- **D-3**: **Text-mining microservice** at `environment.textMiningUrl` — used by intelligence/auto-fill flows.
+- **D-4**: **File-manager microservice** at `environment.fileManagerUrl` — evidence uploads.
+- **D-5**: **AWS Cognito** for authentication.
+- **D-6**: **WebSocket gateway** (ngx-socket-io target) for live presence, notifications, alerts, room collaboration.
+- **D-7**: **Analytics / feedback SaaS** — Hotjar, Microsoft Clarity, Google Analytics, BugHerd.
+- **D-8**: **CI/CD** — GitHub Actions workflows (`jenkins-trigger.yml`, `sonarcloud-analysis.yml`, `unit-tests.yml`); deployment images via Docker + Nginx.
+
+### 8.3 Constraints (Hard Rules)
+
+- **C-1**: Stack is **Angular 19 + PrimeNG 19**. No framework migration.
+- **C-2**: Auth is **AWS Cognito + JWT**. No alternative IdPs.
+- **C-3**: Controlled vocabularies come from **CLARISA**. No parallel taxonomies.
+- **C-4**: Accessibility minimum is **WCAG 2.1 AA**.
+- **C-5**: Bundles must respect the budgets in `angular.json`.
+- **C-6**: New features must be **lazy-loaded standalone components** (the established routing model). No NgModules.
+
+---
+
+## 9. Open Questions
+
+These items intentionally remain unresolved. They block specific commitments and should be triaged with the product owner.
+
+- **OQ-1**: What are the **numeric targets** for the KPIs in §4.2 (e.g., target median time-to-submit, target free-text-override rate)?
+- **OQ-2**: What is the **canonical role list** beyond Admin (1), Center Admin (9), MEL Regional Expert (10)? Are there others (e.g., reviewer, project manager) we should formalize?
+- **OQ-3**: Is **light + dark theme parity** a hard requirement for every new screen, or "nice to have"? (Not codified as a hard constraint in this baseline — confirm.)
+- **OQ-4**: What is the **data-retention policy** for results submitted from decommissioned platforms (e.g., if AICCRA winds down)?
+- **OQ-5**: Should **cross-platform write federation** ever come into scope? Currently out of scope (§5.2).
+- **OQ-6**: What is the **mobile / tablet** support matrix? The CSS includes a `md:` breakpoint tuned to landscape & height ≤ 768px — is that the official target?
+- **OQ-7**: Are there **compliance constraints** (GDPR, funder data-handling) that should be reflected explicitly in the constitution?
+- **OQ-8**: What is the **expected SLO** (uptime, p95 latency) for the backend services this client depends on?

--- a/docs/specs/general-setup/design.md
+++ b/docs/specs/general-setup/design.md
@@ -1,0 +1,135 @@
+# SDD Design Template
+
+> Methodology template used by `/sdd-specify`. Every module-level spec under `docs/specs/<domain>/<feature>/design.md` must follow this structure.
+>
+> **Not a feature spec itself.** This file defines the *format* for future design documents.
+
+---
+
+## How to use this template
+
+- Pair with `requirements.md` in the same folder (created from `./requirements.md`).
+- Defer **product/scope** decisions to `requirements.md`; this file is **how we'll implement them**.
+- Reference and respect the global blueprints in [`../../system-design/design.md`](../../system-design/design.md) and [`../../detailed-design/detailed-design.md`](../../detailed-design/detailed-design.md). If you deviate from them, record the deviation in §11 Design Decisions of this spec **and** update the global blueprint in the same change.
+
+---
+
+## Template structure
+
+> Copy the structure below into your `design.md`. Remove this preamble.
+
+---
+
+### 1. Architectural Overview
+
+A 1–2 paragraph technical summary. What components / services / routes are introduced or touched? Where does the spec sit in the architecture diagram from [`../../detailed-design/detailed-design.md`](../../detailed-design/detailed-design.md) §1?
+
+Include a small textual diagram if it helps:
+
+```
+[Component A] ──signal──▶ [Service B] ──HTTP──▶ [Main API]
+                                  │
+                                  └──websocket──▶ [Gateway]
+```
+
+### 2. Data Model
+
+- **New interfaces** introduced (`src/app/shared/interfaces/...`).
+- **Existing interfaces** modified — list field additions/removals; never silently rename.
+- **Wire shapes** that differ from internal shapes (e.g., DTO ↔ view-model mapping).
+
+### 3. API Contracts
+
+For each endpoint touched:
+
+| Method | URL | Service / Method | Request | Response | Notes |
+|--------|-----|------------------|---------|----------|-------|
+| GET | `/results/:id` | `ApiService.getResult(id, version?)` | `id`, optional `version` | `MainResponse<Result>` | Use `version` query param when present |
+
+- Always wrap responses as `MainResponse<T>` (see [`../../detailed-design/detailed-design.md`](../../detailed-design/detailed-design.md) §4.2).
+- Document 4xx / 5xx handling — especially **409 conflict** flows.
+
+### 4. Frontend Architecture
+
+#### 4.1 Routes
+- New / modified routes in `src/app/app.routes.ts` (lazy `loadComponent`, guards, resolvers).
+
+#### 4.2 Components
+- New components (path, role, props/signals/events).
+- Use shared components from [`../../system-design/design.md`](../../system-design/design.md) §8 before inventing new ones.
+
+#### 4.3 State boundaries
+- What goes in component-local signals vs `cache.service.ts` vs URL/route params.
+- What is persisted to `localStorage` (must be conscious — token/theme persistence already exists; new persistence requires justification).
+
+#### 4.4 Services
+- New services or modifications to existing ones (`ApiService`, domain services, interceptors).
+- Reuse before creating.
+
+#### 4.5 Forms
+- Reactive form layout, validators (client + server cross-check).
+- Use `shared-result-form` and wrapped form fields rather than raw PrimeNG controls.
+
+#### 4.6 Theming
+- Use color tokens (`--ac-*`) and utility classes (`abc-*`, `atc-*`, `rs-*`, `fs-*`).
+- Verify dark-mode parity unless an exemption is documented.
+
+### 5. Security & Authorization
+
+- Role checks added/changed (mirror `rolesGuard`, `centerAdminGuard`).
+- Tokens & sensitive data — no new persistence unless justified; tokens never logged.
+- Backend remains authoritative (PRD §8 — client mirrors UX only).
+
+### 6. Error Handling
+
+- New error paths: how surfaced (toast / alert / inline / 409 flow).
+- Interaction with `httpErrorInterceptor` and `ActionsService`.
+- Stale-data / version handling if relevant.
+
+### 7. Real-Time Considerations
+
+If touching WebSocket (`WebsocketService`):
+- New events emitted / listened to.
+- Degradation plan when the socket is down (must not block).
+
+### 8. Performance
+
+- Bundle impact estimate (kB added) and how it stays within `angular.json` budgets.
+- Lazy-loading strategy (already required by PRD C-6).
+- Network: number of requests on first load; any caching strategy (control-list caches, dropdown caches).
+
+### 9. Accessibility
+
+- Per WCAG 2.1 AA (PRD C-4): keyboard, focus, labels, contrast, motion, live regions.
+- Any new motion respects `prefers-reduced-motion`.
+
+### 10. Telemetry
+
+- Events fired into Hotjar / Clarity / GA / BugHerd.
+- Naming convention follows existing services in `shared/services/`.
+
+### 11. Design Decisions (Decision Record)
+
+Append entries in chronological order. Each entry: date, decision, alternatives considered, rationale.
+
+- **YYYY-MM-DD — <short title>.** Decision: …  Alternatives: …  Rationale: …
+
+If a decision contradicts the global system-design or detailed-design blueprints, update those documents in the same change. Local decisions that conflict with global rules without updating the global rules are not allowed.
+
+### 12. Testing Strategy
+
+- Unit tests added (services, components, guards, pipes).
+- Coverage delta — must not push project metrics below the floors in [`../../detailed-design/detailed-design.md`](../../detailed-design/detailed-design.md) §10.
+- Manual test plan for golden paths affected (referenced from [`../../system-design/design.md`](../../system-design/design.md) §3).
+
+### 13. Risks & Mitigations
+
+- R-1: …  Mitigation: …
+- R-2: …  Mitigation: …
+
+### 14. References
+
+- [`../../prd.md`](../../prd.md)
+- [`../../system-design/design.md`](../../system-design/design.md)
+- [`../../detailed-design/detailed-design.md`](../../detailed-design/detailed-design.md)
+- Related specs.

--- a/docs/specs/general-setup/requirements.md
+++ b/docs/specs/general-setup/requirements.md
@@ -1,0 +1,140 @@
+# SDD Requirements Template
+
+> Methodology template used by `/sdd-specify`. Every module-level spec under `docs/specs/<domain>/<feature>/requirements.md` must follow this structure.
+>
+> **Not a feature spec itself.** This file defines the *format* for future requirement documents.
+
+---
+
+## How to use this template
+
+1. Pick the domain folder under `docs/specs/` that matches your work. The taxonomy is **by domain module**, mirroring the page modules described in [`../../detailed-design/detailed-design.md`](../../detailed-design/detailed-design.md) §2. Established folders:
+   - `docs/specs/results/`
+   - `docs/specs/indicators/`
+   - `docs/specs/projects/`
+   - `docs/specs/dashboard/`
+   - `docs/specs/notifications/`
+   - `docs/specs/administration/`
+   - `docs/specs/auth/`
+   - `docs/specs/shared/` (cross-cutting changes to shared components / services)
+   - `docs/specs/platform/` (shell / navigation)
+2. Inside that folder, create a slug folder for the feature/spec (kebab-case): e.g. `docs/specs/results/bulk-evidence-upload/`.
+3. Inside that slug folder, create:
+   - `requirements.md` (this template)
+   - `design.md` (see `./design.md`)
+   - `task.md` (see `./task.md`)
+4. Cross-link the spec from [`../../prd.md`](../../prd.md) if it changes scope, personas, or KPIs.
+
+---
+
+## Requirement-numbering convention
+
+- Top-level requirements use the format `REQ-<DOMAIN>-<NN>`, e.g. `REQ-RESULTS-01`.
+- `<DOMAIN>` is a 3–8 letter uppercase abbreviation of the domain folder (e.g. `RESULTS`, `IND`, `PROJ`, `DASH`, `NOTIF`, `ADMIN`, `AUTH`, `SHARED`, `PLAT`).
+- Sub-requirements use a dot: `REQ-RESULTS-01.1`, `REQ-RESULTS-01.2`.
+- Never re-number once published — requirements may be marked deprecated but their IDs are immutable.
+- Cross-spec dependencies cite the full ID (`REQ-RESULTS-01` in another spec is unambiguous).
+
+---
+
+## Writing standards
+
+- **One requirement = one testable statement.** "The system shall …" or "The user can …".
+- **Outcome, not implementation.** "User can attach a PDF up to 50 MB" — not "We use FormData with multipart/form-data".
+- **Acceptance criteria are mandatory** for every requirement. ACs are *testable* — written so a reviewer can decide pass/fail without ambiguity.
+- **Reference the PRD.** Each requirement traces back to a persona (PRD §3) and at least one goal (PRD §4).
+- **Reference constraints.** If a requirement is shaped by a PRD constraint (C-1 through C-6), call it out.
+- **Open questions, not silent guesses.** If something is unknown, log it under §10 Open Questions.
+
+Anti-patterns:
+
+- "Make it fast" — not testable. Quantify (p95 latency, frames per second).
+- "Make it intuitive" — not testable. Tie to a measurable UX outcome.
+- Mixing solution detail into requirements (belongs in `design.md`).
+
+---
+
+## Template structure
+
+> Copy the structure below into your `requirements.md`. Remove this preamble.
+
+---
+
+### 1. Summary
+
+One paragraph. What problem does this spec solve, for whom, and what outcome will be true when it ships.
+
+### 2. Motivation & PRD Linkage
+
+- **Persona(s)**: list from [`../../prd.md`](../../prd.md) §3 (Researcher / Center Admin / MEL Regional Expert / Cross-Platform Consumer).
+- **PRD goal(s) addressed**: cite IDs from PRD §4.1.
+- **KPIs moved**: cite IDs from PRD §4.2.
+- **User stories addressed**: cite IDs from PRD §6 (e.g., R-3, MEL-1).
+- **Non-goals from PRD §5.2 invoked**: any non-goals this spec must avoid violating.
+
+### 3. Scope
+
+#### In scope
+- Bulleted list of what *is* included.
+
+#### Out of scope
+- Bulleted list of what is *explicitly* excluded (so reviewers and future readers do not assume otherwise).
+
+### 4. Functional Requirements
+
+- **REQ-<DOMAIN>-01** — *Short title.*
+  - Statement: "The system shall …" / "The user can …".
+  - **Persona(s)**: …
+  - **Acceptance criteria**:
+    - AC-01.1 — …
+    - AC-01.2 — …
+  - **Notes**: any clarifications (NOT implementation detail).
+
+- **REQ-<DOMAIN>-02** — *Short title.*
+  - …
+
+### 5. Non-Functional Requirements
+
+Each NFR follows the same pattern as functional ones but should have a measurable threshold.
+
+- **REQ-<DOMAIN>-NF-01** — Performance: e.g., "Initial render of the screen completes in ≤ 1.5 s on a mid-range laptop (Lighthouse mobile profile)."
+- **REQ-<DOMAIN>-NF-02** — Accessibility: "Screen meets WCAG 2.1 AA on changed surfaces (PRD C-4)."
+- **REQ-<DOMAIN>-NF-03** — Bundle budget: "Net JS added to the initial chunk ≤ 50 KB gzipped (respects `angular.json` budgets, PRD C-5)."
+- **REQ-<DOMAIN>-NF-04** — Theming: dark + light parity for new screens unless an exemption is recorded.
+- **REQ-<DOMAIN>-NF-05** — i18n / locale (if applicable): all user-facing strings extractable.
+
+### 6. Data Inputs & Outputs
+
+- **Inputs**: REST endpoints, query/path params, request bodies (cite `ApiService` methods).
+- **Outputs**: response shapes (cite `interfaces/`).
+- **Persisted state**: any client-side cache / signals introduced (cite `shared/services/cache.service.ts` or equivalent).
+
+### 7. Controlled Vocabularies
+
+If the spec touches institutions, countries, regions, subnational, SDGs, levers, impact areas, languages, delivery modalities, session types — confirm here that the source is **CLARISA** (PRD C-3). If a parallel taxonomy is unavoidable, escalate to the open-questions section.
+
+### 8. Role & Permission Matrix
+
+| Action | Researcher | Center Admin | MEL Regional Expert | Cross-Platform Consumer | Anonymous |
+|--------|------------|--------------|---------------------|-------------------------|-----------|
+| (e.g., create a result) | ✅ | ✅ | ✅ | ❌ | ❌ |
+| … | | | | | |
+
+Mirror server-side enforcement; do not invent client-only rules.
+
+### 9. Telemetry & Observability
+
+- What events fire (Hotjar / Clarity / GA / BugHerd)?
+- What error states surface (toast, alert, inline)?
+
+### 10. Assumptions & Open Questions
+
+- A-1: …
+- OQ-1: …
+
+### 11. References
+
+- [`../../prd.md`](../../prd.md) §X
+- [`../../system-design/design.md`](../../system-design/design.md) §X
+- [`../../detailed-design/detailed-design.md`](../../detailed-design/detailed-design.md) §X
+- Any related specs (`docs/specs/<domain>/<sibling>/requirements.md`).

--- a/docs/specs/general-setup/task.md
+++ b/docs/specs/general-setup/task.md
@@ -1,0 +1,131 @@
+# SDD Task Template
+
+> Methodology template used by `/sdd-specify` (and consumed by `/sdd-execute`). Every module-level spec under `docs/specs/<domain>/<feature>/task.md` must follow this structure.
+>
+> **Not a feature spec itself.** This file defines the *format* for future task lists.
+
+---
+
+## How to use this template
+
+- Pair with `requirements.md` and `design.md` in the same folder.
+- Tasks are the **execution unit** of `/sdd-execute`. Keep them small enough to complete in a single PR, large enough to deliver value.
+- Number every task. Numbers are immutable once published — same rule as requirement IDs in [`./requirements.md`](./requirements.md).
+- Capture **dependencies** explicitly. Use the dependency-graph format below.
+- Each task lists the **acceptance criteria it discharges** (cite AC-IDs from `requirements.md`).
+- Each task lists the **tests it must add or update**.
+
+---
+
+## Task ID convention
+
+- Tasks use `T-<DOMAIN>-<NN>` matching the domain abbreviation used in `requirements.md`.
+- Example: `T-RESULTS-01`, `T-RESULTS-02`.
+- Sub-tasks use a dot: `T-RESULTS-01.1`.
+
+---
+
+## Template structure
+
+> Copy the structure below into your `task.md`. Remove this preamble.
+
+---
+
+### 1. Goal
+
+One sentence: what does this task list deliver when fully executed?
+
+### 2. Pre-flight checklist
+
+Before opening the first task:
+
+- [ ] `requirements.md` and `design.md` exist and are reviewed.
+- [ ] PRD personas, goals, and constraints cited in `requirements.md` are still current.
+- [ ] No conflicting in-flight spec under the same domain (check `docs/specs/<domain>/`).
+- [ ] Path aliases needed are already declared in `tsconfig.json` and `jest.config.ts`.
+
+### 3. Dependency graph
+
+Use a textual graph. One arrow per dependency. Cycles are not allowed.
+
+```
+T-<DOMAIN>-01 (interfaces, no deps)
+    └─▶ T-<DOMAIN>-02 (service)
+            ├─▶ T-<DOMAIN>-03 (component)
+            └─▶ T-<DOMAIN>-04 (route + guard)
+                    └─▶ T-<DOMAIN>-05 (tests)
+T-<DOMAIN>-06 (docs update, no deps)
+```
+
+### 4. Tasks
+
+Each task has the following fields. Keep them concise.
+
+---
+
+#### T-<DOMAIN>-01 — *Short title*
+
+- **Status**: `pending` | `in_progress` | `completed`
+- **Depends on**: list of task IDs (or "none")
+- **Discharges ACs**: list of AC-IDs from `requirements.md`
+- **Touches**:
+  - `src/app/shared/interfaces/...`
+  - `src/app/shared/services/...`
+  - `src/app/pages/.../...`
+  - (other files)
+- **Summary**: 1–3 sentences describing the change.
+- **Implementation notes**:
+  - Reuse existing shared components/services where possible (see [`../../system-design/design.md`](../../system-design/design.md) §8 and [`../../detailed-design/detailed-design.md`](../../detailed-design/detailed-design.md) §6).
+  - Follow the patterns in `design.md` §4.
+- **Tests to add/update**:
+  - Unit: `xxx.service.spec.ts` — cover happy path + 409 conflict.
+  - Component: `xxx.component.spec.ts` — verify role-conditional rendering.
+- **Done when**:
+  - All listed ACs pass.
+  - `npm run lint` is clean for changed files.
+  - `npm run test` passes; coverage does not regress below [`../../detailed-design/detailed-design.md`](../../detailed-design/detailed-design.md) §10 floors.
+  - Manual smoke through the affected golden path in [`../../system-design/design.md`](../../system-design/design.md) §3 succeeds.
+
+---
+
+#### T-<DOMAIN>-02 — *…*
+
+(same structure)
+
+---
+
+### 5. Testing expectations (global rules)
+
+- Use Jest via `jest-preset-angular`. Tests run with `npm run test`. Watch mode: `npm run test:watch`. Coverage: `npm run test:coverage`.
+- Co-locate `.spec.ts` files. Use shared fixtures under `src/app/testing/`.
+- Mirror server-side validation in component-level form tests.
+- For services: use `HttpTestingController` and assert on the `MainResponse<T>` envelope.
+- For role-based UI: assert both authorized and unauthorized renderings.
+- For interceptors: verify token refresh, 409 surfacing, and toast/alert dispatch.
+- For dark-mode parity (if touched): include at least one snapshot or visual-state assertion in both modes.
+
+### 6. Execution conventions
+
+- One task per PR by default. A bundled PR is acceptable when tasks are tightly coupled and reviewable together — record the bundling decision in `design.md` §11.
+- PR title: `<type>(<domain>): <short description>` (e.g., `feat(results): add bulk evidence upload`).
+- PR description references the spec folder and the discharged ACs.
+- Pre-merge:
+  - CI green (`unit-tests.yml`, `sonarcloud-analysis.yml`).
+  - Bundle budget respected (`ng build` does not warn beyond baseline).
+  - Manual smoke of the affected golden paths.
+- Post-merge:
+  - Update task `Status` to `completed` in the spec.
+  - If the spec is fully done, mark the spec folder's `requirements.md` summary accordingly.
+
+### 7. Rollout & feature flags
+
+- If the change is risky or partially shippable, use a feature flag pattern consistent with existing flags in `environment*.ts`. Otherwise, no flag.
+- Document rollout sequence (dev → staging → prod) and any data-migration coordination with the backend team.
+
+### 8. Rollback plan
+
+- For each task, describe how to safely revert (usually `git revert`; flag-off if a flag was introduced; backend coordination if a server contract changed).
+
+### 9. Open items
+
+- Items deferred from this task list to a future spec — link to the issue or follow-up spec slug.

--- a/docs/system-design/design.md
+++ b/docs/system-design/design.md
@@ -1,0 +1,296 @@
+# Alliance Research Indicators — System Design (UI/UX Blueprint)
+
+> The visual & interaction blueprint. Companion to [`../prd.md`](../prd.md) (what & why) and [`../detailed-design/detailed-design.md`](../detailed-design/detailed-design.md) (how the code is wired).
+>
+> When adding a new screen, **read this document first**. Every new screen must fit the patterns below or explicitly document a deviation in §12 Design Decisions.
+
+---
+
+## 1. Product Experience Principles
+
+These are the principles new screens are evaluated against in review. They derive from the personas in [`../prd.md`](../prd.md) §3.
+
+1. **Form clarity over visual flourish.** This product is a data-entry application for research metadata. Every screen optimizes for *legibility, scannability, and confidence that the data is correct* — not for aesthetic novelty.
+2. **The taxonomy is the truth.** Controlled-list inputs (CLARISA) are the default; free text is the exception and must be justified. UI must make it *easier* to pick the canonical value than to type a custom one.
+3. **Status always visible.** A user must always be able to answer: "Where is this result in its lifecycle? Am I allowed to edit it? Did my last save succeed?"
+4. **Predictable navigation.** Every authenticated screen lives inside the platform shell (navbar + sidebar). The result detail screen is the only place with a second-level sidebar (tab navigation).
+5. **Respect role.** Hide actions the current role cannot perform — never disable them silently. Show the user *why* something is read-only when relevant.
+6. **Forgiving by default.** Long forms must autosave or surface "unsaved changes" warnings. Destructive actions (delete result, remove evidence) require confirmation.
+7. **Federated, not duplicated.** When the user is about to create something that already exists across platforms (STAR / TIP / PRMS / AICCRA), the UI offers to *link*, not duplicate.
+8. **Accessible to keyboard-and-screen-reader users.** WCAG 2.1 AA is the floor (§10), not the ceiling.
+
+---
+
+## 2. Information Architecture
+
+Top-level information hierarchy of the authenticated experience:
+
+```
+Platform Shell (navbar + sidebar)
+├── Home                              — landing dashboard for the logged-in user
+├── Indicators
+│   ├── About Indicators              — educational overview
+│   └── Indicator detail (/:id)       — metadata + examples for one indicator
+├── Results
+│   ├── Results Center                — center-scoped overview & quick filters
+│   ├── Search a Result               — federated full-text search across platforms
+│   ├── Load Result                   — create-new flow
+│   └── Result Detail (/:id)          — tabbed metadata editor
+│       ├── General Information
+│       ├── Links to Result
+│       ├── Alliance Alignment
+│       ├── Partners
+│       ├── Evidence
+│       ├── OICR Details
+│       ├── IP Rights
+│       ├── Capacity Sharing
+│       ├── Policy Change
+│       ├── Innovation Details
+│       └── Geographic Scope
+├── Projects
+│   ├── My Projects                   — portfolio
+│   └── Project Detail (/:id)         — project metadata + linked results
+├── Dashboard                         — charts & aggregates
+├── Notifications                     — real-time feed
+├── Profile                           — account settings, theme
+├── About                             — app/version info
+└── Administration
+    └── Center Admin
+        ├── Bulk Upload (capacity sharing)
+        └── SDG Management
+```
+
+Outside the shell:
+
+```
+Public / Unauthenticated
+├── Landing                           — marketing surface for anonymous users
+├── Login                             — Cognito entry
+├── Auth                              — Cognito callback / token exchange
+├── Room (/:id)                       — real-time collaboration deep link
+├── Fields                            — dynamic form-field configurator
+├── Cache-test                        — internal/dev utility
+└── OICR Download                     — public template download
+```
+
+---
+
+## 3. Primary User Flows
+
+Each flow is described as a sequence of screen transitions. These are the **golden paths** new work must not regress.
+
+### 3.1 Create a Result (Researcher)
+1. Home → "Load Result" CTA → `load-results`.
+2. Pick indicator type → indicator → result name.
+3. **Duplicate check** runs (409 if collision); if collision, offer to link to existing result instead.
+4. On success → redirect to `result/:id/general-information`.
+5. User fills tabs left-to-right; sidebar shows per-tab completion checks (green tick / orange warning).
+6. User submits → status transitions; toast confirms; result appears in MEL queue.
+
+### 3.2 Find & Link an Existing Result (Cross-Platform Consumer)
+1. `search-a-result` → enter free-text / filters → federated results from STAR / TIP / PRMS / AICCRA.
+2. Click row → `result/:id` (own platform) or external deep link (other platform).
+3. From a result detail, "Links to result" tab → search & link counterparts on other platforms.
+
+### 3.3 Bulk Upload Capacity Sharing (Center Admin)
+1. Administration → Center Admin → Bulk Upload.
+2. Download template → fill offline → upload.
+3. Server validates row-by-row → results returned with per-row status; user fixes & re-uploads errored rows.
+
+### 3.4 Review & Validate (MEL Regional Expert)
+1. Notifications / Results Center → open submitted result.
+2. Review tabs in order; leave structured feedback; accept or return.
+3. Reporter receives notification (real-time + Notifications page).
+
+### 3.5 Switch Theme
+1. Navbar / profile → toggle dark mode.
+2. `DarkModeService` flips signal → `.dark-mode` class on body → PrimeNG Aura swaps token set → CSS variables swap.
+3. Choice persists (cache service / localStorage).
+
+---
+
+## 4. Screen Inventory
+
+| # | Screen | Route | Shell | Notes |
+|---|--------|-------|-------|-------|
+| 1 | Landing | `/` (anon) | No | Public, marketing |
+| 2 | Login | `/login` | No | Cognito |
+| 3 | Auth callback | `/auth` | No | Token exchange |
+| 4 | Home | `/home` | Yes | Dashboard + quick actions |
+| 5 | About Indicators | `/about-indicators` | Yes | Educational |
+| 6 | Indicator Detail | `/indicator/:id` | Yes | One of 5 indicator types |
+| 7 | Results Center | `/results-center` | Yes | Hub & quick filters |
+| 8 | Search a Result | `/search-a-result` | Yes | Federated search |
+| 9 | Load Result | `/load-results` | Yes | Create-new wizard |
+| 10 | Result Detail | `/result/:id/...` | Yes (+ second-level sidebar) | 11 sub-tabs |
+| 11 | My Projects | `/projects` | Yes | Portfolio |
+| 12 | Project Detail | `/project-detail/:id` | Yes | Project metadata + results |
+| 13 | Dashboard | `/dashboard` | Yes | Chart.js visualizations |
+| 14 | Notifications | `/notifications` | Yes | Real-time feed |
+| 15 | Profile | `/profile` | Yes | User settings & theme |
+| 16 | About | `/about` | Yes | App info |
+| 17 | Bulk Upload | `/administration/center-admin/bulk-upload` | Yes (center-admin only) | Capacity sharing |
+| 18 | SDG Management | `/administration/center-admin/sdg-management` | Yes (center-admin only) | Center SDG alignment |
+| 19 | Room | `/room/:id` | No | Real-time collab |
+| 20 | OICR Download | `/oicr/download` | No | Public download |
+| 21 | Fields | `/fields` | No | Dynamic form config |
+| 22 | Cache-test | `/cache-test` | No | Dev tool |
+
+---
+
+## 5. Navigation Model
+
+- **Primary navigation**: persistent top **navbar** (`alliance-navbar`) — branding, user menu, dark-mode toggle, notifications icon.
+- **Secondary navigation**: persistent left **sidebar** (`alliance-sidebar`) — Home / Results / Projects / Dashboard / Administration sections.
+- **Tertiary navigation**: inside Result Detail, a **second-level sidebar** (`result-sidebar`) lists the 11 tabs with completion indicators.
+- **Contextual navigation**: `section-header` shows page title, breadcrumb-like back behavior, and per-section action buttons (`filters-action-buttons`, `search-export-controls`).
+- **Back behavior**: every screen except `home` and `projects` (configured via `hideBackButton: true`) supports `back` via the section header.
+- **Deep links**: every result tab is independently routable (`/result/:id/<tab>?version=N`) — sharing a URL preserves tab and version context.
+- **Auth-guarded**: All shell routes pass `rolesGuard`; admin routes additionally pass `centerAdminGuard`.
+
+---
+
+## 6. Layout Patterns
+
+| Pattern | When to use | Anchored to |
+|---------|-------------|-------------|
+| **Shell + content** | All authenticated screens | `platform.component`, navbar + sidebar |
+| **Tabbed detail** | Long structured records (Result Detail) | `result-sidebar` + outlet |
+| **List + filter + export** | Search / Results Center / Projects | `results-table`, `filters-action-buttons`, `search-export-controls` |
+| **Card grid** | Indicator catalog, dashboard widgets | section-level layout |
+| **Two-column form** | Result metadata tabs | Label column + control column, full-width on `md:` breakpoint |
+| **Modal-driven action** | Confirmation, link result, evidence upload | `all-modals` host + `modal` wrapper |
+| **Real-time banner** | System alerts (`alert-tag`, `global-alert`, `global-toast`) | Top of shell, dismissible |
+
+Spacing, sizing, and breakpoints use the `rs-*` utility class system (see [`../../research-indicators/README.md`](../../research-indicators/README.md) — colors & responsive sizing) so layouts respond consistently to the `md:` breakpoint (landscape orientation, height ≤ 768px).
+
+---
+
+## 7. Design Tokens
+
+Tokens live in `src/styles/colors.scss`, `src/styles/font.scss`, `src/app/theme/roartheme.ts`, and are surfaced as CSS custom properties under `:root`. **Do not hard-code hex values in new components.**
+
+### 7.1 Color tokens (light mode source values)
+
+| Family | Token range | Use |
+|--------|-------------|-----|
+| Light blue | `--ac-light-blue-100` … `--ac-light-blue-500` | Informational accents, links |
+| Primary blue | `--ac-primary-blue-100` … `--ac-primary-blue-700` | Brand, navbar, primary CTAs |
+| Green | `--ac-green-100` … `--ac-green-700` | Indicators 1–3 (capacity sharing, innovation dev, policy change types A) |
+| Orange | `--ac-orange-1` | Indicators 4–5 |
+| Grey | `--ac-grey-100` … `--ac-grey-900` | Neutrals, borders, body text |
+| Red | `--ac-red-1` | Errors, destructive actions |
+| White | `--ac-white-1`, `--ac-white-2` | Surfaces |
+| Background | `--ac-background` | Page background (flips in dark mode) |
+
+Dark mode overrides the same token names under `:root[data-theme="dark"]`. PrimeNG Aura preset (`roartheme.ts`) flips via the `.dark-mode` body class.
+
+### 7.2 Utility classes (do not invent parallels)
+
+- `.abc-<color>` — background color (e.g., `.abc-primary-blue-500`)
+- `.atc-<color>` — text color (e.g., `.atc-light-blue-300`)
+- `.fs-[n]` / `.md:fs-[n]` — font size (n = 1–30 px)
+- `.rs-size-[n]`, `.rs-w-[n]`, `.rs-h-[n]` — width/height (0–500 px)
+- `.rs-gap-[n]`, `.rs-gap-x-[n]`, `.rs-gap-y-[n]` — flex/grid gaps
+- `.rs-m-[n]`, `.rs-mx-[n]`, `.rs-my-[n]`, `.rs-mt-[n]`, `.rs-mr-[n]`, `.rs-mb-[n]`, `.rs-ml-[n]`
+- `.rs-p-[n]`, `.rs-px-[n]`, `.rs-py-[n]`, `.rs-pt-[n]`, `.rs-pr-[n]`, `.rs-pb-[n]`, `.rs-pl-[n]`
+- `.rs-hide`, `.md-rs-hide`
+
+`.md:` variants apply to the landscape ≤ 768 px height breakpoint and use `!important` to override base rules. See [`../../research-indicators/README.md`](../../research-indicators/README.md) for full reference.
+
+### 7.3 Typography
+
+- Font scale defined in `src/styles/font.scss`.
+- Base size respects browser defaults (rem-based); per-element overrides via `.fs-[n]` utilities.
+- Heading hierarchy used by `section-header` and `form-header` shared components.
+
+### 7.4 Form fields
+
+- Custom form-field styles in `src/styles/custom-fields.scss`.
+- PrimeNG inputs are wrapped/restyled through `src/styles/custom-prime-force-styles.scss`. New form patterns should use the wrapped versions, not raw PrimeNG defaults.
+
+---
+
+## 8. Component Inventory
+
+All shared, reusable components live under `src/app/shared/`. Reach for them before building new ones.
+
+### 8.1 Shell & navigation
+- `alliance-navbar`, `alliance-sidebar`, `section-header`, `result-sidebar`, `section-sidebar`, `form-header`, `navigation-buttons`
+
+### 8.2 Data display
+- `results-table`, `project-results-table`, `project-item`, `partner-selected-item`, `notification-item`, `custom-tag`, `custom-progress-bar`, `metadata-panel`, `alert-tag`
+
+### 8.3 Forms & input
+- `dropdowns`, `dropdown`, `custom-fields`, `search-export-controls`, `shared-result-form`
+
+### 8.4 Modals & overlays
+- `all-modals` (host), `modal` (wrapper). All new dialogs route through these — never instantiate ad-hoc overlays.
+
+### 8.5 System feedback
+- `global-alert`, `global-toast`, `alert-tag` — for user-facing system state.
+
+### 8.6 OICR-specific
+- `download-oicr-template`, `oicr-header`, `oicr-workflow-status`
+
+### 8.7 Utilities
+- `copy-token`, `filters-action-buttons`
+
+> **Rule**: A new screen that introduces a "card" or "table" or "modal" pattern not covered by the inventory above must either (a) extend the shared component or (b) document the new component in §12 Design Decisions and add it to this inventory in the same change.
+
+---
+
+## 9. Responsive Behavior
+
+- **Primary form factor**: desktop browser, 1280–1920 px wide.
+- **Supported**: laptop landscape ≥ 1024 px wide, height ≥ 768 px.
+- **Constrained**: landscape with height ≤ 768 px (the `md:` utility breakpoint). Layouts compress vertically; some chrome may hide via `.md-rs-hide`.
+- **Mobile portrait**: not a primary target (see [`../prd.md`](../prd.md) OQ-6). Layouts should not crash but are not pixel-tuned.
+- **Density**: prefer compact PrimeNG tables on small viewports; use `.rs-*` utilities to scale spacing predictably.
+
+---
+
+## 10. Accessibility Expectations
+
+WCAG 2.1 AA is the floor for every changed screen (PRD constraint C-4).
+
+- **Keyboard**: every interactive control reachable via Tab; visible focus ring; no keyboard trap.
+- **Labels**: all inputs have `<label>` or `aria-label`. Icon-only buttons have `aria-label`.
+- **Color contrast**: token combinations chosen so text on background ≥ 4.5:1 (body) / ≥ 3:1 (large text & UI icons). Dark-mode pairings verified separately.
+- **Status communicated non-visually**: success/error/warning conveyed by icon + text, not color alone (`custom-tag`, `alert-tag`).
+- **Motion**: avoid auto-playing motion; respect `prefers-reduced-motion`.
+- **Live regions**: real-time alerts (`global-alert`, `global-toast`) use ARIA live regions appropriately.
+- **PrimeNG + Angular CDK** are leveraged for focus management & overlays; do not bypass them.
+
+---
+
+## 11. Dark Mode Behavior
+
+- **Toggle**: `DarkModeService` (signal-based). Persisted in user cache / localStorage.
+- **Mechanism**: adds `.dark-mode` class to `<body>`; PrimeNG Aura preset (`roartheme.ts`) detects via `darkModeSelector`; CSS variable set on `:root[data-theme="dark"]` swaps.
+- **Author rule**: components must use token utilities (`.abc-*`, `.atc-*`) or CSS variables — **never** hard-coded hex — so dark mode "just works."
+- **Per-screen requirement**: dark + light parity is **not codified as a hard product constraint** today (see [`../prd.md`](../prd.md) OQ-3). However, breaking dark mode on a screen that previously supported it is a regression.
+
+---
+
+## 12. Design Decisions (Decision Record)
+
+Append new decisions here; do not silently change established patterns. Each entry: short title, date, decision, rationale.
+
+- **2026-05-13 — Lock UI stack at PrimeNG 19 + Aura preset.** No mixing of other component libraries. *Rationale*: prevent design drift; Aura preset already overridden for brand.
+- **2026-05-13 — Controlled-list inputs only for CLARISA-managed fields.** *Rationale*: PRD C-3. Free text for CLARISA fields is a defect.
+- **2026-05-13 — Result Detail is the only tertiary-navigation surface.** *Rationale*: avoid navigation depth elsewhere; tabbed editors are a metadata-record pattern, not a general one.
+- **2026-05-13 — All overlays route through `all-modals` + `modal`.** *Rationale*: consistent escape-key, focus-trap, and dismiss behavior.
+- **2026-05-13 — Spacing/sizing via `rs-*` utilities, not inline styles.** *Rationale*: responsive breakpoint already encoded; ad-hoc CSS drifts.
+
+---
+
+## 13. Open Gaps & Open Questions
+
+- **OG-1**: A formal **design system audit** has not been done against PRMS / STAR siblings. Token names diverge across CGIAR products.
+- **OG-2**: **Dark-mode parity** is incomplete on some legacy PrimeNG overrides; not all custom-prime-force-styles.scss rules account for both modes.
+- **OG-3**: **Mobile portrait** layouts are undefined ([`../prd.md`](../prd.md) OQ-6).
+- **OG-4**: There is no published **icon system** spec — primeicons is used but with no rules for when icons are mandatory vs decorative.
+- **OG-5**: The **landing page** is the only public surface and has no dedicated visual identity guidelines.
+- **OG-6**: **Empty / error / loading** state patterns are not unified across tables and dashboards.
+- **OG-7**: **Localization / i18n** is not yet a constitutional concern; `@angular/build:extract-i18n` exists in `angular.json` but no flows use it.

--- a/research-indicators/src/AGENTS.md
+++ b/research-indicators/src/AGENTS.md
@@ -1,0 +1,179 @@
+# CLAUDE.md — `research-indicators/src/` (Angular SPA source)
+
+Child guide for the actual Angular 19 + PrimeNG 19 application code. Read this **after** the root [`../../CLAUDE.md`](../../CLAUDE.md) — that file holds the constitutional baseline (PRD, system design, detailed design, SDD templates). This file is the **day-to-day coding contract** for working inside `src/`.
+
+> If the rules here ever conflict with the constitutional docs, the constitutional docs win and this file must be updated in the same change.
+
+---
+
+## Where to read first
+
+| Need | Read |
+|------|------|
+| Why the product exists, personas, KPIs, scope | [`../../docs/prd.md`](../../docs/prd.md) |
+| UX rules, screen inventory, tokens, components | [`../../docs/system-design/design.md`](../../docs/system-design/design.md) |
+| Modules, data model, API, state, security, errors | [`../../docs/detailed-design/detailed-design.md`](../../docs/detailed-design/detailed-design.md) |
+| Spec templates for new features | [`../../docs/specs/general-setup/`](../../docs/specs/general-setup/) |
+| Color tokens + responsive utilities reference | [`../README.md`](../README.md) |
+
+---
+
+## Folder layout
+
+```
+src/
+├── index.html                # SPA shell
+├── main.ts                   # Angular bootstrap
+├── setup-jest.ts             # Jest test bootstrap
+├── environments/             # environment.ts / environment.dev.ts (URLs, flags, keys)
+├── styles/                   # global SCSS: colors.scss, font.scss,
+│                             # custom-fields.scss, custom-prime-force-styles.scss,
+│                             # responsive-size.scss, styles.scss
+└── app/
+    ├── app.component.{ts,html,spec.ts}
+    ├── app.config.ts         # providers, router, HTTP, interceptors, socket
+    ├── app.routes.ts         # lazy standalone routes + guards/resolvers
+    ├── pages/                # feature pages (one folder per route group)
+    │   ├── landing/
+    │   ├── login/
+    │   ├── auth/
+    │   ├── room/
+    │   ├── oicr-download/
+    │   ├── dynamic-fields/
+    │   ├── cache-test/
+    │   └── platform/         # authenticated shell + child pages
+    │       └── pages/
+    │           ├── home/
+    │           ├── about/
+    │           ├── about-indicators/
+    │           ├── indicator/
+    │           ├── results-center/
+    │           ├── search-a-result/
+    │           ├── load-result/
+    │           ├── result/
+    │           │   └── pages/      # 11 metadata tabs
+    │           ├── my-projects/
+    │           ├── project-detail/
+    │           ├── dashboard/
+    │           ├── notifications/
+    │           ├── profile/
+    │           └── administration/center-admin/
+    │               ├── capacity-bulk-upload/
+    │               └── sdg-management/
+    ├── shared/               # cross-cutting code
+    │   ├── components/       # shared UI components
+    │   ├── services/         # API, cache, role, websocket, theme, analytics
+    │   ├── interceptors/     # JWT, http-error, result
+    │   ├── guards/           # rolesGuard, centerAdminGuard
+    │   ├── interfaces/       # TypeScript shapes (result, api, cache, etc.)
+    │   ├── pipes/            # format-date, s3-image-url, filter-by-text-with-attr
+    │   ├── utils/            # date/geo/map helpers
+    │   ├── sockets/          # websocket.service
+    │   ├── types/            # shared ts type helpers
+    │   └── enums/            # enum constants
+    ├── theme/                # PrimeNG Aura preset (roartheme.ts)
+    └── testing/              # shared test mocks / harness
+```
+
+---
+
+## Path aliases (use these, not relative `../../..` paths)
+
+Declared in [`../tsconfig.json`](../tsconfig.json) and mirrored in [`../jest.config.ts`](../jest.config.ts). Keep them in sync if you add new ones.
+
+| Alias | Resolves to |
+|-------|-------------|
+| `@public/*` | `public/*` |
+| `@envs/*` | `src/environments/*` |
+| `@pages/*` | `src/app/pages/*` |
+| `@platform/*` | `src/app/pages/platform/*` |
+| `@auth/*` | `src/app/pages/auth/*` |
+| `@landing/*` | `src/app/pages/landing/*` |
+| `@shared/*` | `src/app/shared/*` |
+| `@components/*` | `src/app/shared/components/*` |
+| `@services/*` | `src/app/shared/services/*` |
+| `@interfaces/*` | `src/app/shared/interfaces/*` |
+| `@interceptors/*` | `src/app/shared/interceptors/*` |
+| `@guards/*` | `src/app/shared/guards/*` |
+| `@sockets/*` | `src/app/shared/sockets/*` |
+| `@utils/*` | `src/app/shared/utils/*` |
+| `@ts-types/*` | `src/app/shared/types/*` |
+
+---
+
+## Adding code — where it goes
+
+| You're adding… | Put it in… |
+|----------------|------------|
+| A new authenticated screen | `app/pages/platform/pages/<feature>/` + lazy entry in `app.routes.ts` |
+| A new result-detail tab | `app/pages/platform/pages/result/pages/<tab>/` + child route in `app.routes.ts` |
+| A new public screen | `app/pages/<feature>/` + top-level route (no `rolesGuard`) |
+| A reusable UI element | `app/shared/components/<name>/` — register it in [`../../docs/system-design/design.md`](../../docs/system-design/design.md) §8 |
+| A reusable service / API method | `app/shared/services/<name>.service.ts` — for REST, extend `ApiService` |
+| A reusable interface | `app/shared/interfaces/<name>.interface.ts` |
+| A reusable pipe | `app/shared/pipes/<name>.pipe.ts` |
+| A reusable util | `app/shared/utils/<name>.util.ts` |
+| A new HTTP interceptor | `app/shared/interceptors/` + register order in `app.config.ts` (JWT → error → result) |
+| A new guard | `app/shared/guards/` + reference in `app.routes.ts` `canMatch` |
+| A new WebSocket event | extend `app/shared/sockets/websocket.service.ts` |
+| A new control-list cache | `app/shared/services/cache/` |
+| A test fixture / mock | `app/testing/` (never reinvent fixtures per test) |
+| A new color / spacing token | `src/styles/colors.scss` or `src/styles/responsive-size.scss` — then update [`../README.md`](../README.md) and [`../../docs/system-design/design.md`](../../docs/system-design/design.md) §7 |
+
+---
+
+## Conventions inside `src/`
+
+- **Standalone components only** (PRD C-6). No NgModules. Lazy load via `loadComponent` in `app.routes.ts`.
+- **Selector prefix**: `app` (per `angular.json`). E.g., `app-results-table`.
+- **Style**: SCSS (`inlineStyleLanguage: scss` + component `styleUrls`).
+- **State**: signals (`signal`, `computed`, `WritableSignal<T>`) for cross-cutting client state; RxJS for streams/HTTP/socket. No NgRx.
+- **HTTP**: never call `HttpClient` from a component. Go through `ApiService` (or a domain service that delegates). Always handle `MainResponse<T>` (see [`../../docs/detailed-design/detailed-design.md`](../../docs/detailed-design/detailed-design.md) §4).
+- **Auth**: never bypass `jWtInterceptor`. Tokens stay in `localStorage` + cache signals; never logged or sent to analytics SDKs.
+- **Conflicts (409)**: surface the link-to-existing flow — do not retry blindly.
+- **Modals**: route through `all-modals` host + `modal` wrapper; no ad-hoc overlays.
+- **Forms**: reactive forms; wrapped PrimeNG inputs from `styles/custom-fields.scss` & `styles/custom-prime-force-styles.scss` — not raw PrimeNG controls.
+- **Colors & spacing**: token utility classes (`.abc-*`, `.atc-*`, `.rs-*`, `.fs-*`) or CSS variables (`var(--ac-*)`). **No hex literals in component code.**
+- **Dark mode**: rely on tokens — never branch on `isDarkMode()` for color decisions.
+- **i18n**: not yet wired. Don't add a parallel i18n mechanism — file an open question instead.
+- **Strict TS**: `strict`, `noImplicitOverride`, `noPropertyAccessFromIndexSignature`, `noImplicitReturns`, `noFallthroughCasesInSwitch`, `strictTemplates`. Don't loosen these in `tsconfig.json`.
+
+---
+
+## Tests inside `src/`
+
+- Co-locate `*.spec.ts` next to the subject file. Run with `npm run test` (watch: `test:watch`, coverage: `test:coverage`).
+- Bootstrap: `setup-jest.ts`. Config: [`../jest.config.ts`](../jest.config.ts). Environment: `jsdom`.
+- Use shared mocks in `app/testing/`. Don't re-mock the same service per file.
+- Service tests: assert on the `MainResponse<T>` envelope with `HttpTestingController`.
+- Component tests: cover role-conditional rendering, signal-driven state transitions, form validity, error surfaces.
+- Coverage floors (project-wide, enforced by `jest.config.ts`): statements 40%, branches 20%, lines 45%, functions 30%. Don't regress on changed files.
+- Excluded from coverage by design: `app.config.ts`, `app.routes.ts`, `shared/sockets/websocket.service.ts`, `shared/components/alert/alert.component.ts`.
+
+---
+
+## Quick commands (from `research-indicators/`)
+
+| What | Command |
+|------|---------|
+| Dev server (http://localhost:4200) | `npm start` |
+| Production build | `npm run build` |
+| Dev build with sourcemaps | `npm run build-dev` |
+| Tests | `npm run test` |
+| Coverage | `npm run test:coverage` |
+| Lint (TS/HTML) | `npm run lint` |
+| Lint (SCSS) | `npm run s-lint` |
+| Docker dev compose | `npm run compose:up:dev` |
+
+---
+
+## Hard rules echo (PRD C-1…C-6)
+
+These bind every change inside `src/`. Full text in [`../../docs/prd.md`](../../docs/prd.md) §8.3.
+
+- **C-1** Angular 19 + PrimeNG 19, no migration.
+- **C-2** AWS Cognito + JWT, no alternative IdPs.
+- **C-3** CLARISA is the controlled-vocabulary source — no parallel taxonomies in `interfaces/` or in component dropdowns.
+- **C-4** WCAG 2.1 AA on every changed screen.
+- **C-5** Respect `angular.json` bundle budgets (initial ≤ 3 MB error / 2 MB warning; component styles ≤ 8 kB / 4 kB).
+- **C-6** New routes are lazy-loaded standalone components.


### PR DESCRIPTION
Add the project-wide SDD foundation: PRD, system design, detailed design, and methodology templates under docs/, plus a repo-level AGENTS.md, a child research-indicators/src/AGENTS.md, and a project README that indexes the documentation. Future /sdd-specify, /sdd-execute, /sdd-validate, and /sdd-test work depends on these.

- docs/prd.md — problem, 4 personas, KPIs (M1–M8), scope, constraints (C-1…C-6), user stories, acceptance criteria, assumptions, open questions
- docs/system-design/design.md — UX principles, IA, 5 primary flows, 22-screen inventory, navigation, tokens, component inventory, responsive, a11y, dark mode, decision record, open gaps
- docs/detailed-design/detailed-design.md — system overview, modules, data model, API contracts (MainResponse<T>), state boundaries (signals + RxJS), integrations, security, errors, testing, constraints
- docs/specs/general-setup/{requirements,design,task}.md — methodology templates for module specs under docs/specs/<domain>/<feature>/
- README.md — repository entry point indexing docs/ and getting-started
- AGENTS.md — repo-level guide for Claude Code
- research-indicators/src/AGENTS.md — Angular SPA day-to-day coding contract

Spec taxonomy is by domain module, mirroring the page modules in detailed-design §2: results, indicators, projects, dashboard, notifications, administration, auth, shared, platform.