### PR TITLE
Staging

### DIFF
--- a/research-indicators/src/app/pages/platform/pages/result/pages/evidence/evidence.component.html
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/evidence/evidence.component.html
@@ -1,6 +1,19 @@
 <div class="app-page-wrapper">
   <app-form-header />
   <div class="flex flex-col bg-[#fcfcfc] rounded-[10px] p-[30px] mb-10">
+    @if (cache.currentMetadata().indicator_id === 5) {
+    <div class="flex flex-col gap-3 mb-8">
+      <div class="section-title">CGSPACE LINK</div>
+
+      <div class="flex flex-col">
+        <app-input label="CGspace link"
+          helperText="This field corresponds to the link published in cgspace where the pdf for this work is located."
+          [isRequired]="true" [disabled]="!submission.isEditableStatus()" [validateEmpty]="true" [signal]="body"
+          optionValue="cgspace_link" pattern="handle-url" placeholder="Provide the CGspace link"
+          [maxLength]="400"></app-input>
+      </div>
+    </div>
+    }
     <div class="section-title">EVIDENCE</div>
     <div class="flex flex-col gap-5">
       @for (evidence of body().evidence; track $index) {

--- a/research-indicators/src/app/pages/platform/pages/result/pages/evidence/evidence.component.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/evidence/evidence.component.spec.ts
@@ -77,6 +77,10 @@ describe('EvidenceComponent', () => {
     cache = TestBed.inject(CacheService);
     submission = TestBed.inject(SubmissionService);
     fixture.detectChanges();
+    component.body.update(body => ({
+      ...body,
+      cgspace_link: 'https://hdl.handle.net/10568/182058'
+    }));
   });
 
   it('should create', () => {
@@ -145,12 +149,57 @@ describe('EvidenceComponent', () => {
   });
 
   it('should save data and show toast if editable', async () => {
+    component.body.set({
+      evidence: [{ evidence_url: 'url', evidence_description: 'desc', is_active: true, result_evidence_id: null, result_id: null, evidence_role_id: null, is_private: false }],
+      notable_references: [],
+      cgspace_link: 'https://hdl.handle.net/10568/1'
+    });
     const spyToast = jest.spyOn(actions, 'showToast');
     const spyGetData = jest.spyOn(component, 'getData');
     submission.isEditableStatus.mockReturnValue(true);
     await component.saveData();
     expect(spyToast).toHaveBeenCalled();
     expect(spyGetData).toHaveBeenCalled();
+  });
+
+  it('should block save for OICR when cgspace link has invalid format', async () => {
+    component.body.set({
+      evidence: [new Evidence()],
+      notable_references: [],
+      cgspace_link: 'https://cgspace.cgiar.org/handle/10568/1'
+    });
+    const spyToast = jest.spyOn(actions, 'showToast');
+    const spyPatch = jest.spyOn(api, 'PATCH_ResultEvidences');
+    submission.isEditableStatus.mockReturnValue(true);
+    await component.saveData();
+    expect(spyToast).toHaveBeenCalledWith(
+      expect.objectContaining({ severity: 'error', detail: 'CGspace link must start with https://hdl.handle.net/' })
+    );
+    expect(spyPatch).not.toHaveBeenCalled();
+  });
+
+  it('should block save for OICR when cgspace link is missing', async () => {
+    component.body.set({ evidence: [new Evidence()], notable_references: [], cgspace_link: '' });
+    const spyToast = jest.spyOn(actions, 'showToast');
+    const spyPatch = jest.spyOn(api, 'PATCH_ResultEvidences');
+    submission.isEditableStatus.mockReturnValue(true);
+    await component.saveData();
+    expect(spyToast).toHaveBeenCalledWith(expect.objectContaining({ severity: 'error', detail: 'CGspace link is required' }));
+    expect(spyPatch).not.toHaveBeenCalled();
+  });
+
+  it('should include cgspace_link in PATCH payload for OICR', async () => {
+    component.body.set({
+      evidence: [{ evidence_url: 'url', evidence_description: 'desc', is_active: true, result_evidence_id: null, result_id: null, evidence_role_id: null, is_private: false }],
+      notable_references: [],
+      cgspace_link: '  https://hdl.handle.net/10568/1  '
+    });
+    submission.isEditableStatus.mockReturnValue(true);
+    await component.saveData();
+    expect(api.PATCH_ResultEvidences).toHaveBeenCalledWith(
+      123,
+      expect.objectContaining({ cgspace_link: 'https://hdl.handle.net/10568/1' })
+    );
   });
 
   it('should navigate to back page (links-to-result when indicator_id is 5)', async () => {

--- a/research-indicators/src/app/pages/platform/pages/result/pages/evidence/evidence.component.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/evidence/evidence.component.spec.ts
@@ -162,35 +162,43 @@ describe('EvidenceComponent', () => {
     expect(spyGetData).toHaveBeenCalled();
   });
 
-  it('should block save for OICR when cgspace link has invalid format', async () => {
+  it('should save OICR when cgspace link is not a handle.net URL', async () => {
     component.body.set({
-      evidence: [new Evidence()],
+      evidence: [{ evidence_url: 'url', evidence_description: 'desc', is_active: true, result_evidence_id: null, result_id: null, evidence_role_id: null, is_private: false }],
       notable_references: [],
       cgspace_link: 'https://cgspace.cgiar.org/handle/10568/1'
     });
     const spyToast = jest.spyOn(actions, 'showToast');
-    const spyPatch = jest.spyOn(api, 'PATCH_ResultEvidences');
     submission.isEditableStatus.mockReturnValue(true);
     await component.saveData();
-    expect(spyToast).toHaveBeenCalledWith(
-      expect.objectContaining({ severity: 'error', detail: 'CGspace link must start with https://hdl.handle.net/' })
+    expect(api.PATCH_ResultEvidences).toHaveBeenCalledWith(
+      123,
+      expect.objectContaining({ cgspace_link: 'https://cgspace.cgiar.org/handle/10568/1' })
     );
-    expect(spyPatch).not.toHaveBeenCalled();
+    expect(spyToast).toHaveBeenCalledWith(expect.objectContaining({ severity: 'success' }));
   });
 
-  it('should block save for OICR when cgspace link is missing', async () => {
-    component.body.set({ evidence: [new Evidence()], notable_references: [], cgspace_link: '' });
+  it('should save OICR when cgspace link is empty', async () => {
+    component.body.set({
+      evidence: [{ evidence_url: 'url', evidence_description: 'desc', is_active: true, result_evidence_id: null, result_id: null, evidence_role_id: null, is_private: false }],
+      notable_references: [],
+      cgspace_link: ''
+    });
     const spyToast = jest.spyOn(actions, 'showToast');
-    const spyPatch = jest.spyOn(api, 'PATCH_ResultEvidences');
     submission.isEditableStatus.mockReturnValue(true);
     await component.saveData();
-    expect(spyToast).toHaveBeenCalledWith(expect.objectContaining({ severity: 'error', detail: 'CGspace link is required' }));
-    expect(spyPatch).not.toHaveBeenCalled();
+    expect(api.PATCH_ResultEvidences).toHaveBeenCalledWith(123, expect.objectContaining({ cgspace_link: null }));
+    expect(spyToast).toHaveBeenCalledWith(expect.objectContaining({ severity: 'success' }));
   });
 
   it('isCgspaceLinkFormatInvalid should be false when link is empty', () => {
     component.body.set({ evidence: [new Evidence()], notable_references: [], cgspace_link: '   ' });
     expect(component.isCgspaceLinkFormatInvalid()).toBe(false);
+  });
+
+  it('isCgspaceLinkInvalid should be true when OICR has empty cgspace link', () => {
+    component.body.set({ evidence: [new Evidence()], notable_references: [], cgspace_link: '   ' });
+    expect(component.isCgspaceLinkInvalid()).toBe(true);
   });
 
   it('isCgspaceLinkInvalid and isCgspaceLinkFormatInvalid should be false for non-OICR indicators', () => {

--- a/research-indicators/src/app/pages/platform/pages/result/pages/evidence/evidence.component.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/evidence/evidence.component.spec.ts
@@ -188,6 +188,27 @@ describe('EvidenceComponent', () => {
     expect(spyPatch).not.toHaveBeenCalled();
   });
 
+  it('isCgspaceLinkFormatInvalid should be false when link is empty', () => {
+    component.body.set({ evidence: [new Evidence()], notable_references: [], cgspace_link: '   ' });
+    expect(component.isCgspaceLinkFormatInvalid()).toBe(false);
+  });
+
+  it('isCgspaceLinkInvalid and isCgspaceLinkFormatInvalid should be false for non-OICR indicators', () => {
+    cache.currentMetadata = jest.fn(() => ({ indicator_id: 1, status_id: 4 }));
+    component.body.set({ evidence: [new Evidence()], notable_references: [], cgspace_link: '' });
+    expect(component.isCgspaceLinkInvalid()).toBe(false);
+    expect(component.isCgspaceLinkFormatInvalid()).toBe(false);
+  });
+
+  it('isCgspaceLinkFormatInvalid should be true for invalid handle URL on OICR', () => {
+    component.body.set({
+      evidence: [new Evidence()],
+      notable_references: [],
+      cgspace_link: 'https://invalid.example/handle/1'
+    });
+    expect(component.isCgspaceLinkFormatInvalid()).toBe(true);
+  });
+
   it('should include cgspace_link in PATCH payload for OICR', async () => {
     component.body.set({
       evidence: [{ evidence_url: 'url', evidence_description: 'desc', is_active: true, result_evidence_id: null, result_id: null, evidence_role_id: null, is_private: false }],

--- a/research-indicators/src/app/pages/platform/pages/result/pages/evidence/evidence.component.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/evidence/evidence.component.ts
@@ -1,7 +1,5 @@
 import { Component, inject, signal } from '@angular/core';
-import { FormsModule } from '@angular/forms';
 import { ButtonModule } from 'primeng/button';
-import { InputTextModule } from 'primeng/inputtext';
 import { ActionsService } from '../../../../../../shared/services/actions.service';
 import { ActivatedRoute, Router } from '@angular/router';
 import { CacheService } from '../../../../../../shared/services/cache/cache.service';
@@ -13,10 +11,13 @@ import { FormHeaderComponent } from '@shared/components/form-header/form-header.
 import { VersionWatcherService } from '@shared/services/version-watcher.service';
 import { NavigationButtonsComponent } from '@shared/components/navigation-buttons/navigation-buttons.component';
 import { OtherReferenceItemComponent, OtherReferenceItemData } from '../oicr-details/components/other-reference-item/other-reference-item.component';
+import { InputComponent } from '@shared/components/custom-fields/input/input.component';
+
+const CGSPACE_HANDLE_URL_PATTERN = /^https:\/\/hdl\.handle\.net\/.+/;
 
 @Component({
   selector: 'app-evidence',
-  imports: [ButtonModule, FormHeaderComponent, NavigationButtonsComponent, FormsModule, InputTextModule, EvidenceItemComponent, OtherReferenceItemComponent],
+  imports: [ButtonModule, FormHeaderComponent, NavigationButtonsComponent, InputComponent, EvidenceItemComponent, OtherReferenceItemComponent],
   templateUrl: './evidence.component.html'
 })
 export default class EvidenceComponent {
@@ -72,7 +73,38 @@ export default class EvidenceComponent {
     }
   }
 
+  isCgspaceLinkInvalid(): boolean {
+    if (this.cache.currentMetadata().indicator_id !== 5) return false;
+    const link = this.body().cgspace_link?.trim();
+    return !link;
+  }
+
+  isCgspaceLinkFormatInvalid(): boolean {
+    if (this.cache.currentMetadata().indicator_id !== 5) return false;
+    const link = this.body().cgspace_link?.trim();
+    if (!link) return false;
+    return !CGSPACE_HANDLE_URL_PATTERN.test(link);
+  }
+
   async saveData(page?: 'next' | 'back'): Promise<void> {
+    if (this.submission.isEditableStatus() && this.isCgspaceLinkInvalid()) {
+      this.actions.showToast({
+        severity: 'error',
+        summary: 'Evidence',
+        detail: 'CGspace link is required'
+      });
+      return;
+    }
+
+    if (this.submission.isEditableStatus() && this.isCgspaceLinkFormatInvalid()) {
+      this.actions.showToast({
+        severity: 'error',
+        summary: 'Evidence',
+        detail: 'CGspace link must start with https://hdl.handle.net/'
+      });
+      return;
+    }
+
     this.setLoading(true);
     try {
       if (this.submission.isEditableStatus()) {
@@ -121,11 +153,18 @@ export default class EvidenceComponent {
       link: item.link
     }));
 
-    return {
+    const payload: PatchResultEvidences = {
       ...snapshot,
       evidence: snapshot.evidence,
       notable_references: notableReferences
     };
+
+    if (this.cache.currentMetadata().indicator_id === 5) {
+      const link = snapshot.cgspace_link?.trim();
+      payload.cgspace_link = link || null;
+    }
+
+    return payload;
   }
 
   private syncOtherReferencesFromApi(references?: NotableReference[]): void {

--- a/research-indicators/src/app/pages/platform/pages/result/pages/evidence/evidence.component.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/pages/evidence/evidence.component.ts
@@ -87,24 +87,6 @@ export default class EvidenceComponent {
   }
 
   async saveData(page?: 'next' | 'back'): Promise<void> {
-    if (this.submission.isEditableStatus() && this.isCgspaceLinkInvalid()) {
-      this.actions.showToast({
-        severity: 'error',
-        summary: 'Evidence',
-        detail: 'CGspace link is required'
-      });
-      return;
-    }
-
-    if (this.submission.isEditableStatus() && this.isCgspaceLinkFormatInvalid()) {
-      this.actions.showToast({
-        severity: 'error',
-        summary: 'Evidence',
-        detail: 'CGspace link must start with https://hdl.handle.net/'
-      });
-      return;
-    }
-
     this.setLoading(true);
     try {
       if (this.submission.isEditableStatus()) {
@@ -179,5 +161,4 @@ export default class EvidenceComponent {
 
     this.otherReferences.set([]);
   }
-
 }

--- a/research-indicators/src/app/pages/platform/pages/result/resolvers/result-exists.resolver.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/resolvers/result-exists.resolver.spec.ts
@@ -838,4 +838,24 @@ describe('resultExistsResolver', () => {
     expect(router.navigate).not.toHaveBeenCalled();
     expect(result).toBe(true);
   });
+
+  it('should return true when OICR draft skips modal branch and tryOpenOicrEditor resolves undefined', async () => {
+    route.paramMap.get = jest.fn().mockReturnValue('123');
+    route.queryParamMap.get = jest.fn().mockReturnValue(null);
+    metadataService.update = jest.fn().mockResolvedValue({
+      canOpen: true,
+      indicator_id: 5,
+      status_id: 12,
+      result_official_code: 3,
+      result_contract_id: 456,
+      result_title: 'Test Project'
+    });
+    currentResultService.validateOpenResult = jest.fn().mockReturnValue(true);
+    rolesService.isAdmin = jest.fn().mockReturnValueOnce(false).mockReturnValueOnce(true);
+
+    const result = await runInInjectionContext(injector, () => resultExistsResolver(route, { url: '', root: {} as any }));
+
+    expect(currentResultService.openEditRequestdOicrsModal).not.toHaveBeenCalled();
+    expect(result).toBe(true);
+  });
 });

--- a/research-indicators/src/app/pages/platform/pages/result/resolvers/result-exists.resolver.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/resolvers/result-exists.resolver.spec.ts
@@ -3,7 +3,7 @@ import { runInInjectionContext } from '@angular/core';
 import { Router } from '@angular/router';
 import { ActivatedRoute } from '@angular/router';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { resultExistsResolver } from './result-exists.resolver';
+import { resultExistsResolver, redirectAndOpenOicrEditModal } from './result-exists.resolver';
 import { GetMetadataService } from '@shared/services/get-metadata.service';
 import { CurrentResultService } from '@shared/services/cache/current-result.service';
 import { CacheService } from '@shared/services/cache/cache.service';
@@ -857,5 +857,112 @@ describe('resultExistsResolver', () => {
 
     expect(currentResultService.openEditRequestdOicrsModal).not.toHaveBeenCalled();
     expect(result).toBe(true);
+  });
+});
+
+describe('redirectAndOpenOicrEditModal', () => {
+  let router: { navigate: jest.Mock; url: string };
+  let route: { queryParamMap: { get: jest.Mock } };
+  let currentResultService: { openEditRequestdOicrsModal: jest.Mock };
+  let cacheService: { projectResultsSearchValue: { set: jest.Mock } };
+
+  const meta = {
+    indicator_id: 1,
+    status_id: 2,
+    result_official_code: 3,
+    result_contract_id: 456,
+    result_title: 'Test Project'
+  };
+
+  beforeEach(() => {
+    router = {
+      navigate: jest.fn().mockResolvedValue(true),
+      url: '/some-other-path'
+    };
+    route = {
+      queryParamMap: {
+        get: jest.fn().mockReturnValue(null)
+      }
+    };
+    currentResultService = {
+      openEditRequestdOicrsModal: jest.fn().mockResolvedValue(undefined)
+    };
+    cacheService = {
+      projectResultsSearchValue: {
+        set: jest.fn()
+      }
+    };
+  });
+
+  it('should navigate to project-detail, set search cache, open modal with project context', async () => {
+    const result = await redirectAndOpenOicrEditModal(
+      route as any,
+      router as any,
+      cacheService as any,
+      currentResultService as any,
+      meta
+    );
+
+    expect(router.navigate).toHaveBeenCalledWith(['/project-detail', 456]);
+    expect(cacheService.projectResultsSearchValue.set).toHaveBeenCalledWith('Test Project');
+    expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(1, 2, 3, 'project');
+    expect(result).toBe(false);
+  });
+
+  it('should navigate to results-center and open modal with results-center context', async () => {
+    route.queryParamMap.get = jest.fn((key: string) => (key === 'from' ? 'results-center' : null));
+
+    const result = await redirectAndOpenOicrEditModal(
+      route as any,
+      router as any,
+      cacheService as any,
+      currentResultService as any,
+      meta
+    );
+
+    expect(router.navigate).toHaveBeenCalledWith(['/results-center']);
+    expect(cacheService.projectResultsSearchValue.set).not.toHaveBeenCalled();
+    expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(1, 2, 3, 'results-center');
+    expect(result).toBe(false);
+  });
+
+  it('should navigate to home and open modal without creation context', async () => {
+    route.queryParamMap.get = jest.fn((key: string) => (key === 'from' ? 'home' : null));
+
+    const result = await redirectAndOpenOicrEditModal(
+      route as any,
+      router as any,
+      cacheService as any,
+      currentResultService as any,
+      meta
+    );
+
+    expect(router.navigate).toHaveBeenCalledWith(['/home']);
+    expect(cacheService.projectResultsSearchValue.set).not.toHaveBeenCalled();
+    expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(1, 2, 3, undefined);
+    expect(result).toBe(false);
+  });
+
+  it('should skip cache update when already on project-detail', async () => {
+    router.url = '/project-detail/456';
+
+    await redirectAndOpenOicrEditModal(route as any, router as any, cacheService as any, currentResultService as any, meta);
+
+    expect(router.navigate).toHaveBeenCalledWith(['/project-detail', 456]);
+    expect(cacheService.projectResultsSearchValue.set).not.toHaveBeenCalled();
+  });
+
+  it('should default nullish metadata values when opening modal', async () => {
+    await redirectAndOpenOicrEditModal(route as any, router as any, cacheService as any, currentResultService as any, {
+      indicator_id: null,
+      status_id: undefined,
+      result_official_code: null,
+      result_contract_id: null,
+      result_title: null
+    });
+
+    expect(router.navigate).toHaveBeenCalledWith(['/project-detail', null]);
+    expect(cacheService.projectResultsSearchValue.set).toHaveBeenCalledWith('');
+    expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(0, 0, 0, 'project');
   });
 });

--- a/research-indicators/src/app/pages/platform/pages/result/resolvers/result-exists.resolver.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/resolvers/result-exists.resolver.spec.ts
@@ -19,6 +19,8 @@ describe('resultExistsResolver', () => {
   let rolesService: any;
 
   beforeEach(() => {
+    jest.clearAllMocks();
+
     const metadataServiceMock = {
       update: jest.fn()
     };
@@ -76,6 +78,7 @@ describe('resultExistsResolver', () => {
     currentResultService = TestBed.inject(CurrentResultService);
     cacheService = TestBed.inject(CacheService);
     rolesService = TestBed.inject(RolesService);
+    rolesService.isAdmin = jest.fn().mockReturnValue(false);
   });
 
   it('should return true when metadata service update succeeds', async () => {
@@ -670,35 +673,94 @@ describe('resultExistsResolver', () => {
     expect(result).toBe(false);
   });
 
-  it('should return false and open modal when validateOpenResult returns true and status_id is Published (14)', async () => {
-    // Arrange
+  it('should return false and open modal when published OICR (14) and user is admin', async () => {
     const id = 123;
     route.paramMap.get = jest.fn().mockReturnValue(id.toString());
-    metadataService.update = jest.fn().mockResolvedValue({ 
+    route.queryParamMap.get = jest.fn().mockReturnValue(null);
+    metadataService.update = jest.fn().mockResolvedValue({
       canOpen: true,
-      indicator_id: 1,
+      indicator_id: 5,
       status_id: 14,
       result_official_code: 3,
       result_contract_id: 456,
       result_title: 'Test Project'
     });
     currentResultService.validateOpenResult = jest.fn().mockReturnValue(true);
+    rolesService.isAdmin = jest.fn().mockReturnValue(true);
     router.url = '/some-other-path';
-    cacheService.dataCache = jest.fn().mockReturnValue({
-      user: {
-        user_role_list: [{ role_id: 9 }] // Admin user
-      }
-    });
 
-    // Act
     const result = await runInInjectionContext(injector, () => resultExistsResolver(route, { url: '', root: {} as any }));
 
-    // Assert
-    expect(metadataService.update).toHaveBeenCalledWith(id, 'STAR');
-    expect(currentResultService.validateOpenResult).toHaveBeenCalledWith(1, 14);
+    expect(currentResultService.validateOpenResult).toHaveBeenCalledWith(5, 14);
+    expect(router.navigate).toHaveBeenCalledWith(['/project-detail', 456]);
+    expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(5, 14, 3, 'project');
+    expect(result).toBe(false);
+  });
+
+  it('should return false and open modal when published OICR has oicrFullEdit but user is not admin', async () => {
+    const id = 123;
+    route.paramMap.get = jest.fn().mockReturnValue(id.toString());
+    route.queryParamMap.get = jest.fn((key: string) => (key === 'oicrFullEdit' ? '1' : null));
+    metadataService.update = jest.fn().mockResolvedValue({
+      canOpen: true,
+      indicator_id: 5,
+      status_id: 14,
+      result_official_code: 3,
+      result_contract_id: 456,
+      result_title: 'Test Project'
+    });
+    currentResultService.validateOpenResult = jest.fn().mockReturnValue(true);
+    rolesService.isAdmin = jest.fn().mockReturnValue(false);
+    router.url = '/some-other-path';
+
+    const result = await runInInjectionContext(injector, () => resultExistsResolver(route, { url: '', root: {} as any }));
+
+    expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(5, 14, 3, 'project');
+    expect(result).toBe(false);
+  });
+
+  it('should return true without modal when published OICR and oicrFullEdit query from modal Editar', async () => {
+    const id = 123;
+    route.paramMap.get = jest.fn().mockReturnValue(id.toString());
+    route.queryParamMap.get = jest.fn((key: string) => (key === 'oicrFullEdit' ? '1' : null));
+    metadataService.update = jest.fn().mockResolvedValue({
+      canOpen: true,
+      indicator_id: 5,
+      status_id: 14,
+      result_official_code: 3,
+      result_contract_id: 456,
+      result_title: 'Test Project'
+    });
+    currentResultService.validateOpenResult = jest.fn().mockReturnValue(true);
+    rolesService.isAdmin = jest.fn().mockReturnValue(true);
+
+    const result = await runInInjectionContext(injector, () => resultExistsResolver(route, { url: '', root: {} as any }));
+
+    expect(currentResultService.openEditRequestdOicrsModal).not.toHaveBeenCalled();
+    expect(result).toBe(true);
+  });
+
+  it('should return false and open modal when published OICR (14) and user is not admin', async () => {
+    const id = 123;
+    route.paramMap.get = jest.fn().mockReturnValue(id.toString());
+    metadataService.update = jest.fn().mockResolvedValue({
+      canOpen: true,
+      indicator_id: 5,
+      status_id: 14,
+      result_official_code: 3,
+      result_contract_id: 456,
+      result_title: 'Test Project'
+    });
+    currentResultService.validateOpenResult = jest.fn().mockReturnValue(true);
+    rolesService.isAdmin = jest.fn().mockReturnValue(false);
+    router.url = '/some-other-path';
+
+    const result = await runInInjectionContext(injector, () => resultExistsResolver(route, { url: '', root: {} as any }));
+
+    expect(currentResultService.validateOpenResult).toHaveBeenCalledWith(5, 14);
     expect(router.navigate).toHaveBeenCalledWith(['/project-detail', 456]);
     expect(cacheService.projectResultsSearchValue.set).toHaveBeenCalledWith('Test Project');
-    expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(1, 14, 3, 'project');
+    expect(currentResultService.openEditRequestdOicrsModal).toHaveBeenCalledWith(5, 14, 3, 'project');
     expect(result).toBe(false);
   });
 

--- a/research-indicators/src/app/pages/platform/pages/result/resolvers/result-exists.resolver.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/resolvers/result-exists.resolver.ts
@@ -105,5 +105,6 @@ async function tryOpenOicrEditorFromResolver(
     );
     return false;
   }
-  return true;
+
+  return undefined;
 }

--- a/research-indicators/src/app/pages/platform/pages/result/resolvers/result-exists.resolver.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/resolvers/result-exists.resolver.ts
@@ -6,6 +6,8 @@ import { CacheService } from '../../../../../shared/services/cache/cache.service
 import { PLATFORM_CODES } from '@shared/constants/platform-codes';
 import { RolesService } from '@shared/services/cache/roles.service';
 import {
+  OICR_FULL_EDIT_QUERY,
+  OICR_FULL_EDIT_VALUE,
   RESULT_ENTRY_SOURCE_QUERY,
   RESULT_ENTRY_SOURCE_VALUE_HOME,
   RESULT_ENTRY_SOURCE_VALUE_RESULTS_CENTER
@@ -70,6 +72,13 @@ async function tryOpenOicrEditorFromResolver(
   }
 
   const isDraft = (status_id ?? 0) === 10 || (status_id ?? 0) === 12 || (status_id ?? 0) === 13;
+  const openingFullFormFromModal =
+    route.queryParamMap.get(OICR_FULL_EDIT_QUERY) === OICR_FULL_EDIT_VALUE && rolesService.isAdmin();
+
+  if (openingFullFormFromModal || (isDraft && rolesService.isAdmin())) {
+    return true;
+  }
+
   if (!isDraft || (isDraft && !rolesService.isAdmin())) {
     const from = route.queryParamMap.get(RESULT_ENTRY_SOURCE_QUERY);
     const fromResultsCenter = from === RESULT_ENTRY_SOURCE_VALUE_RESULTS_CENTER;

--- a/research-indicators/src/app/pages/platform/pages/result/resolvers/result-exists.resolver.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/resolvers/result-exists.resolver.ts
@@ -72,39 +72,54 @@ async function tryOpenOicrEditorFromResolver(
   }
 
   const isDraft = (status_id ?? 0) === 10 || (status_id ?? 0) === 12 || (status_id ?? 0) === 13;
-  const openingFullFormFromModal =
-    route.queryParamMap.get(OICR_FULL_EDIT_QUERY) === OICR_FULL_EDIT_VALUE && rolesService.isAdmin();
+  const openingFullFormFromModal = route.queryParamMap.get(OICR_FULL_EDIT_QUERY) === OICR_FULL_EDIT_VALUE && rolesService.isAdmin();
 
   if (openingFullFormFromModal || (isDraft && rolesService.isAdmin())) {
     return true;
   }
 
   if (!isDraft || (isDraft && !rolesService.isAdmin())) {
-    const from = route.queryParamMap.get(RESULT_ENTRY_SOURCE_QUERY);
-    const fromResultsCenter = from === RESULT_ENTRY_SOURCE_VALUE_RESULTS_CENTER;
-    const fromHome = from === RESULT_ENTRY_SOURCE_VALUE_HOME;
-    if (fromResultsCenter) {
-      await router.navigate(['/results-center']);
-    } else if (fromHome) {
-      await router.navigate(['/home']);
-    } else {
-      await router.navigate(['/project-detail', result_contract_id]);
-      if (!router.url.includes('/project-detail/')) cacheService.projectResultsSearchValue.set(result_title ?? '');
-    }
-    let creationContext: 'results-center' | 'project' | undefined;
-    if (fromResultsCenter) {
-      creationContext = 'results-center';
-    } else if (!fromHome) {
-      creationContext = 'project';
-    }
-    await currentResultService.openEditRequestdOicrsModal(
-      indicator_id ?? 0,
-      status_id ?? 0,
-      result_official_code ?? 0,
-      creationContext
-    );
-    return false;
+    return redirectAndOpenOicrEditModal(route, router, cacheService, currentResultService, meta);
   }
 
   return undefined;
+}
+
+export async function redirectAndOpenOicrEditModal(
+  route: ActivatedRouteSnapshot,
+  router: Router,
+  cacheService: CacheService,
+  currentResultService: CurrentResultService,
+  meta: OicrResolverMetadata
+): Promise<false> {
+  const { indicator_id, status_id, result_official_code, result_contract_id, result_title } = meta;
+  const from = route.queryParamMap.get(RESULT_ENTRY_SOURCE_QUERY);
+  const fromResultsCenter = from === RESULT_ENTRY_SOURCE_VALUE_RESULTS_CENTER;
+  const fromHome = from === RESULT_ENTRY_SOURCE_VALUE_HOME;
+
+  if (fromResultsCenter) {
+    await router.navigate(['/results-center']);
+  } else if (fromHome) {
+    await router.navigate(['/home']);
+  } else {
+    await router.navigate(['/project-detail', result_contract_id]);
+    if (!router.url.includes('/project-detail/')) {
+      cacheService.projectResultsSearchValue.set(result_title ?? '');
+    }
+  }
+
+  let creationContext: 'results-center' | 'project' | undefined;
+  if (fromResultsCenter) {
+    creationContext = 'results-center';
+  } else if (!fromHome) {
+    creationContext = 'project';
+  }
+
+  await currentResultService.openEditRequestdOicrsModal(
+    indicator_id ?? 0,
+    status_id ?? 0,
+    result_official_code ?? 0,
+    creationContext
+  );
+  return false;
 }

--- a/research-indicators/src/app/pages/platform/pages/result/resolvers/result-exists.resolver.ts
+++ b/research-indicators/src/app/pages/platform/pages/result/resolvers/result-exists.resolver.ts
@@ -65,7 +65,7 @@ async function tryOpenOicrEditorFromResolver(
   rolesService: RolesService,
   meta: OicrResolverMetadata
 ): Promise<boolean | undefined> {
-  const { indicator_id, status_id, result_official_code, result_contract_id, result_title } = meta;
+  const { indicator_id, status_id } = meta;
 
   if (!currentResultService.validateOpenResult(indicator_id ?? 0, status_id ?? 0)) {
     return undefined;
@@ -115,11 +115,6 @@ export async function redirectAndOpenOicrEditModal(
     creationContext = 'project';
   }
 
-  await currentResultService.openEditRequestdOicrsModal(
-    indicator_id ?? 0,
-    status_id ?? 0,
-    result_official_code ?? 0,
-    creationContext
-  );
+  await currentResultService.openEditRequestdOicrsModal(indicator_id ?? 0, status_id ?? 0, result_official_code ?? 0, creationContext);
   return false;
 }

--- a/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.html
+++ b/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.html
@@ -6,7 +6,7 @@
         [badge]="resultsCenterService.countTableFiltersSelected()"
         [showOverlayDot]="!!resultsCenterService.countTableFiltersSelected()" [showClear]="true"
         [searchValue]="this.resultsCenterService.searchInput()"
-        [searchPlaceholder]="'Find a result by code, title or creator'" (searchChange)="setSearchInputFilter($event)"
+        [searchPlaceholder]="'Find a result by code, title, creator or public link'" (searchChange)="setSearchInputFilter($event)"
         (apply)="showFiltersSidebar()" (clear)="this.resultsCenterService.clearAllFilters()">
       </app-search-export-controls>
 
@@ -135,6 +135,19 @@
               </div>
               }
             </div>
+          </td>
+          } @else if (column.field === 'public_link') {
+          <td class="{{ column.minWidth }} {{ column.maxWidth }} align-center" (click)="$event.stopPropagation()">
+            @if (result.public_link) {
+            <button type="button" (click)="openPublicLink(result.public_link); $event.stopPropagation()"
+              [pTooltip]="result.public_link" tooltipPosition="top"
+              [attr.aria-label]="'Open public link for ' + result.result_official_code"
+              class="cursor-pointer border-0 bg-transparent p-0 text-[#035BA9] hover:text-[#1689CA]">
+              <i class="pi pi-external-link !text-[16px]"></i>
+            </button>
+            } @else {
+            <span class="text-gray-500">None</span>
+            }
           </td>
           } @else if (column.field === 'project') {
           <td class="project-cell">

--- a/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.html
+++ b/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.html
@@ -78,7 +78,7 @@
         </tr>
       </ng-template>
       <ng-template pTemplate="body" let-result>
-        <tr (keydown.enter)="openResult(result)" (click)="openResult(result)"
+        <tr (keydown.enter)="openResult(result)" (click)="onTableRowClick($event, result)"
           [attr.data-result-id]="result.result_official_code" [attr.data-platform]="result.platform_code"
           class="cursor-pointer hover:surface-ground transition-colors duration-150 text-[14px] xl:text-[16px]">
           @for (column of getVisibleColumns(); track column.field) {
@@ -139,7 +139,7 @@
           } @else if (column.field === 'public_link') {
           <td class="{{ column.minWidth }} {{ column.maxWidth }} align-center" (click)="$event.stopPropagation()">
             @if (result.public_link) {
-            <button type="button" (click)="openPublicLink(result.public_link); $event.stopPropagation()"
+            <button type="button" data-public-link-action (click)="openPublicLink(result.public_link); $event.stopPropagation()"
               [pTooltip]="result.public_link" tooltipPosition="left"
               [attr.aria-label]="'Open public link for ' + result.result_official_code"
               class="cursor-pointer border-0 bg-transparent p-0 text-[#035BA9]">

--- a/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.html
+++ b/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.html
@@ -6,8 +6,9 @@
         [badge]="resultsCenterService.countTableFiltersSelected()"
         [showOverlayDot]="!!resultsCenterService.countTableFiltersSelected()" [showClear]="true"
         [searchValue]="this.resultsCenterService.searchInput()"
-        [searchPlaceholder]="'Find a result by code, title, creator or public link'" (searchChange)="setSearchInputFilter($event)"
-        (apply)="showFiltersSidebar()" (clear)="this.resultsCenterService.clearAllFilters()">
+        [searchPlaceholder]="'Find a result by code, title, creator or public link'"
+        (searchChange)="setSearchInputFilter($event)" (apply)="showFiltersSidebar()"
+        (clear)="this.resultsCenterService.clearAllFilters()">
       </app-search-export-controls>
 
       <div class="flex items-center gap-5">
@@ -21,9 +22,8 @@
         }
 
         <app-filters-action-buttons [showExportButton]="true" [exportLabel]="'Export metadata results'"
-          [isExportLoading]="isExporting()"
-          [showViewToggleButtons]="false" [showConfigButton]="true" (config)="showConfiguratiosnSidebar()"
-          (export)="exportTable()">
+          [isExportLoading]="isExporting()" [showViewToggleButtons]="false" [showConfigButton]="true"
+          (config)="showConfiguratiosnSidebar()" (export)="exportTable()">
         </app-filters-action-buttons>
       </div>
     </div>
@@ -140,13 +140,13 @@
           <td class="{{ column.minWidth }} {{ column.maxWidth }} align-center" (click)="$event.stopPropagation()">
             @if (result.public_link) {
             <button type="button" (click)="openPublicLink(result.public_link); $event.stopPropagation()"
-              [pTooltip]="result.public_link" tooltipPosition="top"
+              [pTooltip]="result.public_link" tooltipPosition="left"
               [attr.aria-label]="'Open public link for ' + result.result_official_code"
-              class="cursor-pointer border-0 bg-transparent p-0 text-[#035BA9] hover:text-[#1689CA]">
+              class="cursor-pointer border-0 bg-transparent p-0 text-[#035BA9]">
               <i class="pi pi-external-link !text-[16px]"></i>
             </button>
             } @else {
-            <span class="text-gray-500">None</span>
+            <span>None</span>
             }
           </td>
           } @else if (column.field === 'project') {

--- a/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.html
+++ b/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.html
@@ -137,7 +137,8 @@
             </div>
           </td>
           } @else if (column.field === 'public_link') {
-          <td class="{{ column.minWidth }} {{ column.maxWidth }} align-center" (click)="$event.stopPropagation()">
+          <td class="{{ column.minWidth }} {{ column.maxWidth }} align-center" (click)="$event.stopPropagation()"
+            (keydown.enter)="$event.stopPropagation()">
             @if (result.public_link) {
             <button type="button" data-public-link-action (click)="openPublicLink(result.public_link); $event.stopPropagation()"
               [pTooltip]="result.public_link" tooltipPosition="left"

--- a/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.spec.ts
@@ -477,6 +477,43 @@ describe('ResultsCenterTableComponent', () => {
     expect(processSpy).not.toHaveBeenCalled();
   });
 
+  it('processRowClick should return early when clicking public link action', () => {
+    mockModals.isAnyModalOpen.mockReturnValue(false);
+    const tableElement = document.createElement('div');
+    const tbody = document.createElement('tbody');
+    const row = document.createElement('tr');
+    const td = document.createElement('td');
+    const button = document.createElement('button');
+    button.setAttribute('data-public-link-action', '');
+    td.appendChild(button);
+    tbody.appendChild(row);
+    row.appendChild(td);
+    tableElement.appendChild(tbody);
+    (component as any).dt2 = {
+      first: 0,
+      value: [mockResult],
+      el: { nativeElement: tableElement }
+    } as any;
+    const handleSpy = jest.spyOn(component as any, 'handleRowClickResult');
+    (component as any).processRowClick(button, new MouseEvent('click'));
+    expect(handleSpy).not.toHaveBeenCalled();
+  });
+
+  it('onTableRowClick should not open result when clicking public link action', () => {
+    const openSpy = jest.spyOn(component, 'openResult');
+    const button = document.createElement('button');
+    button.setAttribute('data-public-link-action', '');
+    component.onTableRowClick({ target: button } as MouseEvent, mockResult);
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it('onTableRowClick should open result for normal row clicks', () => {
+    const openSpy = jest.spyOn(component, 'openResult');
+    const td = document.createElement('td');
+    component.onTableRowClick({ target: td } as MouseEvent, mockResult);
+    expect(openSpy).toHaveBeenCalledWith(mockResult);
+  });
+
   it('processRowClick should open PRMS modal and prevent default', () => {
     mockModals.isAnyModalOpen.mockReturnValue(false);
     const tableElement = document.createElement('div');

--- a/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.ts
+++ b/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.ts
@@ -219,6 +219,14 @@ export class ResultsCenterTableComponent implements AfterViewInit, OnDestroy {
     return severityMap[status];
   }
 
+  onTableRowClick(event: MouseEvent, result: Result): void {
+    const target = event.target as Element | null;
+    if (target?.closest('[data-public-link-action]')) {
+      return;
+    }
+    this.openResult(result);
+  }
+
   openResult(result: Result) {
     if (
       result.platform_code === PLATFORM_CODES.PRMS ||
@@ -353,6 +361,10 @@ export class ResultsCenterTableComponent implements AfterViewInit, OnDestroy {
     }
 
     if (target.closest('thead') || target.closest('th') || target.tagName.toLowerCase() === 'th') {
+      return;
+    }
+
+    if (target.closest('[data-public-link-action]')) {
       return;
     }
 

--- a/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.ts
+++ b/research-indicators/src/app/pages/platform/pages/results-center/components/results-center-table/results-center-table.component.ts
@@ -21,6 +21,8 @@ import { PLATFORM_COLOR_MAP } from '../../../../../../shared/constants/platform-
 import { PLATFORM_CODES } from '../../../../../../shared/constants/platform-codes';
 import { AllModalsService } from '@shared/services/cache/all-modals.service';
 import { CreateResultManagementService } from '@shared/components/all-modals/modals-content/create-result-modal/services/create-result-management.service';
+import { TooltipModule } from 'primeng/tooltip';
+import { openPublicLink } from '@shared/utils/public-link.util';
 @Component({
   selector: 'app-results-center-table',
   imports: [
@@ -32,6 +34,7 @@ import { CreateResultManagementService } from '@shared/components/all-modals/mod
     TagModule,
     MenuModule,
     RouterLink,
+    TooltipModule,
     CustomTagComponent,
     FiltersActionButtonsComponent,
     SearchExportControlsComponent,
@@ -43,6 +46,7 @@ import { CreateResultManagementService } from '@shared/components/all-modals/mod
 export class ResultsCenterTableComponent implements AfterViewInit, OnDestroy {
   readonly statusTagMaxWidth = '140px';
   readonly isExporting = signal(false);
+  readonly openPublicLink = openPublicLink;
 
   resultsCenterService = inject(ResultsCenterService);
   private readonly router = inject(Router);

--- a/research-indicators/src/app/pages/platform/pages/results-center/results-center.service.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/results-center/results-center.service.spec.ts
@@ -177,7 +177,7 @@ describe('ResultsCenterService', () => {
 
       const publicLinkColumn = columns.find(col => col.field === 'public_link');
       expect(publicLinkColumn).toBeDefined();
-      expect(publicLinkColumn?.header).toBe('Public link');
+      expect(publicLinkColumn?.header).toBe('Link');
       expect(publicLinkColumn?.filter).toBe(true);
       expect(publicLinkColumn?.hideFilterIf?.()).toBe(true);
       expect(columns[columns.length - 1].field).toBe('public_link');

--- a/research-indicators/src/app/pages/platform/pages/results-center/results-center.service.spec.ts
+++ b/research-indicators/src/app/pages/platform/pages/results-center/results-center.service.spec.ts
@@ -174,6 +174,14 @@ describe('ResultsCenterService', () => {
       expect(codeColumn).toBeDefined();
       expect(codeColumn?.header).toBe('Code');
       expect(codeColumn?.filter).toBe(true);
+
+      const publicLinkColumn = columns.find(col => col.field === 'public_link');
+      expect(publicLinkColumn).toBeDefined();
+      expect(publicLinkColumn?.header).toBe('Public link');
+      expect(publicLinkColumn?.filter).toBe(true);
+      expect(publicLinkColumn?.hideFilterIf?.()).toBe(true);
+      expect(columns[columns.length - 1].field).toBe('public_link');
+      expect(publicLinkColumn?.getValue?.({ public_link: undefined } as Result)).toBe('None');
     });
 
     it('should get result_platform value correctly', () => {

--- a/research-indicators/src/app/pages/platform/pages/results-center/results-center.service.ts
+++ b/research-indicators/src/app/pages/platform/pages/results-center/results-center.service.ts
@@ -161,6 +161,16 @@ export class ResultsCenterService {
       maxWidth: 'max-w-[110px]',
 
       getValue: (result: Result) => (result.created_at ? new Date(result.created_at).toLocaleDateString() : '-')
+    },
+    {
+      field: 'public_link',
+      path: 'public_link',
+      header: 'Link',
+      minWidth: 'min-w-[90px]',
+      maxWidth: 'max-w-[100px]',
+      filter: true,
+      hideFilterIf: () => true,
+      getValue: (result: Result) => result.public_link ?? 'None'
     }
   ]);
 

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.html
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.html
@@ -18,7 +18,7 @@
   <button type="button" (click)="openFullOicrEdit()"
     class="flex cursor-pointer items-center gap-2 border-2 font-medium border-[#035BA9] bg-[#035BA9] text-white px-4 py-2 rounded-[13px] text-[15px]">
     <i class="pi pi-pencil !text-[12px]"></i>
-    Editar
+    Edit
   </button>
   }
 </ng-template>

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.html
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.html
@@ -13,6 +13,16 @@
   </button>
 </ng-template>
 
+<ng-template #editPublishedOicr>
+  @if (showEditPublishedOicrButton()) {
+  <button type="button" (click)="openFullOicrEdit()"
+    class="flex cursor-pointer items-center gap-2 border-2 font-medium border-[#035BA9] bg-[#035BA9] text-white px-4 py-2 rounded-[13px] text-[15px]">
+    <i class="pi pi-pencil !text-[12px]"></i>
+    Editar
+  </button>
+  }
+</ng-template>
+
 <ng-template #createButton>
   @if (this.createResultManagementService.statusId() !== 10 && this.createResultManagementService.statusId() !== 15 &&
   this.createResultManagementService.statusId() !== 11 && this.createResultManagementService.statusId() !== 12 &&
@@ -189,7 +199,10 @@
       </div>
 
       <div class="w-full flex justify-between">
-        <ng-container *ngTemplateOutlet="next"></ng-container>
+        <div class="flex gap-3">
+          <ng-container *ngTemplateOutlet="next"></ng-container>
+        </div>
+        <ng-container *ngTemplateOutlet="editPublishedOicr"></ng-container>
         <ng-container *ngTemplateOutlet="createButton"></ng-container>
       </div>
     </div>
@@ -276,6 +289,7 @@
           <ng-container *ngTemplateOutlet="previous"></ng-container>
           <ng-container *ngTemplateOutlet="next"></ng-container>
         </div>
+        <ng-container *ngTemplateOutlet="editPublishedOicr"></ng-container>
         <ng-container *ngTemplateOutlet="createButton"></ng-container>
       </div>
     </div>
@@ -394,6 +408,7 @@
           <ng-container *ngTemplateOutlet="previous"></ng-container>
           <ng-container *ngTemplateOutlet="next"></ng-container>
         </div>
+        <ng-container *ngTemplateOutlet="editPublishedOicr"></ng-container>
         <ng-container *ngTemplateOutlet="createButton"></ng-container>
       </div>
     </div>
@@ -414,7 +429,10 @@
       </div>
 
       <div class="w-full flex justify-between">
-        <ng-container *ngTemplateOutlet="previous"></ng-container>
+        <div class="flex gap-3">
+          <ng-container *ngTemplateOutlet="previous"></ng-container>
+        </div>
+        <ng-container *ngTemplateOutlet="editPublishedOicr"></ng-container>
         <ng-container *ngTemplateOutlet="createButton"></ng-container>
       </div>
     </div>

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.html
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.html
@@ -18,7 +18,7 @@
   <button type="button" (click)="openFullOicrEdit()"
     class="flex cursor-pointer items-center gap-2 border-2 font-medium border-[#035BA9] bg-[#035BA9] text-white px-4 py-2 rounded-[13px] text-[15px]">
     <i class="pi pi-pencil !text-[12px]"></i>
-    Edit
+    View all OICR metadata
   </button>
   }
 </ng-template>

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.html
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.html
@@ -18,7 +18,7 @@
   <button type="button" (click)="openFullOicrEdit()"
     class="flex cursor-pointer items-center gap-2 border-2 font-medium border-[#035BA9] bg-[#035BA9] text-white px-4 py-2 rounded-[13px] text-[15px]">
     <i class="pi pi-pencil !text-[12px]"></i>
-    View all OICR metadata
+    Edit all OICR metadata
   </button>
   }
 </ng-template>

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.html
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.html
@@ -198,12 +198,14 @@
         </app-oicr-form-fields>
       </div>
 
-      <div class="w-full flex justify-between">
+      <div class="w-full flex justify-between items-center">
         <div class="flex gap-3">
           <ng-container *ngTemplateOutlet="next"></ng-container>
         </div>
-        <ng-container *ngTemplateOutlet="editPublishedOicr"></ng-container>
-        <ng-container *ngTemplateOutlet="createButton"></ng-container>
+        <div class="flex gap-3 items-center">
+          <ng-container *ngTemplateOutlet="editPublishedOicr"></ng-container>
+          <ng-container *ngTemplateOutlet="createButton"></ng-container>
+        </div>
       </div>
     </div>
     }
@@ -284,13 +286,15 @@
         </div>
       </div>
 
-      <div class="w-full flex justify-between pt-4">
+      <div class="w-full flex justify-between items-center pt-4">
         <div class="flex gap-3">
           <ng-container *ngTemplateOutlet="previous"></ng-container>
           <ng-container *ngTemplateOutlet="next"></ng-container>
         </div>
-        <ng-container *ngTemplateOutlet="editPublishedOicr"></ng-container>
-        <ng-container *ngTemplateOutlet="createButton"></ng-container>
+        <div class="flex gap-3 items-center">
+          <ng-container *ngTemplateOutlet="editPublishedOicr"></ng-container>
+          <ng-container *ngTemplateOutlet="createButton"></ng-container>
+        </div>
       </div>
     </div>
     }
@@ -403,13 +407,15 @@
         </div>
       </div>
 
-      <div class="w-full flex justify-between">
+      <div class="w-full flex justify-between items-center">
         <div class="flex gap-3">
           <ng-container *ngTemplateOutlet="previous"></ng-container>
           <ng-container *ngTemplateOutlet="next"></ng-container>
         </div>
-        <ng-container *ngTemplateOutlet="editPublishedOicr"></ng-container>
-        <ng-container *ngTemplateOutlet="createButton"></ng-container>
+        <div class="flex gap-3 items-center">
+          <ng-container *ngTemplateOutlet="editPublishedOicr"></ng-container>
+          <ng-container *ngTemplateOutlet="createButton"></ng-container>
+        </div>
       </div>
     </div>
     }
@@ -428,12 +434,14 @@
         </div>
       </div>
 
-      <div class="w-full flex justify-between">
+      <div class="w-full flex justify-between items-center">
         <div class="flex gap-3">
           <ng-container *ngTemplateOutlet="previous"></ng-container>
         </div>
-        <ng-container *ngTemplateOutlet="editPublishedOicr"></ng-container>
-        <ng-container *ngTemplateOutlet="createButton"></ng-container>
+        <div class="flex gap-3 items-center">
+          <ng-container *ngTemplateOutlet="editPublishedOicr"></ng-container>
+          <ng-container *ngTemplateOutlet="createButton"></ng-container>
+        </div>
       </div>
     </div>
     }

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.html
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.html
@@ -75,7 +75,8 @@
       status_id: getStatusIdAsString(),
       status_config: cache.currentMetadata().result_status
     }" [showTag]="this.createResultManagementService.editingOicr()"
-    [showDownload]="this.createResultManagementService.editingOicr()"></app-oicr-header>
+    [showDownload]="this.createResultManagementService.editingOicr()"
+    [cgspaceLink]="createResultManagementService.createOicrBody().cgspace_link ?? null"></app-oicr-header>
   }
 
   <div class="px-5 flex flex-col mx-10 mt-8">

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.spec.ts
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.spec.ts
@@ -30,6 +30,7 @@ describe('CreateOicrFormComponent', () => {
   let mockActionsService: any;
   let mockRouter: any;
   let mockElementRef: any;
+  let mockRolesService: { isAdmin: jest.Mock };
 
   beforeEach(async () => {
     mockCreateResultManagementService = {
@@ -147,7 +148,7 @@ describe('CreateOicrFormComponent', () => {
       list: signal([])
     };
 
-    const mockRolesService = {
+    mockRolesService = {
       isAdmin: jest.fn().mockReturnValue(false)
     };
 
@@ -2802,6 +2803,61 @@ describe('CreateOicrFormComponent', () => {
       // Should not throw error
       expect(component.elementRef.nativeElement.querySelector).toHaveBeenCalledWith('#test-section');
       expect(component.elementRef.nativeElement.querySelector).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('published OICR full edit', () => {
+    it('showEditPublishedOicrButton is true for admin editing published OICR', () => {
+      mockCreateResultManagementService.editingOicr.set(true);
+      mockCreateResultManagementService.statusId.set(14);
+      mockRolesService.isAdmin.mockReturnValue(true);
+      expect(component.showEditPublishedOicrButton()).toBe(true);
+    });
+
+    it('showEditPublishedOicrButton is false for non-admin', () => {
+      mockCreateResultManagementService.editingOicr.set(true);
+      mockCreateResultManagementService.statusId.set(14);
+      mockRolesService.isAdmin.mockReturnValue(false);
+      expect(component.showEditPublishedOicrButton()).toBe(false);
+    });
+
+    it('showEditPublishedOicrButton is false when status is not published', () => {
+      mockCreateResultManagementService.editingOicr.set(true);
+      mockCreateResultManagementService.statusId.set(10);
+      mockRolesService.isAdmin.mockReturnValue(true);
+      expect(component.showEditPublishedOicrButton()).toBe(false);
+    });
+
+    it('openFullOicrEdit does nothing without result code', async () => {
+      mockCreateResultManagementService.currentRequestedResultCode.set(null);
+      await component.openFullOicrEdit();
+      expect(mockRouter.navigate).not.toHaveBeenCalled();
+    });
+
+    it('openFullOicrEdit closes modal and navigates to STAR oicr-details', async () => {
+      mockRouter.navigate = jest.fn().mockResolvedValue(true);
+      mockCreateResultManagementService.currentRequestedResultCode.set(11809);
+      mockCreateResultManagementService.resultCreationEntryContext.set('results-center');
+
+      await component.openFullOicrEdit();
+
+      expect(mockCreateResultManagementService.editingOicr()).toBe(false);
+      expect(mockAllModalsService.closeModal).toHaveBeenCalledWith('createResult');
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['/result', 'STAR-11809', 'oicr-details'], {
+        queryParams: { oicrFullEdit: '1', from: 'results-center' }
+      });
+    });
+
+    it('openFullOicrEdit navigates with oicrFullEdit for project context', async () => {
+      mockRouter.navigate = jest.fn().mockResolvedValue(true);
+      mockCreateResultManagementService.currentRequestedResultCode.set(42);
+      mockCreateResultManagementService.resultCreationEntryContext.set('project');
+
+      await component.openFullOicrEdit();
+
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['/result', 'STAR-42', 'oicr-details'], {
+        queryParams: { oicrFullEdit: '1' }
+      });
     });
   });
 });

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.ts
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/create-result-modal/components/create-oicr-form/create-oicr-form.component.ts
@@ -54,7 +54,14 @@ import { RolesService } from '@shared/services/cache/roles.service';
 import { ProjectResultsTableService } from '@shared/components/project-results-table/project-results-table.service';
 import { OicrHeaderComponent } from '@shared/components/oicr-header/oicr-header.component';
 import { CurrentResultService } from '@shared/services/cache/current-result.service';
-import { isResultsCenterEntryFromUrl } from '@shared/constants/result-entry-source';
+import {
+  isResultsCenterEntryFromUrl,
+  OICR_FULL_EDIT_QUERY,
+  OICR_FULL_EDIT_VALUE,
+  RESULT_ENTRY_SOURCE_QUERY,
+  RESULT_ENTRY_SOURCE_VALUE_RESULTS_CENTER
+} from '@shared/constants/result-entry-source';
+import { PLATFORM_CODES } from '@shared/constants/platform-codes';
 import { FindContracts } from '@shared/interfaces/find-contracts.interface';
 import { AccordionModule } from 'primeng/accordion';
 import { SubmissionService } from '@shared/services/submission.service';
@@ -170,6 +177,15 @@ export class CreateOicrFormComponent implements OnInit {
       Number(this.createResultManagementService.createOicrBody().step_three.geo_scope_id),
       this.createResultManagementService.createOicrBody().step_three.countries
     )
+  );
+
+  private readonly publishedStatusId = 14;
+
+  showEditPublishedOicrButton = computed(
+    () =>
+      this.createResultManagementService.editingOicr() &&
+      this.createResultManagementService.statusId() === this.publishedStatusId &&
+      this.rolesService.isAdmin()
   );
 
   currentContract = computed(() => {
@@ -526,6 +542,27 @@ export class CreateOicrFormComponent implements OnInit {
     this.createResultManagementService.setModalTitle('Create A Result');
     this.createResultManagementService.resultPageStep.set(0);
     this.createResultManagementService.setStatusId(null);
+  }
+
+  async openFullOicrEdit(): Promise<void> {
+    const resultCode = this.createResultManagementService.currentRequestedResultCode();
+    if (!resultCode) {
+      return;
+    }
+
+    const queryParams: Record<string, string> = {
+      [OICR_FULL_EDIT_QUERY]: OICR_FULL_EDIT_VALUE
+    };
+    if (this.createResultManagementService.resultCreationEntryContext() === 'results-center') {
+      queryParams[RESULT_ENTRY_SOURCE_QUERY] = RESULT_ENTRY_SOURCE_VALUE_RESULTS_CENTER;
+    }
+
+    this.createResultManagementService.editingOicr.set(false);
+    this.allModalsService.closeModal('createResult');
+
+    await this.router.navigate(['/result', `${PLATFORM_CODES.STAR}-${resultCode}`, 'oicr-details'], {
+      queryParams
+    });
   }
 
   isGeoScopeId(value: number | string): boolean {

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/select-linked-results-modal/select-linked-results-modal.component.html
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/select-linked-results-modal/select-linked-results-modal.component.html
@@ -128,7 +128,7 @@
             </div>
           </td>
           } @else if (column.field === 'public_link') {
-          <td (click)="$event.stopPropagation()">
+          <td (click)="$event.stopPropagation()" (keydown.enter)="$event.stopPropagation()">
             @if (result.public_link) {
             <button type="button" data-public-link-action (click)="openPublicLink(result.public_link); $event.stopPropagation()"
               [pTooltip]="result.public_link" tooltipPosition="left"

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/select-linked-results-modal/select-linked-results-modal.component.html
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/select-linked-results-modal/select-linked-results-modal.component.html
@@ -9,7 +9,8 @@
     <app-search-export-controls [applyLabel]="'Apply Filters'"
       [badge]="resultsCenterService.countTableFiltersSelected()"
       [showOverlayDot]="!!resultsCenterService.countTableFiltersSelected()" [showClear]="true"
-      [searchValue]="resultsCenterService.searchInput()" [searchPlaceholder]="'Find a result by code, title, creator or public link'"
+      [searchValue]="resultsCenterService.searchInput()"
+      [searchPlaceholder]="'Find a result by code, title, creator or public link'"
       (searchChange)="setSearchInputFilter($event)" (apply)="showFiltersSidebar()" (clear)="clearFilters()">
     </app-search-export-controls>
 
@@ -18,184 +19,186 @@
   </div>
 
   @if (resultsCenterService.loading()) {
-    <app-custom-progress-bar></app-custom-progress-bar>
+  <app-custom-progress-bar></app-custom-progress-bar>
   }
 
   <div class="w-full border border-[#E4EAEE] rounded-[18px] border-t-0 overflow-visible">
-  <p-table #dt2 [value]="resultsCenterService.list()" [paginator]="true" [lazy]="true"
-    [first]="resultsCenterService.resultsTablePaginatorFirst()" [rows]="resultsCenterService.resultsTablePaginatorRows()"
-    [totalRecords]="resultsCenterService.resultsTableTotalRecords()"
-    (onLazyLoad)="handleLinkedTableLazyLoad($event)"
-    [paginatorDropdownAppendTo]="'body'"
-    class="border-0 rounded-[18px]"
-    [scrollHeight]="getScrollHeight()" [showCurrentPageReport]="true" [scrollable]="true"
-    [tableStyle]="{ 'min-width': '100%' }" [rowsPerPageOptions]="[5, 10, 25, 50]"
-    currentPageReportTemplate="Showing {first} to {last} of {totalRecords} results"
-    [sortField]="resultsCenterService.resultsTableSortField()" [sortOrder]="resultsCenterService.resultsTableSortOrder()"
-    [customSort]="true"
-    styleClass="p-datatable-gridlines table-custom-styles p-datatable-hoverable-rows">
-    <ng-template pTemplate="header">
-      <tr>
-        <th class="!text-[#173F6F] min-w-[60px]" scope="col">
-          <div class="flex items-center font-[500] leading-4.5 gap-2 text-[14px] xl:text-[16px]">
-            Select
-          </div>
-        </th>
-        @for (column of resultsCenterService.tableColumns(); track column.field) {
-        @if (column.field !== 'versions' && (!column.hideIf || !column.hideIf())) {
-        <th class="{{ column.minWidth }} {{ column.maxWidth }} !text-[#173F6F]"
-          [pSortableColumn]="column?.hideFilterIf?.() ? '' : column.path" scope="col">
-          <div class="flex items-center font-[500] leading-4.5 gap-2 text-[14px] ">
-            {{
-            column.field === 'project'
-            ? 'Project'
-            : column.field === 'lever'
-            ? 'Lever'
-            : column.field === 'year'
-            ? 'Year'
-            : column.header
-            }}
-            @if (!column?.hideFilterIf?.()) {
-            <p-sortIcon field="{{ column.path }}"></p-sortIcon>
+    <p-table #dt2 [value]="resultsCenterService.list()" [paginator]="true" [lazy]="true"
+      [first]="resultsCenterService.resultsTablePaginatorFirst()"
+      [rows]="resultsCenterService.resultsTablePaginatorRows()"
+      [totalRecords]="resultsCenterService.resultsTableTotalRecords()" (onLazyLoad)="handleLinkedTableLazyLoad($event)"
+      [paginatorDropdownAppendTo]="'body'" class="border-0 rounded-[18px]" [scrollHeight]="getScrollHeight()"
+      [showCurrentPageReport]="true" [scrollable]="true" [tableStyle]="{ 'min-width': '100%' }"
+      [rowsPerPageOptions]="[5, 10, 25, 50]"
+      currentPageReportTemplate="Showing {first} to {last} of {totalRecords} results"
+      [sortField]="resultsCenterService.resultsTableSortField()"
+      [sortOrder]="resultsCenterService.resultsTableSortOrder()" [customSort]="true"
+      styleClass="p-datatable-gridlines table-custom-styles p-datatable-hoverable-rows">
+      <ng-template pTemplate="header">
+        <tr>
+          <th class="!text-[#173F6F] min-w-[60px]" scope="col">
+            <div class="flex items-center font-[500] leading-4.5 gap-2 text-[14px] xl:text-[16px]">
+              Select
+            </div>
+          </th>
+          @for (column of resultsCenterService.tableColumns(); track column.field) {
+          @if (column.field !== 'versions' && (!column.hideIf || !column.hideIf())) {
+          <th class="{{ column.minWidth }} {{ column.maxWidth }} !text-[#173F6F]"
+            [pSortableColumn]="column?.hideFilterIf?.() ? '' : column.path" scope="col">
+            <div class="flex items-center font-[500] leading-4.5 gap-2 text-[14px] ">
+              {{
+              column.field === 'project'
+              ? 'Project'
+              : column.field === 'lever'
+              ? 'Lever'
+              : column.field === 'year'
+              ? 'Year'
+              : column.header
+              }}
+              @if (!column?.hideFilterIf?.()) {
+              <p-sortIcon field="{{ column.path }}"></p-sortIcon>
+              }
+            </div>
+          </th>
+          }
+          }
+        </tr>
+      </ng-template>
+      <ng-template pTemplate="body" let-result>
+        <tr class="hover:surface-ground transition-colors duration-150 text-[14px] xl:text-[16px]">
+          <td>
+            <div class="flex justify-center">
+              <p-checkbox [binary]="true" [ngModel]="isSelected(result)" (ngModelChange)="toggleSelection(result)"
+                (click)="$event.stopPropagation()" (keydown.enter)="toggleSelection(result); $event.stopPropagation()">
+              </p-checkbox>
+            </div>
+          </td>
+          @for (column of resultsCenterService.tableColumns(); track column.field) {
+          @if (column.field !== 'versions' && (!column.hideIf || !column.hideIf())) {
+          @if (column.field === 'status') {
+          <td>
+            @if (isNonStarPlatform(result)) {
+            <button type="button" (click)="openResultInfoModal(result); $event.stopPropagation()"
+              class="block cursor-pointer border-none bg-transparent p-0 text-inherit">
+              <app-custom-tag [statusId]="result.result_status.result_status_id"
+                [statusColor]="result.result_status?.config?.color?.text ?? ''"
+                [statusBackground]="result.result_status?.config?.color?.background ?? ''"
+                [statusBorder]="result.result_status?.config?.color?.border ?? ''" [tiny]="true"
+                [statusName]="result.result_status?.name" [icon]="true"
+                [iconName]="result.result_status?.config?.icon?.name ?? ''"
+                [iconColor]="result.result_status?.config?.icon?.color ?? ''"
+                [tooltip]="result.result_status?.description ?? ''">
+              </app-custom-tag>
+            </button>
+            } @else {
+            <a [href]="getResultHref(result)" target="_blank" (click)="$event.stopPropagation()" class="block"
+              style="color: inherit; text-decoration: none" rel="noopener noreferrer">
+              <app-custom-tag [statusId]="result.result_status.result_status_id"
+                [statusColor]="result.result_status?.config?.color?.text ?? ''"
+                [statusBackground]="result.result_status?.config?.color?.background ?? ''"
+                [statusBorder]="result.result_status?.config?.color?.border ?? ''" [tiny]="true"
+                [statusName]="result.result_status?.name" [icon]="true"
+                [iconName]="result.result_status?.config?.icon?.name ?? ''"
+                [iconColor]="result.result_status?.config?.icon?.color ?? ''"
+                [tooltip]="result.result_status?.description ?? ''">
+              </app-custom-tag>
+            </a>
             }
-          </div>
-        </th>
-        }
-        }
-      </tr>
-    </ng-template>
-    <ng-template pTemplate="body" let-result>
-      <tr class="hover:surface-ground transition-colors duration-150 text-[14px] xl:text-[16px]">
-        <td>
-          <div class="flex justify-center">
-            <p-checkbox [binary]="true" [ngModel]="isSelected(result)" (ngModelChange)="toggleSelection(result)"
-              (click)="$event.stopPropagation()" (keydown.enter)="toggleSelection(result); $event.stopPropagation()">
-            </p-checkbox>
-          </div>
-        </td>
-        @for (column of resultsCenterService.tableColumns(); track column.field) {
-        @if (column.field !== 'versions' && (!column.hideIf || !column.hideIf())) {
-        @if (column.field === 'status') {
-        <td>
-          @if (isNonStarPlatform(result)) {
-          <button type="button" (click)="openResultInfoModal(result); $event.stopPropagation()"
-            class="block cursor-pointer border-none bg-transparent p-0 text-inherit">
-            <app-custom-tag [statusId]="result.result_status.result_status_id"
-              [statusColor]="result.result_status?.config?.color?.text ?? ''"
-              [statusBackground]="result.result_status?.config?.color?.background ?? ''"
-              [statusBorder]="result.result_status?.config?.color?.border ?? ''" [tiny]="true"
-              [statusName]="result.result_status?.name" [icon]="true"
-              [iconName]="result.result_status?.config?.icon?.name ?? ''"
-              [iconColor]="result.result_status?.config?.icon?.color ?? ''"
-              [tooltip]="result.result_status?.description ?? ''">
-            </app-custom-tag>
-          </button>
-          } @else {
-          <a [href]="getResultHref(result)" target="_blank" (click)="$event.stopPropagation()" class="block"
-            style="color: inherit; text-decoration: none" rel="noopener noreferrer">
-            <app-custom-tag [statusId]="result.result_status.result_status_id"
-              [statusColor]="result.result_status?.config?.color?.text ?? ''"
-              [statusBackground]="result.result_status?.config?.color?.background ?? ''"
-              [statusBorder]="result.result_status?.config?.color?.border ?? ''" [tiny]="true"
-              [statusName]="result.result_status?.name" [icon]="true"
-              [iconName]="result.result_status?.config?.icon?.name ?? ''"
-              [iconColor]="result.result_status?.config?.icon?.color ?? ''"
-              [tooltip]="result.result_status?.description ?? ''">
-            </app-custom-tag>
-          </a>
-          }
-        </td>
-        } @else if (column.field === 'result_official_code') {
-        <td>
-          <div class="flex flex-col gap-0.5 items-center text-[13px] {{result.platform_code !== 'STAR' ? 'pt-1.5' : ''}}">
-            <div class="flex">
-              <span class="py-1 px-2 rounded-l-lg font-[600] min-w-[50px] max-w-[50px] text-center"
-                [style.color]="getPlatformColors(result.platform_code)?.text"
-                [style.background-color]="getPlatformColors(result.platform_code)?.background">
-                {{ result.platform_code }}
-              </span>
-              <span class="text-[#4C5158] bg-[#E8EBED] py-1 px-2 rounded-r-lg min-w-[43px] text-center">
-                {{ formatResultCode(result.result_official_code) }}
-              </span>
-            </div>
-            @if (result.platform_code !== 'STAR') {
-            <div class="flex items-center gap-1 text-[#B9C0C5] justify-center mt-0.5">
-              <i class="pi pi-eye !text-[11px]" aria-hidden="true"></i>
-              <span class="tracking-[0.24em] font-[space_grotesk] text-[10px] pl-1">READ ONLY</span>
-            </div>
-            }
-          </div>
-        </td>
-        } @else if (column.field === 'public_link') {
-        <td (click)="$event.stopPropagation()">
-          @if (result.public_link) {
-          <button type="button" (click)="openPublicLink(result.public_link); $event.stopPropagation()"
-            [pTooltip]="result.public_link" tooltipPosition="top"
-            [attr.aria-label]="'Open public link for ' + result.result_official_code"
-            class="cursor-pointer border-0 bg-transparent p-0 text-[#035BA9] hover:text-[#1689CA]">
-            <i class="pi pi-external-link !text-[16px]"></i>
-          </button>
-          } @else {
-          <span class="text-gray-500">None</span>
-          }
-        </td>
-        } @else if (column.field === 'project') {
-        <td>
-          @if (result.result_contracts?.contract_id) {
-          <a [href]="getProjectHref(result.result_contracts.contract_id)" target="_blank"
-            rel="noopener noreferrer" (click)="$event.stopPropagation()" (keydown.enter)="$event.stopPropagation()"
-            class="cursor-pointer hover:text-blue-800 hover:underline transition-colors duration-200"
-            style="color: inherit; text-decoration: none">
-            {{ result.result_contracts.contract_id }}
-          </a>
-          } @else {
-          <span class="text-gray-500">Not provided</span>
-          }
-        </td>
-        } @else {
-        <td [class]="column.minWidth + ' ' + column.maxWidth" [class.break-words]="column.field === 'title'" lang="es">
-          @if (isNonStarPlatform(result)) {
-          <button type="button" (click)="openResultInfoModal(result); $event.stopPropagation()"
-            class="block w-full h-full cursor-pointer border-none bg-transparent p-0 text-inherit text-left">
-            <div class="overflow-hidden line-clamp-3 xl:line-clamp-2">
-              {{ column.getValue ? column.getValue(result) : '-' }}
-            </div>
-          </button>
-          } @else {
-          <a [href]="getResultHref(result)" target="_blank" (click)="$event.stopPropagation()"
-            class="block w-full h-full" style="color: inherit; text-decoration: none" rel="noopener noreferrer">
-            <div class="overflow-hidden line-clamp-3 xl:line-clamp-2">
-              {{ column.getValue ? column.getValue(result) : '-' }}
-            </div>
-          </a>
-          }
-        </td>
-        }
-        }
-        }
-      </tr>
-    </ng-template>
-    <ng-template pTemplate="emptymessage">
-      @if (!resultsCenterService.loading()) {
-      <tr>
-        <td [attr.colspan]="resultsCenterService.tableColumns().length + 1" class="text-center p-8">
-          <div class="flex flex-col items-center gap-4 bg-surface-ground p-6 rounded-xl">
-            <div class="flex flex-col items-center gap-2">
-              <div class="w-16 h-16 flex items-center justify-center rounded-xl bg-blue-50">
-                <i class="pi pi-inbox text-3xl text-blue-500"></i>
+          </td>
+          } @else if (column.field === 'result_official_code') {
+          <td>
+            <div
+              class="flex flex-col gap-0.5 items-center text-[13px] {{result.platform_code !== 'STAR' ? 'pt-1.5' : ''}}">
+              <div class="flex">
+                <span class="py-1 px-2 rounded-l-lg font-[600] min-w-[50px] max-w-[50px] text-center"
+                  [style.color]="getPlatformColors(result.platform_code)?.text"
+                  [style.background-color]="getPlatformColors(result.platform_code)?.background">
+                  {{ result.platform_code }}
+                </span>
+                <span class="text-[#4C5158] bg-[#E8EBED] py-1 px-2 rounded-r-lg min-w-[43px] text-center">
+                  {{ formatResultCode(result.result_official_code) }}
+                </span>
               </div>
-              <h2 class="text-900 font-semibold m-0">No Results Available</h2>
-              <p class="text-600 text-center m-0 max-w-[30rem] leading-relaxed">
-                There are currently no results in the database. New results will appear here once they are added to the
-                system.
-              </p>
+              @if (result.platform_code !== 'STAR') {
+              <div class="flex items-center gap-1 text-[#B9C0C5] justify-center mt-0.5">
+                <i class="pi pi-eye !text-[11px]" aria-hidden="true"></i>
+                <span class="tracking-[0.24em] font-[space_grotesk] text-[10px] pl-1">READ ONLY</span>
+              </div>
+              }
             </div>
-          </div>
-        </td>
-      </tr>
-      }
-    </ng-template>
-  </p-table>
+          </td>
+          } @else if (column.field === 'public_link') {
+          <td (click)="$event.stopPropagation()">
+            @if (result.public_link) {
+            <button type="button" (click)="openPublicLink(result.public_link); $event.stopPropagation()"
+              [pTooltip]="result.public_link" tooltipPosition="left"
+              [attr.aria-label]="'Open public link for ' + result.result_official_code"
+              class="cursor-pointer border-0 bg-transparent p-0 text-[#035BA9]">
+              <i class="pi pi-external-link !text-[16px]"></i>
+            </button>
+            } @else {
+            <span>None</span>
+            }
+          </td>
+          } @else if (column.field === 'project') {
+          <td>
+            @if (result.result_contracts?.contract_id) {
+            <a [href]="getProjectHref(result.result_contracts.contract_id)" target="_blank" rel="noopener noreferrer"
+              (click)="$event.stopPropagation()" (keydown.enter)="$event.stopPropagation()"
+              class="cursor-pointer hover:text-blue-800 hover:underline transition-colors duration-200"
+              style="color: inherit; text-decoration: none">
+              {{ result.result_contracts.contract_id }}
+            </a>
+            } @else {
+            <span class="text-gray-500">Not provided</span>
+            }
+          </td>
+          } @else {
+          <td [class]="column.minWidth + ' ' + column.maxWidth" [class.break-words]="column.field === 'title'"
+            lang="es">
+            @if (isNonStarPlatform(result)) {
+            <button type="button" (click)="openResultInfoModal(result); $event.stopPropagation()"
+              class="block w-full h-full cursor-pointer border-none bg-transparent p-0 text-inherit text-left">
+              <div class="overflow-hidden line-clamp-3 xl:line-clamp-2">
+                {{ column.getValue ? column.getValue(result) : '-' }}
+              </div>
+            </button>
+            } @else {
+            <a [href]="getResultHref(result)" target="_blank" (click)="$event.stopPropagation()"
+              class="block w-full h-full" style="color: inherit; text-decoration: none" rel="noopener noreferrer">
+              <div class="overflow-hidden line-clamp-3 xl:line-clamp-2">
+                {{ column.getValue ? column.getValue(result) : '-' }}
+              </div>
+            </a>
+            }
+          </td>
+          }
+          }
+          }
+        </tr>
+      </ng-template>
+      <ng-template pTemplate="emptymessage">
+        @if (!resultsCenterService.loading()) {
+        <tr>
+          <td [attr.colspan]="resultsCenterService.tableColumns().length + 1" class="text-center p-8">
+            <div class="flex flex-col items-center gap-4 bg-surface-ground p-6 rounded-xl">
+              <div class="flex flex-col items-center gap-2">
+                <div class="w-16 h-16 flex items-center justify-center rounded-xl bg-blue-50">
+                  <i class="pi pi-inbox text-3xl text-blue-500"></i>
+                </div>
+                <h2 class="text-900 font-semibold m-0">No Results Available</h2>
+                <p class="text-600 text-center m-0 max-w-[30rem] leading-relaxed">
+                  There are currently no results in the database. New results will appear here once they are added to
+                  the
+                  system.
+                </p>
+              </div>
+            </div>
+          </td>
+        </tr>
+        }
+      </ng-template>
+    </p-table>
   </div>
 </div>
 

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/select-linked-results-modal/select-linked-results-modal.component.html
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/select-linked-results-modal/select-linked-results-modal.component.html
@@ -9,7 +9,7 @@
     <app-search-export-controls [applyLabel]="'Apply Filters'"
       [badge]="resultsCenterService.countTableFiltersSelected()"
       [showOverlayDot]="!!resultsCenterService.countTableFiltersSelected()" [showClear]="true"
-      [searchValue]="resultsCenterService.searchInput()" [searchPlaceholder]="'Find a result by code, title or creator'"
+      [searchValue]="resultsCenterService.searchInput()" [searchPlaceholder]="'Find a result by code, title, creator or public link'"
       (searchChange)="setSearchInputFilter($event)" (apply)="showFiltersSidebar()" (clear)="clearFilters()">
     </app-search-export-controls>
 
@@ -125,6 +125,19 @@
             </div>
             }
           </div>
+        </td>
+        } @else if (column.field === 'public_link') {
+        <td (click)="$event.stopPropagation()">
+          @if (result.public_link) {
+          <button type="button" (click)="openPublicLink(result.public_link); $event.stopPropagation()"
+            [pTooltip]="result.public_link" tooltipPosition="top"
+            [attr.aria-label]="'Open public link for ' + result.result_official_code"
+            class="cursor-pointer border-0 bg-transparent p-0 text-[#035BA9] hover:text-[#1689CA]">
+            <i class="pi pi-external-link !text-[16px]"></i>
+          </button>
+          } @else {
+          <span class="text-gray-500">None</span>
+          }
         </td>
         } @else if (column.field === 'project') {
         <td>

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/select-linked-results-modal/select-linked-results-modal.component.html
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/select-linked-results-modal/select-linked-results-modal.component.html
@@ -130,7 +130,7 @@
           } @else if (column.field === 'public_link') {
           <td (click)="$event.stopPropagation()">
             @if (result.public_link) {
-            <button type="button" (click)="openPublicLink(result.public_link); $event.stopPropagation()"
+            <button type="button" data-public-link-action (click)="openPublicLink(result.public_link); $event.stopPropagation()"
               [pTooltip]="result.public_link" tooltipPosition="left"
               [attr.aria-label]="'Open public link for ' + result.result_official_code"
               class="cursor-pointer border-0 bg-transparent p-0 text-[#035BA9]">

--- a/research-indicators/src/app/shared/components/all-modals/modals-content/select-linked-results-modal/select-linked-results-modal.component.ts
+++ b/research-indicators/src/app/shared/components/all-modals/modals-content/select-linked-results-modal/select-linked-results-modal.component.ts
@@ -21,6 +21,8 @@ import { TableFiltersSidebarComponent } from '@pages/platform/pages/results-cent
 import { CustomProgressBarComponent } from '@shared/components/custom-progress-bar/custom-progress-bar.component';
 import { PLATFORM_CODES } from '@shared/constants/platform-codes';
 import { Router, UrlTree } from '@angular/router';
+import { TooltipModule } from 'primeng/tooltip';
+import { openPublicLink } from '@shared/utils/public-link.util';
 
 const MODAL_INDICATOR_CODES = [1, 2, 3, 4, 6] as const;
 
@@ -38,11 +40,13 @@ const MODAL_INDICATOR_CODES = [1, 2, 3, 4, 6] as const;
     SearchExportControlsComponent,
     SectionSidebarComponent,
     TableFiltersSidebarComponent,
-    CustomProgressBarComponent
+    CustomProgressBarComponent,
+    TooltipModule
   ],
   templateUrl: './select-linked-results-modal.component.html'
 })
 export class SelectLinkedResultsModalComponent implements OnDestroy {
+  readonly openPublicLink = openPublicLink;
   allModalsService = inject(AllModalsService);
   resultsCenterService = inject(ResultsCenterService);
   cacheService = inject(CacheService);

--- a/research-indicators/src/app/shared/components/custom-fields/input/input.component.spec.ts
+++ b/research-indicators/src/app/shared/components/custom-fields/input/input.component.spec.ts
@@ -480,6 +480,14 @@ describe('InputComponent', () => {
       });
     });
 
+    it('should return handle-url pattern', () => {
+      component.pattern = 'handle-url';
+      expect(component.getPattern()).toEqual({
+        pattern: String.raw`^https:\/\/hdl\.handle\.net\/.+`,
+        message: 'URL must start with https://hdl.handle.net/'
+      });
+    });
+
     it('should return empty pattern for default case', () => {
       component.pattern = 'other' as any;
       expect(component.getPattern()).toEqual({ pattern: '', message: '' });

--- a/research-indicators/src/app/shared/components/custom-fields/input/input.component.ts
+++ b/research-indicators/src/app/shared/components/custom-fields/input/input.component.ts
@@ -26,7 +26,7 @@ export class InputComponent {
   @ViewChild('numberInput', { static: false }) numberInput!: ElementRef;
   @Input() signal: WritableSignal<any> = signal({});
   @Input() optionValue = '';
-  @Input() pattern: 'email' | 'url' | '' = '';
+  @Input() pattern: 'email' | 'url' | 'handle-url' | '' = '';
   @Input() label = '';
   @Input() description = '';
   @Input() type: 'text' | 'number' = 'text';
@@ -250,6 +250,11 @@ export class InputComponent {
         return {
           pattern: String.raw`^(https?:\/\/)?(www\.)?([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(\/\S*)?$`,
           message: 'Please enter a valid URL.'
+        };
+      case 'handle-url':
+        return {
+          pattern: String.raw`^https:\/\/hdl\.handle\.net\/.+`,
+          message: 'URL must start with https://hdl.handle.net/'
         };
       default:
         return { pattern: '', message: '' };

--- a/research-indicators/src/app/shared/components/oicr-header/oicr-header.component.html
+++ b/research-indicators/src/app/shared/components/oicr-header/oicr-header.component.html
@@ -82,9 +82,11 @@
     }
     @if (showHandleLinkButton()) {
     <div class="xl:hidden pt-2.5">
-      <p-button label="Handle link" variant="outlined" size="small" (onClick)="openHandleLink()">
+      <p-button label="CGSpace link" variant="outlined" size="small" (onClick)="openHandleLink()">
         <ng-template pTemplate="icon">
-          <i class="pi pi-external-link text-[#035BA9] !text-[14px]"></i>
+          <div>
+            <i class="pi pi-external-link !text-[13px]" style="color: #035BA9"></i>
+          </div>
         </ng-template>
       </p-button>
     </div>
@@ -98,9 +100,11 @@
   }
   @if (showHandleLinkButton()) {
   <div class="xl:min-w-[200px] hidden xl:flex ml-4 shrink-0 items-center">
-    <p-button label="Handle link" variant="outlined" size="small" (onClick)="openHandleLink()">
+    <p-button label="CGSpace link" variant="outlined" size="small" (onClick)="openHandleLink()">
       <ng-template pTemplate="icon">
-        <i class="pi pi-external-link text-[#035BA9] !text-[14px]"></i>
+        <div>
+          <i class="pi pi-external-link !text-[13px]" style="color: #035BA9"></i>
+        </div>
       </ng-template>
     </p-button>
   </div>

--- a/research-indicators/src/app/shared/components/oicr-header/oicr-header.component.html
+++ b/research-indicators/src/app/shared/components/oicr-header/oicr-header.component.html
@@ -99,7 +99,7 @@
   </div>
   }
   @if (showHandleLinkButton()) {
-  <div class="xl:min-w-[200px] hidden xl:flex ml-4 shrink-0 items-center">
+  <div class="xl:min-w-[200px] hidden xl:flex ml-4 shrink-0 items-center justify-end">
     <p-button label="CGSpace link" variant="outlined" size="small" (onClick)="openHandleLink()">
       <ng-template pTemplate="icon">
         <div>

--- a/research-indicators/src/app/shared/components/oicr-header/oicr-header.component.html
+++ b/research-indicators/src/app/shared/components/oicr-header/oicr-header.component.html
@@ -77,14 +77,32 @@
       }
       }
     </div>
-    @if (showDownload) {
+    @if (showDownloadTemplate()) {
     <app-download-oicr-template class="xl:hidden pt-2.5"></app-download-oicr-template>
+    }
+    @if (showHandleLinkButton()) {
+    <div class="xl:hidden pt-2.5">
+      <p-button label="Handle link" variant="outlined" size="small" (onClick)="openHandleLink()">
+        <ng-template pTemplate="icon">
+          <i class="pi pi-external-link text-[#035BA9] !text-[14px]"></i>
+        </ng-template>
+      </p-button>
+    </div>
     }
   </div>
 
-  @if (showDownload) {
+  @if (showDownloadTemplate()) {
   <div class="xl:min-w-[200px] hidden xl:flex ml-4">
     <app-download-oicr-template></app-download-oicr-template>
+  </div>
+  }
+  @if (showHandleLinkButton()) {
+  <div class="xl:min-w-[200px] hidden xl:flex ml-4 shrink-0 items-center">
+    <p-button label="Handle link" variant="outlined" size="small" (onClick)="openHandleLink()">
+      <ng-template pTemplate="icon">
+        <i class="pi pi-external-link text-[#035BA9] !text-[14px]"></i>
+      </ng-template>
+    </p-button>
   </div>
   }
 </div>

--- a/research-indicators/src/app/shared/components/oicr-header/oicr-header.component.spec.ts
+++ b/research-indicators/src/app/shared/components/oicr-header/oicr-header.component.spec.ts
@@ -268,6 +268,26 @@ describe('OicrHeaderComponent', () => {
       expect(openSpy).toHaveBeenCalledWith('https://hdl.handle.net/10568/182058', '_blank', 'noopener,noreferrer');
       openSpy.mockRestore();
     });
+
+    it('cgspacePublicationHref should return empty string when link is null', () => {
+      component.cgspaceLink = null;
+      fixture.detectChanges();
+      expect(component.cgspacePublicationHref()).toBe('');
+    });
+
+    it('cgspacePublicationHref should trim whitespace from link', () => {
+      component.cgspaceLink = '  https://hdl.handle.net/10568/182058  ';
+      fixture.detectChanges();
+      expect(component.cgspacePublicationHref()).toBe('https://hdl.handle.net/10568/182058');
+    });
+
+    it('openHandleLink should no-op when href is empty', () => {
+      const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+      component.cgspaceLink = null;
+      component.openHandleLink();
+      expect(openSpy).not.toHaveBeenCalled();
+      openSpy.mockRestore();
+    });
   });
 });
 

--- a/research-indicators/src/app/shared/components/oicr-header/oicr-header.component.spec.ts
+++ b/research-indicators/src/app/shared/components/oicr-header/oicr-header.component.spec.ts
@@ -232,6 +232,43 @@ describe('OicrHeaderComponent', () => {
       expect(c.shouldShowWorkflow()).toBe(false);
     });
   });
+
+  describe('handle link button', () => {
+    it('showHandleLinkButton should be true when published and cgspace_link is set', () => {
+      component.showDownload = true;
+      component.data = { status_id: '14' } as OicrHeaderData;
+      component.cgspaceLink = 'https://hdl.handle.net/10568/182058';
+      fixture.detectChanges();
+      expect(component.showHandleLinkButton()).toBe(true);
+      expect(component.showDownloadTemplate()).toBe(false);
+    });
+
+    it('showHandleLinkButton should be false when not published', () => {
+      component.showDownload = true;
+      component.data = { status_id: '11' } as OicrHeaderData;
+      component.cgspaceLink = 'https://hdl.handle.net/10568/182058';
+      fixture.detectChanges();
+      expect(component.showHandleLinkButton()).toBe(false);
+      expect(component.showDownloadTemplate()).toBe(true);
+    });
+
+    it('showDownloadTemplate should be false when published even without link', () => {
+      component.showDownload = true;
+      component.data = { status_id: '14' } as OicrHeaderData;
+      component.cgspaceLink = null;
+      fixture.detectChanges();
+      expect(component.showHandleLinkButton()).toBe(false);
+      expect(component.showDownloadTemplate()).toBe(false);
+    });
+
+    it('openHandleLink should open cgspace link in a new tab', () => {
+      const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+      component.cgspaceLink = 'https://hdl.handle.net/10568/182058';
+      component.openHandleLink();
+      expect(openSpy).toHaveBeenCalledWith('https://hdl.handle.net/10568/182058', '_blank', 'noopener,noreferrer');
+      openSpy.mockRestore();
+    });
+  });
 });
 
 

--- a/research-indicators/src/app/shared/components/oicr-header/oicr-header.component.ts
+++ b/research-indicators/src/app/shared/components/oicr-header/oicr-header.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input, computed } from '@angular/core';
 import { DatePipe } from '@angular/common';
+import { ButtonModule } from 'primeng/button';
 import { DownloadOicrTemplateComponent } from '@shared/components/download-oicr-template/download-oicr-template.component';
 import { OicrHeaderData } from '@shared/interfaces/oicr-header-data.interface';
 import { CustomTagComponent } from '../custom-tag/custom-tag.component';
@@ -9,21 +10,41 @@ import { OicrWorkflowStatusComponent } from '../oicr-workflow-status/oicr-workfl
   selector: 'app-oicr-header',
   standalone: true,
   templateUrl: './oicr-header.component.html',
-  imports: [DatePipe, DownloadOicrTemplateComponent, CustomTagComponent, OicrWorkflowStatusComponent]
+  imports: [DatePipe, ButtonModule, DownloadOicrTemplateComponent, CustomTagComponent, OicrWorkflowStatusComponent]
 })
 export class OicrHeaderComponent {
   @Input() data: OicrHeaderData | null = null;
   @Input() showDownload = false;
   @Input() showTag = false;
+  @Input() cgspaceLink: string | null = null;
 
   readonly intermediateStatusIds = [10, 12, 13, 14];
-  
+  readonly publishedStatusId = 14;
+
   shouldShowWorkflow = computed(() => {
     const statusId = this.data?.status_id;
     if (!statusId) return false;
     const statusIdNum = Number(statusId);
     return this.intermediateStatusIds.includes(statusIdNum);
   });
+
+  isPublished = computed(() => Number(this.data?.status_id) === this.publishedStatusId);
+
+  showDownloadTemplate = computed(() => this.showDownload && !this.isPublished());
+
+  showHandleLinkButton = computed(() => {
+    const link = this.cgspaceLink?.trim();
+    return this.showDownload && this.isPublished() && !!link;
+  });
+
+  cgspacePublicationHref = computed(() => this.cgspaceLink?.trim() ?? '');
+
+  openHandleLink(): void {
+    const href = this.cgspacePublicationHref();
+    if (href) {
+      window.open(href, '_blank', 'noopener,noreferrer');
+    }
+  }
 }
 
 

--- a/research-indicators/src/app/shared/components/result-sidebar/result-sidebar.component.html
+++ b/research-indicators/src/app/shared/components/result-sidebar/result-sidebar.component.html
@@ -20,7 +20,7 @@
 
   <div
     class="flex p-[25px] pb-4 flex-wrap items-center justify-between font-medium full text-[13px]  text-[#777c83] title">
-    @if (roles.isAdmin() && cache.currentMetadata().indicator_id === 5) {
+    @if (showOicrStatusDropdown()) {
     <app-status-dropdown [statusId]="cache.currentMetadata().status_id ?? 0"
       [statusName]="cache.currentMetadata().status_name ?? ''" (statusChange)="onStatusChange($event)"
       class="cursor-pointer -mt-1">
@@ -30,8 +30,8 @@
       [statusName]="cache.currentMetadata().status_name ?? ''"
       [statusColor]="cache.currentMetadata().result_status?.config?.color?.text ?? ''"
       [statusBackground]="cache.currentMetadata().result_status?.config?.color?.background ?? ''"
-      [statusBorder]="cache.currentMetadata().result_status?.config?.color?.border ?? ''"
-      class="-mt-1"></app-custom-tag>
+      [statusBorder]="cache.currentMetadata().result_status?.config?.color?.border ?? ''" class="-mt-1"
+      [maxWidth]="'150px'"></app-custom-tag>
     }
     <div class="flex w-full text-[13.5px] font-normal pt-3">
       <span class="text-[#E69F00] pr-1">{{ getCompletedCount() }}/{{ getTotalCount() }}</span> sections completed

--- a/research-indicators/src/app/shared/components/result-sidebar/result-sidebar.component.spec.ts
+++ b/research-indicators/src/app/shared/components/result-sidebar/result-sidebar.component.spec.ts
@@ -132,6 +132,23 @@ describe('ResultSidebarComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  describe('showOicrStatusDropdown', () => {
+    it('should be true for admin on OICR when status is not Published', () => {
+      cacheService.currentMetadata.set({ indicator_id: 5, status_id: 13 });
+      expect(component.showOicrStatusDropdown()).toBe(true);
+    });
+
+    it('should be false for admin on OICR when status is Published (14)', () => {
+      cacheService.currentMetadata.set({ indicator_id: 5, status_id: 14 });
+      expect(component.showOicrStatusDropdown()).toBe(false);
+    });
+
+    it('should be false for non-OICR indicators', () => {
+      cacheService.currentMetadata.set({ indicator_id: 1, status_id: 4 });
+      expect(component.showOicrStatusDropdown()).toBe(false);
+    });
+  });
+
   describe('allOptionsWithGreenChecks computed', () => {
     it('should filter options by indicator_id and add greenCheck property', () => {
       const options = component.allOptionsWithGreenChecks();

--- a/research-indicators/src/app/shared/components/result-sidebar/result-sidebar.component.ts
+++ b/research-indicators/src/app/shared/components/result-sidebar/result-sidebar.component.ts
@@ -67,6 +67,17 @@ export class ResultSidebarComponent {
       }));
   });
 
+  private readonly publishedOicrStatusId = 14;
+
+  showOicrStatusDropdown = computed(() => {
+    const meta = this.cache.currentMetadata();
+    return (
+      this.roles.isAdmin() &&
+      meta.indicator_id === 5 &&
+      meta.status_id !== this.publishedOicrStatusId
+    );
+  });
+
   getResultChildQueryParams(): Record<string, string> {
     const m = this.route.snapshot.queryParamMap;
     const o: Record<string, string> = {};

--- a/research-indicators/src/app/shared/components/search-export-controls/search-export-controls.component.html
+++ b/research-indicators/src/app/shared/components/search-export-controls/search-export-controls.component.html
@@ -3,40 +3,26 @@
     <span class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
       <i class="pi pi-search text-[#6B7280] !text-[12px]"></i>
     </span>
-    <input
-      pInputText
-      type="text"
-      [ngModel]="searchValue"
-      (input)="onInputChange($event)"
-      (keydown.enter)="onEnter($event)"
-      [placeholder]="searchPlaceholder"
+    <input pInputText type="text" [ngModel]="searchValue" (input)="onInputChange($event)"
+      (keydown.enter)="onEnter($event)" [placeholder]="searchPlaceholder"
       class="w-full !pl-9 !rounded-[8px] py-2 border !max-h-[27px] !text-[12px] !py-1 !border-[#B9C0C5] !text-[#6B7280] rounded-lg" />
   </div>
 
   <div class="flex gap-3 items-center">
     <div class="relative">
       <p-button
-        styleClass="!rounded-[8px] !text-[12px] !py-1 !max-h-[27px] !bg-white !text-[#035BA9] !border-[#035BA9]"
-        [label]="badge ? applyLabel + ' (' + badge + ')' : applyLabel"
-        icon="pi pi-filter !text-[10px]"
-        size="small"
-        (keydown.enter)="apply.emit()"
-        (click)="apply.emit()"></p-button>
+        styleClass="!rounded-[8px] !text-[12px] !flex !items-center !justify-center  !max-h-[27px] !bg-white !text-[#035BA9] !border-[#035BA9]"
+        [label]="badge ? applyLabel + ' (' + badge + ')' : applyLabel" icon="pi pi-filter !text-[10px] !pt-0.5"
+        size="small" (keydown.enter)="apply.emit()" (click)="apply.emit()"></p-button>
 
       @if (showOverlayDot) {
-        <div class="absolute -top-1 -right-1 w-3 h-3 bg-orange-500 rounded-full border-2 border-white"></div>
+      <div class="absolute -top-1 -right-1 w-3 h-3 bg-orange-500 rounded-full border-2 border-white"></div>
       }
     </div>
 
     @if (showClear) {
-      <p-button
-        styleClass="!text-[12px] !text-[#777C83]"
-        label="Clear Filters"
-        [text]="true"
-        size="small"
-        severity="secondary"
-        (keydown.enter)="clear.emit()"
-        (click)="clear.emit()"></p-button>
+    <p-button styleClass="!text-[12px] !text-[#777C83]" label="Clear Filters" [text]="true" size="small"
+      severity="secondary" (keydown.enter)="clear.emit()" (click)="clear.emit()"></p-button>
     }
   </div>
 </div>

--- a/research-indicators/src/app/shared/components/status-dropdown/status-dropdown.component.html
+++ b/research-indicators/src/app/shared/components/status-dropdown/status-dropdown.component.html
@@ -12,7 +12,13 @@
   @if (isOpen()) {
   <div class="absolute top-full left-0 py-2 bg-white border border-[#E4EAEE] rounded-lg shadow-lg z-50 min-w-[200px]">
     @for (status of getAvailableStatuses(); track status.id) {
-    <div class="flex items-center gap-2.5 py-2 px-5 cursor-pointer hover:bg-[#F4F7F9] transition-colors"
+    <div class="flex items-center gap-2.5 py-2 px-5 transition-colors"
+      [class.cursor-pointer]="!isStatusOptionDisabled(status)"
+      [class.hover:bg-[#F4F7F9]]="!isStatusOptionDisabled(status)"
+      [class.cursor-not-allowed]="isStatusOptionDisabled(status)"
+      [class.opacity-50]="isStatusOptionDisabled(status)"
+      [pTooltip]="getStatusOptionTooltip(status)" tooltipPosition="right"
+      [tooltipDisabled]="!isStatusOptionDisabled(status)"
       (click)="selectStatus(status.id, $event)" (keydown.enter)="selectStatus(status.id, $event)">
       <div class="w-4 h-4 flex items-center justify-center">
         @if (status.transition_direction === 'unknown' && status.result_status_id === 15) {

--- a/research-indicators/src/app/shared/components/status-dropdown/status-dropdown.component.spec.ts
+++ b/research-indicators/src/app/shared/components/status-dropdown/status-dropdown.component.spec.ts
@@ -3,6 +3,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { StatusDropdownComponent } from './status-dropdown.component';
 import { ApiService } from '@shared/services/api.service';
 import { CacheService } from '@shared/services/cache/cache.service';
+import { SubmissionService } from '@shared/services/submission.service';
 import { GetNextStep } from '@shared/interfaces/get-next-step.interface';
 import { MainResponse } from '@shared/interfaces/responses.interface';
 
@@ -11,8 +12,12 @@ describe('StatusDropdownComponent', () => {
   let fixture: ComponentFixture<StatusDropdownComponent>;
   let mockApiService: jest.Mocked<ApiService>;
   let mockCacheService: jest.Mocked<CacheService>;
+  let mockSubmissionService: { meetsStatusChangeValidationRequirements: jest.Mock };
 
   beforeEach(async () => {
+    mockSubmissionService = {
+      meetsStatusChangeValidationRequirements: jest.fn().mockReturnValue(true)
+    };
     mockApiService = {
       GET_NextStep: jest.fn()
     } as unknown as jest.Mocked<ApiService>;
@@ -27,7 +32,8 @@ describe('StatusDropdownComponent', () => {
       imports: [StatusDropdownComponent, HttpClientTestingModule],
       providers: [
         { provide: ApiService, useValue: mockApiService },
-        { provide: CacheService, useValue: mockCacheService }
+        { provide: CacheService, useValue: mockCacheService },
+        { provide: SubmissionService, useValue: mockSubmissionService }
       ]
     }).compileComponents();
 
@@ -225,7 +231,78 @@ describe('StatusDropdownComponent', () => {
     });
   });
 
+  describe('status change validation', () => {
+    it('should disable option when validation is required and requirements are not met', async () => {
+      mockSubmissionService.meetsStatusChangeValidationRequirements.mockReturnValue(false);
+      component.statusId = 13;
+      mockApiService.GET_NextStep.mockResolvedValue({
+        successfulRequest: true,
+        data: [
+          {
+            result_status_id: 14,
+            id: 14,
+            name: 'Published',
+            transition_direction: 'forward',
+            is_status_change_validation_required: true
+          }
+        ]
+      } as MainResponse<GetNextStep>);
+      await component.loadNextSteps();
+      const published = component.getAvailableStatuses()[0];
+      expect(component.isStatusOptionDisabled(published)).toBe(true);
+      expect(component.getStatusOptionTooltip(published)).toContain('green checks');
+    });
+
+    it('should enable option when validation is not required', async () => {
+      mockSubmissionService.meetsStatusChangeValidationRequirements.mockReturnValue(false);
+      component.statusId = 13;
+      mockApiService.GET_NextStep.mockResolvedValue({
+        successfulRequest: true,
+        data: [
+          {
+            result_status_id: 12,
+            id: 12,
+            name: 'Science Edition',
+            transition_direction: 'backward',
+            is_status_change_validation_required: false
+          }
+        ]
+      } as MainResponse<GetNextStep>);
+      await component.loadNextSteps();
+      const option = component.getAvailableStatuses()[0];
+      expect(component.isStatusOptionDisabled(option)).toBe(false);
+    });
+
+    it('should enable option when validation is required and requirements are met', async () => {
+      mockSubmissionService.meetsStatusChangeValidationRequirements.mockReturnValue(true);
+      component.statusId = 13;
+      mockApiService.GET_NextStep.mockResolvedValue({
+        successfulRequest: true,
+        data: [
+          {
+            result_status_id: 14,
+            id: 14,
+            name: 'Published',
+            is_status_change_validation_required: true
+          }
+        ]
+      } as MainResponse<GetNextStep>);
+      await component.loadNextSteps();
+      expect(component.isStatusOptionDisabled(component.getAvailableStatuses()[0])).toBe(false);
+    });
+  });
+
   describe('selectStatus', () => {
+    it('should not emit when option is disabled by validation', async () => {
+      mockSubmissionService.meetsStatusChangeValidationRequirements.mockReturnValue(false);
+      component.availableStatuses.set([
+        { id: 14, name: 'Published', is_status_change_validation_required: true }
+      ]);
+      const emitSpy = jest.spyOn(component.statusChange, 'emit');
+      component.selectStatus(14, new Event('click'));
+      expect(emitSpy).not.toHaveBeenCalled();
+    });
+
     it('should emit statusChange event and close dropdown', () => {
       component.isOpen.set(true);
       const event = new Event('click');

--- a/research-indicators/src/app/shared/components/status-dropdown/status-dropdown.component.spec.ts
+++ b/research-indicators/src/app/shared/components/status-dropdown/status-dropdown.component.spec.ts
@@ -273,6 +273,27 @@ describe('StatusDropdownComponent', () => {
       expect(component.isStatusOptionDisabled(option)).toBe(false);
     });
 
+    it('getStatusOptionTooltip returns empty string when option is not disabled', () => {
+      expect(component.getStatusOptionTooltip({ id: 12, name: 'Science Edition' })).toBe('');
+    });
+
+    it('should map is_status_change_validation_required as undefined when API sends false', async () => {
+      component.statusId = 4;
+      mockApiService.GET_NextStep.mockResolvedValue({
+        successfulRequest: true,
+        data: [
+          {
+            result_status_id: 12,
+            id: 12,
+            name: 'Science Edition',
+            is_status_change_validation_required: false
+          }
+        ]
+      } as MainResponse<GetNextStep>);
+      await component.loadNextSteps();
+      expect(component.availableStatuses()[0].is_status_change_validation_required).toBeUndefined();
+    });
+
     it('should enable option when validation is required and requirements are met', async () => {
       mockSubmissionService.meetsStatusChangeValidationRequirements.mockReturnValue(true);
       component.statusId = 13;

--- a/research-indicators/src/app/shared/components/status-dropdown/status-dropdown.component.ts
+++ b/research-indicators/src/app/shared/components/status-dropdown/status-dropdown.component.ts
@@ -3,10 +3,13 @@ import { CommonModule } from '@angular/common';
 import { CacheService } from '@shared/services/cache/cache.service';
 import { ApiService } from '@shared/services/api.service';
 import { NextStepOption, GetNextStep } from '@shared/interfaces/get-next-step.interface';
+import { SubmissionService, STATUS_CHANGE_VALIDATION_TOOLTIP } from '@shared/services/submission.service';
+import { isStatusChangeValidationRequired } from '@shared/utils/status-workflow.util';
+import { TooltipModule } from 'primeng/tooltip';
 
 @Component({
   selector: 'app-status-dropdown',
-  imports: [CommonModule],
+  imports: [CommonModule, TooltipModule],
   templateUrl: './status-dropdown.component.html'
 })
 export class StatusDropdownComponent implements OnInit, OnChanges {
@@ -15,7 +18,9 @@ export class StatusDropdownComponent implements OnInit, OnChanges {
   @Output() statusChange = new EventEmitter<number>();
   cache = inject(CacheService);
   api = inject(ApiService);
+  submissionService = inject(SubmissionService);
   isOpen = signal(false);
+  readonly statusChangeValidationTooltip = STATUS_CHANGE_VALIDATION_TOOLTIP;
   
   availableStatuses = signal<NextStepOption[]>([]);
   isLoading = signal(false);
@@ -52,29 +57,11 @@ export class StatusDropdownComponent implements OnInit, OnChanges {
       
       if (response.successfulRequest && response.data) {
         if (Array.isArray(response.data)) {
-          this.availableStatuses.set(response.data.map(item => ({
-            id: item.result_status_id || item.id,
-            result_status_id: item.result_status_id,
-            name: item.name,
-            direction: item.direction,
-            transition_direction: item.transition_direction,
-            icon: item.icon
-          })));
+          this.availableStatuses.set(response.data.map(item => this.mapNextStepOption(item)));
         } else if (response.data.available_statuses) {
-          this.availableStatuses.set(response.data.available_statuses.map((item: NextStepOption) => ({
-            ...item,
-            id: item.result_status_id || item.id,
-            result_status_id: item.result_status_id
-          })));
+          this.availableStatuses.set(response.data.available_statuses.map((item: NextStepOption) => this.mapNextStepOption(item)));
         } else if (response.data.data && Array.isArray(response.data.data)) {
-          this.availableStatuses.set(response.data.data.map(item => ({
-            id: item.result_status_id || item.id,
-            result_status_id: item.result_status_id,
-            name: item.name,
-            direction: item.direction,
-            transition_direction: item.transition_direction,
-            icon: item.icon
-          })));
+          this.availableStatuses.set(response.data.data.map(item => this.mapNextStepOption(item)));
         } else {
           const options = this.buildOptionsFromResponse(response.data);
           this.availableStatuses.set(options);
@@ -124,6 +111,32 @@ export class StatusDropdownComponent implements OnInit, OnChanges {
     return options;
   }
 
+  private mapNextStepOption(item: NextStepOption): NextStepOption {
+    return {
+      ...item,
+      id: item.result_status_id || item.id,
+      result_status_id: item.result_status_id,
+      name: item.name,
+      direction: item.direction,
+      transition_direction: item.transition_direction,
+      icon: item.icon,
+      is_status_change_validation_required: isStatusChangeValidationRequired(item.is_status_change_validation_required)
+        ? true
+        : undefined
+    };
+  }
+
+  isStatusOptionDisabled(status: NextStepOption): boolean {
+    if (!isStatusChangeValidationRequired(status.is_status_change_validation_required)) {
+      return false;
+    }
+    return !this.submissionService.meetsStatusChangeValidationRequirements();
+  }
+
+  getStatusOptionTooltip(status: NextStepOption): string {
+    return this.isStatusOptionDisabled(status) ? this.statusChangeValidationTooltip : '';
+  }
+
   getAvailableStatuses(): NextStepOption[] {
     const statuses = this.availableStatuses();
     return [...statuses].sort((a, b) => {
@@ -143,6 +156,10 @@ export class StatusDropdownComponent implements OnInit, OnChanges {
 
   selectStatus(statusId: number, event: Event) {
     event.stopPropagation();
+    const status = this.availableStatuses().find(s => s.id === statusId);
+    if (status && this.isStatusOptionDisabled(status)) {
+      return;
+    }
     this.statusChange.emit(statusId);
     this.isOpen.set(false);
   }

--- a/research-indicators/src/app/shared/constants/result-entry-source.ts
+++ b/research-indicators/src/app/shared/constants/result-entry-source.ts
@@ -3,6 +3,10 @@ export const RESULT_ENTRY_SOURCE_VALUE_RESULTS_CENTER = 'results-center';
 /** User opened the result from the Home dashboard (e.g. My latest results). */
 export const RESULT_ENTRY_SOURCE_VALUE_HOME = 'home';
 
+/** Navigating from published OICR modal "Editar" into the full result form (skip modal resolver). */
+export const OICR_FULL_EDIT_QUERY = 'oicrFullEdit';
+export const OICR_FULL_EDIT_VALUE = '1';
+
 export function getResultEntrySourceFromSearch(search: string): string | null {
   if (!search) return null;
   const q = search.startsWith('?') ? search.slice(1) : search;

--- a/research-indicators/src/app/shared/constants/result-entry-source.ts
+++ b/research-indicators/src/app/shared/constants/result-entry-source.ts
@@ -3,7 +3,7 @@ export const RESULT_ENTRY_SOURCE_VALUE_RESULTS_CENTER = 'results-center';
 /** User opened the result from the Home dashboard (e.g. My latest results). */
 export const RESULT_ENTRY_SOURCE_VALUE_HOME = 'home';
 
-/** Navigating from published OICR modal "Editar" into the full result form (skip modal resolver). */
+/** Navigating from published OICR modal "Edit" into the full result form (skip modal resolver). */
 export const OICR_FULL_EDIT_QUERY = 'oicrFullEdit';
 export const OICR_FULL_EDIT_VALUE = '1';
 

--- a/research-indicators/src/app/shared/interfaces/get-next-step.interface.ts
+++ b/research-indicators/src/app/shared/interfaces/get-next-step.interface.ts
@@ -5,7 +5,8 @@ export interface NextStepOption {
   transition_direction?: 'forward' | 'backward' | 'unknown';
   icon?: 'reject' | 'postpone';
   result_status_id?: number;
-  [key: string]: string | number | undefined;
+  is_status_change_validation_required?: boolean;
+  [key: string]: string | number | boolean | undefined;
 }
 
 interface SequenceItem {
@@ -19,4 +20,3 @@ export interface GetNextStep {
   special_transitions?: Record<number, NextStepOption[]>;
   available_statuses?: NextStepOption[];
 }
-

--- a/research-indicators/src/app/shared/interfaces/oicr-creation.interface.ts
+++ b/research-indicators/src/app/shared/interfaces/oicr-creation.interface.ts
@@ -9,6 +9,7 @@ export interface OicrCreation {
   step_three: StepThree;
   step_four: StepFour;
   base_information: BaseInformation;
+  cgspace_link?: string | null;
 }
 
 export interface BaseInformation {

--- a/research-indicators/src/app/shared/interfaces/patch-result-evidences.interface.ts
+++ b/research-indicators/src/app/shared/interfaces/patch-result-evidences.interface.ts
@@ -1,6 +1,7 @@
 export class PatchResultEvidences {
   evidence: Evidence[] = [];
   notable_references: NotableReference[] = [];
+  cgspace_link: string | null = null;
 }
 
 export class Evidence {

--- a/research-indicators/src/app/shared/services/submission.service.spec.ts
+++ b/research-indicators/src/app/shared/services/submission.service.spec.ts
@@ -65,6 +65,20 @@ describe('SubmissionService', () => {
     expect(service.isEditableStatus()).toBe(true);
   });
 
+  it('isEditableStatus true for published status_id 14 on STAR when user is admin', () => {
+    cacheMock.currentMetadata.mockReturnValue({ status_id: 14 });
+    cacheMock.getCurrentPlatformCode.mockReturnValue('STAR');
+    rolesMock.isAdmin.mockReturnValue(true);
+    expect(service.isEditableStatus()).toBe(true);
+  });
+
+  it('isEditableStatus false for published status_id 14 on STAR when user is not admin', () => {
+    cacheMock.currentMetadata.mockReturnValue({ status_id: 14 });
+    cacheMock.getCurrentPlatformCode.mockReturnValue('STAR');
+    rolesMock.isAdmin.mockReturnValue(false);
+    expect(service.isEditableStatus()).toBe(false);
+  });
+
   it('isEditableStatus false for status_id 4 but TIP platform', () => {
     cacheMock.currentMetadata.mockReturnValue({ status_id: 4 });
     cacheMock.getCurrentPlatformCode.mockReturnValue('TIP');
@@ -128,6 +142,21 @@ describe('SubmissionService', () => {
     expect(service.isSubmitted()).toBe(false);
   });
 
+  it('meetsStatusChangeValidationRequirements true when all green checks are true', () => {
+    cacheMock.greenChecks.mockReturnValue({ a: true, b: true });
+    expect(service.meetsStatusChangeValidationRequirements()).toBe(true);
+  });
+
+  it('meetsStatusChangeValidationRequirements false when green checks are empty', () => {
+    cacheMock.greenChecks.mockReturnValue({});
+    expect(service.meetsStatusChangeValidationRequirements()).toBe(false);
+  });
+
+  it('meetsStatusChangeValidationRequirements false when any green check is false', () => {
+    cacheMock.greenChecks.mockReturnValue({ a: true, b: false });
+    expect(service.meetsStatusChangeValidationRequirements()).toBe(false);
+  });
+
   it('canSubmitResult true when all conditions met', () => {
     cacheMock.allGreenChecksAreTrue.mockReturnValue(true);
     cacheMock.greenChecks.mockReturnValue({ a: 1 });
@@ -146,7 +175,7 @@ describe('SubmissionService', () => {
 
   it('canSubmitResult false if not allGreenChecksAreTrue', () => {
     cacheMock.allGreenChecksAreTrue.mockReturnValue(false);
-    cacheMock.greenChecks.mockReturnValue({ a: 1 });
+    cacheMock.greenChecks.mockReturnValue({ a: false });
     cacheMock.isMyResult.mockReturnValue(true);
     cacheMock.currentMetadata.mockReturnValue({ is_principal_investigator: false });
     expect(service.canSubmitResult()).toBe(false);

--- a/research-indicators/src/app/shared/services/submission.service.ts
+++ b/research-indicators/src/app/shared/services/submission.service.ts
@@ -6,6 +6,9 @@ import { RolesService } from './cache/roles.service';
 
 const STAR_DRAFT_RBAC_STATUS_IDS = new Set([4, 12, 13]);
 
+export const STATUS_CHANGE_VALIDATION_TOOLTIP =
+  'All green checks must be completed. All mandatory fields must be filled.';
+
 export interface SubmissionStatus {
   id: number;
   name: string;
@@ -24,10 +27,14 @@ export class SubmissionService {
   statusSelected = signal<ReviewOption | null>(null);
   canSubmitResult = computed(() => {
     return (
-      this.cache.allGreenChecksAreTrue() &&
-      Object.values(this.cache.greenChecks()).length &&
+      this.meetsStatusChangeValidationRequirements() &&
       (this.cache.isMyResult() || this.cache.currentMetadata().is_principal_investigator || this.rolesService.isAdmin())
     );
+  });
+
+  meetsStatusChangeValidationRequirements = computed(() => {
+    const checks = this.cache.greenChecks();
+    return Object.values(checks).length > 0 && Object.values(checks).every(Boolean);
   });
   submissionStatuses = signal<SubmissionStatus[]>([
     { id: 1, name: 'Editing' },
@@ -54,11 +61,17 @@ export class SubmissionService {
     const editableStatuses = [4, 5, 12, 13, 10];
     const meta = this.cache.currentMetadata();
     const statusId = meta.status_id ?? -1;
-    const hasEditableStatus = editableStatuses.includes(statusId);
     const platformCode = this.cache.getCurrentPlatformCode();
     const isStarPlatform = platformCode === 'STAR';
     const hasNoPlatformCode = platformCode === '';
-    if (!hasEditableStatus || (!isStarPlatform && !hasNoPlatformCode)) {
+    if (!isStarPlatform && !hasNoPlatformCode) {
+      return false;
+    }
+    if (statusId === 14 && this.rolesService.isAdmin()) {
+      return true;
+    }
+    const hasEditableStatus = editableStatuses.includes(statusId);
+    if (!hasEditableStatus) {
       return false;
     }
     if (!STAR_DRAFT_RBAC_STATUS_IDS.has(statusId)) {

--- a/research-indicators/src/app/shared/services/text-mining.service.ts
+++ b/research-indicators/src/app/shared/services/text-mining.service.ts
@@ -22,7 +22,7 @@ export interface CountryArea {
   areas: string[];
 }
 
-export interface ResponseAiRoarDto {
+export interface ResponseAiDto {
   content: MiningTextItem[];
 }
 
@@ -40,7 +40,7 @@ export class TextMiningService {
 
   constructor(private readonly http: HttpClient) {}
 
-  async executeTextMining(documentName: string): Promise<ResponseAiRoarDto> {
+  async executeTextMining(documentName: string): Promise<ResponseAiDto> {
     const formData = new FormData();
     formData.append('token', this.cache.dataCache().access_token);
     formData.append('key', `${environment.keyTextMining}${documentName}`);
@@ -53,9 +53,7 @@ export class TextMiningService {
     });
 
     try {
-      const response = await firstValueFrom(
-        this.http.post<ResponseAiRoarDto>(`${environment.textMiningUrl}/star/text-mining`, formData, { headers })
-      );
+      const response = await firstValueFrom(this.http.post<ResponseAiDto>(`${environment.textMiningUrl}/star/text-mining`, formData, { headers }));
       return response;
     } catch (error) {
       console.error('Error occurred during text mining:', error);

--- a/research-indicators/src/app/shared/utils/public-link.util.spec.ts
+++ b/research-indicators/src/app/shared/utils/public-link.util.spec.ts
@@ -1,0 +1,18 @@
+import { openPublicLink } from './public-link.util';
+
+describe('public-link.util', () => {
+  it('openPublicLink should open trimmed link in a new tab', () => {
+    const openSpy = jest.spyOn(globalThis, 'open').mockImplementation(() => null);
+    openPublicLink('  https://hdl.handle.net/10568/1  ');
+    expect(openSpy).toHaveBeenCalledWith('https://hdl.handle.net/10568/1', '_blank', 'noopener,noreferrer');
+    openSpy.mockRestore();
+  });
+
+  it('openPublicLink should no-op when link is empty', () => {
+    const openSpy = jest.spyOn(globalThis, 'open').mockImplementation(() => null);
+    openPublicLink('');
+    openPublicLink(null);
+    expect(openSpy).not.toHaveBeenCalled();
+    openSpy.mockRestore();
+  });
+});

--- a/research-indicators/src/app/shared/utils/public-link.util.ts
+++ b/research-indicators/src/app/shared/utils/public-link.util.ts
@@ -1,0 +1,5 @@
+export function openPublicLink(link: string | null | undefined): void {
+  const trimmed = link?.trim();
+  if (!trimmed) return;
+  globalThis.open(trimmed, '_blank', 'noopener,noreferrer');
+}

--- a/research-indicators/src/app/shared/utils/status-workflow.util.spec.ts
+++ b/research-indicators/src/app/shared/utils/status-workflow.util.spec.ts
@@ -1,0 +1,16 @@
+import { isStatusChangeValidationRequired } from './status-workflow.util';
+
+describe('isStatusChangeValidationRequired', () => {
+  it('returns true for boolean true and numeric/string 1', () => {
+    expect(isStatusChangeValidationRequired(true)).toBe(true);
+    expect(isStatusChangeValidationRequired(1)).toBe(true);
+    expect(isStatusChangeValidationRequired('1')).toBe(true);
+  });
+
+  it('returns false for falsy and other values', () => {
+    expect(isStatusChangeValidationRequired(false)).toBe(false);
+    expect(isStatusChangeValidationRequired(0)).toBe(false);
+    expect(isStatusChangeValidationRequired(undefined)).toBe(false);
+    expect(isStatusChangeValidationRequired(null)).toBe(false);
+  });
+});

--- a/research-indicators/src/app/shared/utils/status-workflow.util.ts
+++ b/research-indicators/src/app/shared/utils/status-workflow.util.ts
@@ -1,0 +1,3 @@
+export function isStatusChangeValidationRequired(value: unknown): boolean {
+  return value === true || value === 1 || value === '1';
+}


### PR DESCRIPTION
## Summary

This PR introduces two major improvements to the OICR workflow:

### 1. Published OICR Access Control and Edit Flow

Implemented role-based access for Published OICR results (Status 14):

* System Admin (Role ID 1) and Center Admin (Role ID 9) can review Published OICRs through the stepper modal and optionally access the full STAR result form using the new **Edit** action.
* All other roles are restricted to the OICR modal experience and cannot access the full edit form, even through direct URL manipulation.
* Access control is enforced through:

  * `RolesService.isAdmin()`
  * `resultExistsResolver`
  * `SubmissionService.isEditableStatus()`
  * Conditional UI rendering

#### Key Behaviors

* Published OICRs always open in the OICR modal first.
* Admin users can navigate to the full result form through:

  * `Editar` button in the modal
  * `oicrFullEdit=1` query parameter
* Non-admin users remain restricted to the modal experience.
* Draft OICRs (statuses 10, 12, 13) continue using the existing admin full-edit workflow.
* Published status now displays as a tag only, hiding the status dropdown.

#### Files Updated

* `result-exists.resolver.ts`
* `create-oicr-form.component.ts`
* `create-oicr-form.component.html`
* `result-entry-source.ts`
* `result-sidebar.component.ts`
* `result-sidebar.component.html`
* `roles.service.ts`
* `submission.service.ts`
* `current-result.service.ts`

---

### 2. Backend-Driven Status Transition Validation

Added support for workflow-based status validation using the backend field:

`is_status_change_validation_required`

#### New Behavior

* Status options requiring validation are disabled until:

  * At least one green check exists.
  * All green checks are completed.
* Disabled options display an explanatory tooltip:

  * "All green checks must be completed. All mandatory fields must be filled."
* Status transitions remain enabled when validation is not required.

#### Validation Logic

Implemented in:

`SubmissionService.meetsStatusChangeValidationRequirements()`

Requirements:

* `Object.values(greenChecks).length > 0`
* Every green check value must be `true`

#### API Integration

Supported endpoints:

* `GET results/status/workflow/result/{resultCode}/next-step`
* `GET results/status/workflow/config/indicator/{indicatorId}/from-status/{fromStatusId}`

#### Files Updated

* `get-next-step.interface.ts`
* `status-workflow.util.ts`
* `status-dropdown.component.ts`
* `status-dropdown.component.html`
* `submission.service.ts`
* `result-sidebar.component.html`

---

## Benefits

* Improves security and consistency of Published OICR access.
* Aligns frontend behavior with backend workflow validation rules.
* Prevents invalid status transitions before API submission.
* Preserves existing draft workflows while enhancing the Published result experience.
* Provides clearer UX through disabled actions and contextual tooltips.

## Testing

Verified:

* Published OICR access for Admin and Center Admin users.
* Published OICR access restrictions for non-admin users.
* Direct URL navigation with and without `oicrFullEdit=1`.
* Draft workflow behavior remains unchanged.
* Status dropdown enable/disable behavior based on validation requirements.
* Tooltip visibility and transition blocking.
* Green check validation scenarios.
* Existing status change flow continues to work when requirements are satisfied.
